### PR TITLE
align text in footer before VacuumLabs logo to be on the same line

### DIFF
--- a/app/frontend/components/common/footer.js
+++ b/app/frontend/components/common/footer.js
@@ -20,7 +20,7 @@ const Footer = connect(
     h(
       'p',
       undefined,
-      'Developed by ',
+      h('span', {class: 'footer-text-before-logo'}, 'Developed by '),
       h('a', {href: 'https://vacuumlabs.com', target: '_blank'}, h(VacuumlabsLogo))
     ),
     h(

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -924,7 +924,7 @@ div.box.box-auto {
   font-size: 1rem;
   color: var(--text-color);
   border-top: 1px solid var(--border);
-  padding: 1.5rem 0;
+  padding: 1rem 0;
   margin-left: calc(100vw - 100%);
   align-self: center;
 }
@@ -945,6 +945,10 @@ div.box.box-auto {
 .footer .contact-link {
   padding-left: 0.5em;
   padding-right: 0.5em;
+}
+.footer-text-before-logo {
+  position: relative;
+  top: 2.5px;
 }
 
 


### PR DESCRIPTION
+ smaller footer padding, `1.5rem` was too much IMO, changed it to `1rem`