### PR TITLE
format date in TransactionHistory to have same length

### DIFF
--- a/app/frontend/components/pages/txHistory/transactionHistory.js
+++ b/app/frontend/components/pages/txHistory/transactionHistory.js
@@ -1,6 +1,7 @@
 const {h} = require('preact')
 const printAda = require('../../../helpers/printAda')
 const printConversionRates = require('../../../helpers/printConversionRates')
+const formatDate = require('../../../helpers/formatDate')
 const AdaIcon = require('../../common/svg').AdaIcon
 const Tooltip = require('../../common/tooltip')
 
@@ -57,7 +58,7 @@ const TransactionHistory = ({transactionHistory, conversionRates}) =>
             h(
               'tr',
               undefined,
-              h('td', undefined, new Date(transaction.ctbTimeIssued * 1000).toLocaleString()),
+              h('td', undefined, formatDate(transaction.ctbTimeIssued)),
               h(
                 'td',
                 {class: 'align-right'},

--- a/app/frontend/helpers/formatDate.js
+++ b/app/frontend/helpers/formatDate.js
@@ -1,0 +1,12 @@
+const formatDate = (date) =>
+  new Date(date * 1000).toLocaleString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour12: false,
+  })
+
+module.exports = formatDate


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/41968972/48250938-45624080-e400-11e8-8608-2168fc7e1172.png)
Closes https://github.com/vacuumlabs/adalite/issues/203