### PR TITLE
Remove code splitting, fix webpack build, add source map

### DIFF
--- a/app/frontend/actions.js
+++ b/app/frontend/actions.js
@@ -14,6 +14,8 @@ const getConversionRates = require('./helpers/getConversionRates')
 const sleep = require('./helpers/sleep')
 const {ADA_DONATION_ADDRESS} = require('./wallet/constants')
 const NamedError = require('./helpers/NamedError')
+const Cardano = require('./wallet/cardano-wallet')
+const KeypassJson = require('./wallet/keypass-json')
 
 let wallet = null
 
@@ -66,15 +68,12 @@ module.exports = ({setState, getState}) => {
     switch (cryptoProvider) {
       case 'trezor':
         try {
-          wallet = await import(/* webpackPrefetch: true */ './wallet/cardano-wallet').then(
-            (Cardano) =>
-              Cardano.CardanoWallet({
-                cryptoProvider: 'trezor',
-                config: ADALITE_CONFIG,
-                network: 'mainnet',
-                derivationScheme: DERIVATION_SCHEMES.v2,
-              })
-          )
+          wallet = await Cardano.CardanoWallet({
+            cryptoProvider: 'trezor',
+            config: ADALITE_CONFIG,
+            network: 'mainnet',
+            derivationScheme: DERIVATION_SCHEMES.v2,
+          })
         } catch (e) {
           debugLog(e)
           return setState({
@@ -85,16 +84,13 @@ module.exports = ({setState, getState}) => {
         break
       case 'mnemonic':
         secret = secret.trim()
-        wallet = await import(/* webpackPrefetch: true */ './wallet/cardano-wallet').then(
-          (Cardano) =>
-            Cardano.CardanoWallet({
-              cryptoProvider: 'mnemonic',
-              mnemonicOrHdNodeString: secret,
-              config: ADALITE_CONFIG,
-              network: 'mainnet',
-              derivationScheme: DERIVATION_SCHEMES.v1,
-            })
-        )
+        wallet = await Cardano.CardanoWallet({
+          cryptoProvider: 'mnemonic',
+          mnemonicOrHdNodeString: secret,
+          config: ADALITE_CONFIG,
+          network: 'mainnet',
+          derivationScheme: DERIVATION_SCHEMES.v1,
+        })
         break
       default:
         return setState({
@@ -456,11 +452,8 @@ module.exports = ({setState, getState}) => {
   }
 
   const exportJsonWallet = async (state, password, walletName) => {
-    const walletExport = await import(/* webpackPrefetch: true */ './wallet/keypass-json').then(
-      async (KeypassJson) =>
-        JSON.stringify(
-          await KeypassJson.exportWalletSecret(wallet.getSecret(), password, walletName)
-        )
+    const walletExport = JSON.stringify(
+      await KeypassJson.exportWalletSecret(wallet.getSecret(), password, walletName)
     )
 
     const blob = new Blob([walletExport], {type: 'application/json;charset=utf-8'})

--- a/app/frontend/components/pages/login/keyFileAuth.js
+++ b/app/frontend/components/pages/login/keyFileAuth.js
@@ -3,6 +3,7 @@ const connect = require('unistore/preact').connect
 const actions = require('../../../actions')
 const debugLog = require('../../../helpers/debugLog')
 const CloseIcon = require('../../common/svg').CloseIcon
+const KeypassJson = require('../../../wallet/keypass-json')
 
 class LoadKeyFileClass extends Component {
   constructor(props) {
@@ -36,12 +37,10 @@ class LoadKeyFileClass extends Component {
     this.props.loadingAction('Unlocking key file')
 
     try {
-      const secret = await import(/* webpackPrefetch: true */ '../../../wallet/keypass-json').then(
-        async (KeypassJson) =>
-          (await KeypassJson.importWalletSecret(this.state.keyFile, this.state.password)).toString(
-            'hex'
-          )
-      )
+      const secret = (await KeypassJson.importWalletSecret(
+        this.state.keyFile,
+        this.state.password
+      )).toString('hex')
 
       this.setState({error: undefined})
       this.props.loadWallet({cryptoProvider: 'mnemonic', secret})
@@ -86,10 +85,7 @@ class LoadKeyFileClass extends Component {
       return async (e) => {
         try {
           const walletExport = await JSON.parse(e.target.result)
-          const isWalletExportEncrypted = await import(/* webpackPrefetch: true */ '../../../wallet/keypass-json').then(
-            async (KeypassJson) => await KeypassJson.isWalletExportEncrypted(walletExport)
-          )
-
+          const isWalletExportEncrypted = await KeypassJson.isWalletExportEncrypted(walletExport)
           if (isWalletExportEncrypted) {
             this.setState({
               keyFile: walletExport,
@@ -101,10 +97,7 @@ class LoadKeyFileClass extends Component {
             })
           } else {
             this.props.loadingAction('Reading key file')
-            const secret = await import(/* webpackPrefetch: true */ '../../../wallet/keypass-json').then(
-              async (KeypassJson) =>
-                (await KeypassJson.importWalletSecret(walletExport, '')).toString('hex')
-            )
+            const secret = (await KeypassJson.importWalletSecret(walletExport, '')).toString('hex')
 
             this.props.loadWallet({cryptoProvider: 'mnemonic', secret})
             this.setState({error: undefined})

--- a/app/webpack.build.config.js
+++ b/app/webpack.build.config.js
@@ -1,3 +1,5 @@
+const env = process.env.NODE_ENV
+
 module.exports = {
   entry: './frontend/walletApp.js',
   output: {
@@ -7,11 +9,15 @@ module.exports = {
     path: `${__dirname}/dist/js`,
     publicPath: '/js/',
   },
+  optimization: {
+    minimize: false,
+  },
+  devtool: 'source-map',
+  mode: env || 'development',
   externals: {
     // to avoid including webpack's 'crypto' if window.crypto is available - reduces bundle size
     crypto: 'crypto',
   },
-  mode: 'development',
   node: {
     fs: 'empty',
   },


### PR DESCRIPTION
I was tinkering with code splitting and I fixed webpack along the way to produce a nicer output and it builds in prod mode on production. I disabled uglification so the code is more readable when somebody wants to examine it and added source map to improve debugging. This should also be helpful to fully implementing CSP #236 , since evals from webpack build were removed and the only eval remaining being in init.js which I hope could be overcome somehow.