### PR TITLE
Send form validation fixes

### DIFF
--- a/app/frontend/actions.js
+++ b/app/frontend/actions.js
@@ -120,7 +120,6 @@ module.exports = ({setState, getState}) => {
         balance,
         sendAmount,
         sendAddress,
-        isSendAddressValid: false,
         sendResponse,
         transactionHistory,
         loading: false,
@@ -255,15 +254,9 @@ module.exports = ({setState, getState}) => {
 
   const validateSendForm = (state) => {
     setState({
-      isSendAddressValid: !sendAddressValidator(state.sendAddress.fieldValue).validationError,
+      sendAddress: sendAddressValidator(state.sendAddress.fieldValue),
+      sendAmount: sendAmountValidator(state.sendAmount.fieldValue),
     })
-
-    if (state.sendAddress.fieldValue !== '' && state.sendAmount.fieldValue !== '') {
-      setState({
-        sendAddress: sendAddressValidator(state.sendAddress.fieldValue),
-        sendAmount: sendAmountValidator(state.sendAmount.fieldValue),
-      })
-    }
   }
 
   const isSendFormFilledAndValid = (state) =>
@@ -349,15 +342,15 @@ module.exports = ({setState, getState}) => {
         sendResponse: '',
         sendAmount: sendAmountValidator(printAda(maxAmount)),
       })
+      validateSendFormAndCalculateFee()
     } else {
       setState({
         sendAmount: Object.assign({}, state.sendAmount, {
           validationError: {code: 'SendAmountCantSendMaxFunds'},
         }),
+        calculatingFee: false,
       })
     }
-
-    validateSendFormAndCalculateFee(state)
   }
 
   const resetSendForm = (state) => {
@@ -368,7 +361,6 @@ module.exports = ({setState, getState}) => {
       transactionFee: 0,
       loading: false,
       showConfirmTransactionDialog: false,
-      isSendAddressValid: false,
     })
   }
 

--- a/app/frontend/components/pages/sendAda/sendAdaPage.js
+++ b/app/frontend/components/pages/sendAda/sendAdaPage.js
@@ -74,7 +74,6 @@ class SendAdaPage extends Component {
     sendResponse,
     sendAddress,
     sendAddressValidationError,
-    isSendAddressValid,
     sendAmount,
     sendAmountValidationError,
     updateAddress,
@@ -91,7 +90,10 @@ class SendAdaPage extends Component {
     const enableSubmit =
       sendAmount && !sendAmountValidationError && sendAddress && !sendAddressValidationError
 
+    const isSendAddressValid = !sendAddressValidationError && sendAddress !== ''
+
     const displayTransactionFee =
+      isSendAddressValid &&
       sendAmount !== '' &&
       transactionFee > 0 &&
       !feeRecalculating &&
@@ -129,6 +131,7 @@ class SendAdaPage extends Component {
           {class: 'row'},
           h('label', undefined, h('span', undefined, 'Receiving address')),
           sendAddressValidationError &&
+            sendAddress !== '' &&
             h('span', {class: 'validationMsg'}, getTranslation(sendAddressValidationError.code))
         ),
         h('input', {
@@ -208,6 +211,7 @@ class SendAdaPage extends Component {
           )
         ),
         sendAmountValidationError &&
+          (sendAmount !== '' || sendAmountValidationError.code === 'SendAmountCantSendMaxFunds') &&
           h(
             'p',
             {class: 'validationMsg send-amount-validation-error'},
@@ -255,7 +259,6 @@ module.exports = connect(
     sendResponse: state.sendResponse,
     sendAddressValidationError: state.sendAddress.validationError,
     sendAddress: state.sendAddress.fieldValue,
-    isSendAddressValid: state.isSendAddressValid,
     sendAmountValidationError: state.sendAmount.validationError,
     sendAmount: state.sendAmount.fieldValue,
     transactionFee: state.transactionFee,


### PR DESCRIPTION
closes #200 and fixes other weird behaviour

`validateSendForm` now always validates both fields and presentation of resulting validation is handled in component.
(Includes removing `isSendAddressValid` from state as it is ~duplicate of `validationError` / can be derived)

Suspending the address error display until inputting amount is clashing with behavior of 'MAX' button. Unified to match the button as it is more intuitive. Besides, not stressing user while typing email makes sense but the address will most likely be copy-pasted in in >99% of cases.

`sendMaxFunds` changes fix other errors overriding 'SendAmountCantSendMaxFunds', which imo should be the more important one

Displaying transaction fee when address isn't valid can cause (see picture) so I added checks for valid address
![image](https://user-images.githubusercontent.com/18385255/47925040-76e98200-debd-11e8-93c6-e4277ed57c1b.png)
