### PR TITLE
Facelift

### DIFF
--- a/app/frontend/components/common/addressDetailDialog.js
+++ b/app/frontend/components/common/addressDetailDialog.js
@@ -19,7 +19,7 @@ class AddressDetailDialogClass extends Component {
       h(
         'div',
         {
-          class: 'overlay fade-in-up',
+          class: 'overlay',
           onKeyDown: (e) => e.key === 'Escape' && closeAddressDetail(),
         },
         !showVerification &&

--- a/app/frontend/components/pages/exportWallet/exportWalletPage.js
+++ b/app/frontend/components/pages/exportWallet/exportWalletPage.js
@@ -98,90 +98,94 @@ class ExportWalletDialog extends Component {
         'div',
         {class: 'margin-2rem'},
         h('h2', undefined, 'Export wallet to JSON file:'),
-        showError && h('div', {class: 'alert error'}, 'Wallet export failed'),
         h(
           'div',
-          {class: 'row'},
-          h('label', {for: 'keyfile-name'}, h('span', undefined, 'Choose wallet name:'))
-        ),
-        h('input', {
-          type: 'text',
-          class: 'styled-input-nodiv',
-          id: 'keyfile-name',
-          name: 'keyfile-name',
-          placeholder: 'adalite_wallet',
-          value: walletName,
-          onInput: this.updateWalletName,
-          onBlur: this.touchPasswordField,
-          autocomplete: 'off',
-          ref: (element) => {
-            this.walletNameField = element
-          },
-        }),
-        h(
-          'div',
-          {class: 'row margin-top'},
-          h('label', {for: 'keyfile-password'}, h('span', undefined, 'Password:'))
-        ),
-        h('input', {
-          type: 'password',
-          class: 'styled-input-nodiv',
-          id: 'keyfile-password',
-          name: 'keyfile-password',
-          placeholder: 'Enter password',
-          value: password,
-          onInput: this.updatePassword,
-          onBlur: this.touchPasswordField,
-          autocomplete: 'new-password',
-        }),
-        h(
-          'div',
-          {class: 'row margin-top'},
+          {class: 'export-walet-dialog'},
+          showError && h('div', {class: 'alert error'}, 'Wallet export failed'),
           h(
-            'label',
-            {for: 'keyfile-password-confirmation'},
-            h('span', undefined, 'Password confirmation:')
-          )
-        ),
-        h('input', {
-          type: 'password',
-          class: 'styled-input-nodiv',
-          id: 'keyfile-password-confirmation',
-          name: 'keyfile-password-confirmation',
-          placeholder: 'Enter password confirmation',
-          value: confirmation,
-          onInput: this.updatePasswordConfirmation,
-          onBlur: this.touchPasswordConfirmationField,
-          autocomplete: 'new-password',
-        }),
-        h(
-          'p',
-          {
-            class: `validationMsg margin-top center ${
-              (!isPasswordValid && isPasswordDirty && isPasswordConfirmationDirty) ||
-              !isWalletNameValid
-                ? ''
-                : 'hidden'
-            }`,
-          },
-          !isWalletNameValid
-            ? 'Allowed characters for wallet name are only a-z, A-Z, 0-9, -, _'
-            : 'Password must match and cannot be empty'
-        ),
-        h(
-          'button',
-          {
-            disabled: !this.isPasswordValid(password, confirmation) || !isWalletNameValid,
-            onClick: this.exportJsonWallet,
-            onKeyDown: (e) => {
-              if (e.key === 'Tab') {
-                this.walletNameField.focus()
-                e.preventDefault()
-              }
+            'div',
+            {class: 'row'},
+            h('label', {for: 'keyfile-name'}, h('span', undefined, 'Choose wallet name:'))
+          ),
+          h('input', {
+            type: 'text',
+            class: 'styled-input-nodiv',
+            id: 'keyfile-name',
+            name: 'keyfile-name',
+            placeholder: 'adalite_wallet',
+            value: walletName,
+            onInput: this.updateWalletName,
+            onBlur: this.touchPasswordField,
+            autocomplete: 'off',
+            ref: (element) => {
+              this.walletNameField = element
             },
-            class: 'button-like submit-button',
-          },
-          'Export'
+          }),
+          h(
+            'div',
+            {class: 'row margin-top'},
+            h('label', {for: 'keyfile-password'}, h('span', undefined, 'Password:'))
+          ),
+          h('input', {
+            type: 'password',
+            class: 'styled-input-nodiv',
+            id: 'keyfile-password',
+            name: 'keyfile-password',
+            placeholder: 'Enter password',
+            value: password,
+            onInput: this.updatePassword,
+            onBlur: this.touchPasswordField,
+            autocomplete: 'new-password',
+          }),
+          h(
+            'div',
+            {class: 'row margin-top'},
+            h(
+              'label',
+              {for: 'keyfile-password-confirmation'},
+              h('span', undefined, 'Password confirmation:')
+            )
+          ),
+          h('input', {
+            type: 'password',
+            class: 'styled-input-nodiv',
+            id: 'keyfile-password-confirmation',
+            name: 'keyfile-password-confirmation',
+            placeholder: 'Enter password confirmation',
+            value: confirmation,
+            onInput: this.updatePasswordConfirmation,
+            onBlur: this.touchPasswordConfirmationField,
+            autocomplete: 'new-password',
+          }),
+          h(
+            'p',
+            {
+              class: `validationMsg margin-top center ${
+                (!isPasswordValid && isPasswordDirty && isPasswordConfirmationDirty) ||
+                !isWalletNameValid
+                  ? ''
+                  : 'hidden'
+              }`,
+            },
+            !isWalletNameValid
+              ? 'Allowed characters for wallet name are only a-z, A-Z, 0-9, -, _'
+              : 'Password must match and cannot be empty'
+          ),
+          h(
+            'button',
+            {
+              disabled: !this.isPasswordValid(password, confirmation) || !isWalletNameValid,
+              onClick: this.exportJsonWallet,
+              onKeyDown: (e) => {
+                if (e.key === 'Tab') {
+                  this.walletNameField.focus()
+                  e.preventDefault()
+                }
+              },
+              class: 'button-like submit-button',
+            },
+            'Export'
+          )
         )
       )
     )

--- a/app/frontend/components/pages/login/aboutOverlay.js
+++ b/app/frontend/components/pages/login/aboutOverlay.js
@@ -40,7 +40,8 @@ class AboutOverlayClass extends Component {
           h(
             'div',
             {class: 'message'},
-            h('h4', undefined, ' Disclaimer: AdaLite is not created by Cardano Foundation. '),
+            h('h4', {class: 'text-center strong'}, ' Disclaimer '),
+            h('h4', undefined, ' AdaLite is not created by Cardano Foundation. '),
             h(
               'p',
               undefined,

--- a/app/frontend/components/pages/login/demoWalletWarningDialog.js
+++ b/app/frontend/components/pages/login/demoWalletWarningDialog.js
@@ -13,7 +13,7 @@ class DemoWalletWarningDialogClass {
       {class: 'overlay'},
       h(
         'div',
-        {class: 'box center fade-in-up'},
+        {class: 'box center'},
         h('h4', undefined, 'Warning'),
         h(
           'p',

--- a/app/frontend/components/pages/login/generateMnemonicDialog.js
+++ b/app/frontend/components/pages/login/generateMnemonicDialog.js
@@ -19,7 +19,7 @@ class GenerateMnemonicDialogClass extends Component {
       },
       h(
         'div',
-        {class: 'mnemonic-box-header box center fade-in-up'},
+        {class: 'mnemonic-box-header box center'},
         h(
           'span',
           {

--- a/app/frontend/components/pages/login/keyFileAuth.js
+++ b/app/frontend/components/pages/login/keyFileAuth.js
@@ -167,7 +167,7 @@ class LoadKeyFileClass extends Component {
           h(
             'div',
             {
-              class: 'overlay fade-in-up',
+              class: 'overlay',
               onKeyDown: (e) => {
                 e.key === 'Escape' && this.closePasswordModal()
               },

--- a/app/frontend/components/pages/login/loginPage.js
+++ b/app/frontend/components/pages/login/loginPage.js
@@ -33,7 +33,7 @@ class LoginPage extends Component {
       h(
         'div',
         undefined,
-        h('h1', {class: 'intro-header fade-in-up'}, 'Access Cardano Wallet via'),
+        h('h1', {class: 'intro-header'}, 'Access Cardano Wallet via'),
         h(
           'ul',
           {class: 'tab-row'},

--- a/app/frontend/components/pages/login/mnemonicAuth.js
+++ b/app/frontend/components/pages/login/mnemonicAuth.js
@@ -94,7 +94,7 @@ class LoadByMenmonicSectionClass extends Component {
       h(
         'a',
         {
-          class: 'intro-link fade-in-up',
+          class: 'intro-link',
           /*
           * onMouseDown to prevent onBlur before handling the click event
           * https://stackoverflow.com/questions/17769005/onclick-and-onblur-ordering-issue

--- a/app/frontend/components/pages/sendAda/sendAdaPage.js
+++ b/app/frontend/components/pages/sendAda/sendAdaPage.js
@@ -19,7 +19,7 @@ class ThanksForDonationModal extends Component {
     return h(
       'div',
       {
-        class: 'overlay fade-in-up',
+        class: 'overlay',
         onKeyDown: (e) => e.key === 'Escape' && closeThanksForDonationModal(),
       },
       h('div', {

--- a/app/frontend/components/router.js
+++ b/app/frontend/components/router.js
@@ -30,6 +30,7 @@ const TopLevelRouter = connect((state) => ({
       content = h(ExportWalletPage)
       break
     default:
+      window.history.pushState({}, 'txHistory', 'txHistory')
       content = h(TxHistoryPage)
   }
   // TODO is Alert used anywhere? if so add here

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -172,8 +172,9 @@ td {
 .main {
   max-width: var(--width);
   width: 100%;
-  margin: 0 auto;
   flex: 0 1 auto;
+  margin-left: calc(100vw - 100%);
+  align-self: center;
 }
 @media screen and (max-width: 1200px) {
   .main {
@@ -538,6 +539,7 @@ div.box.box-auto {
   background-color: var(--navbar);
   border-bottom: 1px solid var(--border);
   z-index: 1;
+  padding-left: calc(100vw - 100%)
 }
 .navbar-wrap, .navbar-wrap-unauth {
   display: flex;
@@ -923,7 +925,8 @@ div.box.box-auto {
   color: var(--text-color);
   border-top: 1px solid var(--border);
   padding: 1.5rem 0;
-  margin: auto auto 0;
+  margin-left: calc(100vw - 100%);
+  align-self: center;
 }
 .footer p {
   margin-top: 0;

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -1476,6 +1476,11 @@ div.box.box-auto {
 .export-wallet-dialog label {
   margin-bottom: 0.3em;
 }
+
+.export-walet-dialog {
+  max-width: 360px;
+}
+
 .hidden {
   visibility: hidden;
 }

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -927,10 +927,14 @@ div.box.box-auto {
 }
 .footer p {
   margin-top: 0;
+  margin-bottom: 0.5rem;
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   justify-content: center;
+}
+.footer p:first-child, .footer p:last-child {
+  margin-bottom: 0;
 }
 .footer .logo {
   height: 2rem;

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -1234,19 +1234,6 @@ div.box.box-auto {
   display: block;
   margin: 5px;
 }
-@keyframes rise-up {
-  from {
-    opacity: 0;
-    transform: translateY(20%);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-.fade-in-up {
-  animation: fade-in 1.5s, rise-up 1.5s;
-}
 .loading-inside-button {
   display: inline-block;
   border: 2px solid rgba(150, 150, 150, 0.4);


### PR DESCRIPTION
addresses points 3 - 8 from #208 :

- Logging in(defaulting to) `TxHistoryPage` updates url
- Scrollbar issues resolved with `calc(100vw - 100%)` from https://stackoverflow.com/a/30293718
- Consistent spacing between footer items' texts
- Narrower(`360px`) inputs in `/exportWallet`
- Disclaimer title now separate, centered and bold
- `fade-in-up` removed from modals, kept in `LoginPage` title and `MnemoticAuth` 'generate new' link 