### PR TITLE
show raw unsigned transaction in modal

### DIFF
--- a/app/frontend/components/common/addressDetailDialog.js
+++ b/app/frontend/components/common/addressDetailDialog.js
@@ -28,7 +28,7 @@ class AddressDetailDialogClass extends Component {
           h(
             'span',
             {
-              class: 'full-address selectable',
+              class: 'full-address force-select-all',
             },
             showDetail.address
           )

--- a/app/frontend/components/pages/sendAda/rawTransactionModal.js
+++ b/app/frontend/components/pages/sendAda/rawTransactionModal.js
@@ -1,0 +1,37 @@
+const {h} = require('preact')
+const connect = require('unistore/preact').connect
+const actions = require('../../../actions')
+const Modal = require('../../common/modal')
+
+class RawTransactionModal {
+  render({rawTransaction, setRawTransactionOpen}) {
+    return h(
+      Modal,
+      {
+        closeHandler: () => setRawTransactionOpen(false),
+        bodyClass: 'width-auto',
+      },
+      h(
+        'div',
+        {class: 'width-auto'},
+        h('h4', undefined, 'Raw unsigned transaction'),
+        h(
+          'div',
+          undefined,
+          h(
+            'div',
+            {class: 'raw-unsigned-transaction force-select-all'},
+            h('span', undefined, rawTransaction)
+          )
+        )
+      )
+    )
+  }
+}
+
+module.exports = connect(
+  (state) => ({
+    rawTransaction: state.rawTransaction,
+  }),
+  actions
+)(RawTransactionModal)

--- a/app/frontend/components/pages/sendAda/sendAdaPage.js
+++ b/app/frontend/components/pages/sendAda/sendAdaPage.js
@@ -9,6 +9,7 @@ const printConversionRates = require('../../../helpers/printConversionRates')
 const Balance = require('../../common/balance')
 const Modal = require('../../common/modal')
 const ConfirmTransactionDialog = require('./confirmTransactionDialog')
+const RawTransactionModal = require('./rawTransactionModal')
 
 class ThanksForDonationModal extends Component {
   componentDidMount() {
@@ -59,6 +60,7 @@ class SendAdaPage extends Component {
     sendAddress,
     sendAddressValidationError,
     sendAmount,
+    coinsAmount,
     sendAmountValidationError,
     updateAddress,
     updateAmount,
@@ -71,6 +73,10 @@ class SendAdaPage extends Component {
     showThanksForDonation,
     closeThanksForDonationModal,
     conversionRates,
+    getRawTransaction,
+    rawTransactionOpen,
+    setRawTransactionOpen,
+    rawTransaction,
   }) {
     const enableSubmit =
       sendAmount && !sendAmountValidationError && sendAddress && !sendAddressValidationError
@@ -213,7 +219,20 @@ class SendAdaPage extends Component {
           ),
         h(
           'div',
-          undefined,
+          {class: 'submit-row'},
+          h(
+            'span',
+            {
+              onClick: async () => {
+                await getRawTransaction(sendAddress, coinsAmount)
+                setRawTransactionOpen(true)
+              },
+              class: `link raw-transaction-link${
+                !enableSubmit || feeRecalculating ? '-disabled' : ''
+              }`,
+            },
+            'Raw unsigned transaction'
+          ),
           feeRecalculating
             ? h(
               'button',
@@ -240,6 +259,7 @@ class SendAdaPage extends Component {
               'Submit'
             )
         ),
+        rawTransactionOpen && h(RawTransactionModal),
         showConfirmTransactionDialog && h(ConfirmTransactionDialog),
         showThanksForDonation && h(ThanksForDonationModal, {closeThanksForDonationModal})
       )
@@ -255,12 +275,15 @@ module.exports = connect(
     sendAddress: state.sendAddress.fieldValue,
     sendAmountValidationError: state.sendAmount.validationError,
     sendAmount: state.sendAmount.fieldValue,
+    coinsAmount: state.sendAmount.coins,
     transactionFee: state.transactionFee,
     showConfirmTransactionDialog: state.showConfirmTransactionDialog,
     feeRecalculating: state.calculatingFee,
     totalAmount: state.sendAmountForTransactionFee + state.transactionFee,
     showThanksForDonation: state.showThanksForDonation,
     conversionRates: state.conversionRates && state.conversionRates.data,
+    rawTransaction: state.rawTransaction,
+    rawTransactionOpen: state.rawTransactionOpen,
   }),
   actions
 )(SendAdaPage)

--- a/app/frontend/store.js
+++ b/app/frontend/store.js
@@ -32,6 +32,8 @@ const initialState = {
   enableTrezor: ADALITE_CONFIG.ADALITE_ENABLE_TREZOR,
   showDemoWalletWarningDialog: false,
   logoutNotificationOpen: false,
+  rawTransactionOpen: false,
+  rawTransaction: '',
 }
 
 const createStore = () =>

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -87,6 +87,11 @@ p {
 path {
   fill: currentColor;
 }
+.link {
+  text-decoration: underline;
+  color: var(--brand);
+  cursor: pointer;
+}
 /* BUTTON */
 button,
 .button-like {
@@ -818,12 +823,19 @@ td {
   align-items: center;
   font-size: 1.1rem;
   font-weight: 600;
-  float: right;
-  margin: 15px 5px;
+  margin: 0 5px;
   height: 2.6rem;
   width: 200px;
   text-align: center;
   justify-content: center;
+}
+.raw-transaction-link {
+  margin: 0 auto auto 0;
+}
+.raw-transaction-link-disabled {
+  margin: 0 auto auto 0;
+  color: var(--disabled);
+  pointer-events: none;
 }
 .loading-button-wrapper {
   display: flex;
@@ -1413,6 +1425,20 @@ td {
   .total-other-currencies {
     margin-top: 2rem;
   }
+}
+.raw-unsigned-transaction {
+  display: flex;
+  padding: 0.3rem;
+  margin-bottom: 0.5rem;
+  word-break: break-all;
+  background-color: #eee;
+}
+.submit-row {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 15px 0;
 }
 
 /* tab-row */

--- a/app/tests/src/cardano-wallet.js
+++ b/app/tests/src/cardano-wallet.js
@@ -152,7 +152,7 @@ describe('successful transaction fee computation', () => {
     mockNet.mockAddressSummaryEndpoint()
     mockNet.mockUtxoEndpoint()
 
-    assert.equal(await wallets.used.getTxFee(47, myAddress), 179288)
+    assert.equal(await wallets.used.getTxFee(myAddress, 47), 179288)
   })
 
   it('should compute the right transaction fee for shorter outgoing address', async () => {
@@ -160,7 +160,7 @@ describe('successful transaction fee computation', () => {
     mockNet.mockAddressSummaryEndpoint()
     mockNet.mockUtxoEndpoint()
 
-    assert.equal(await wallets.used.getTxFee(47, shortAddress), 177838)
+    assert.equal(await wallets.used.getTxFee(shortAddress, 47), 177838)
   })
 })
 
@@ -182,7 +182,7 @@ describe('transaction serialization', () => {
     mockNet.mockAddressSummaryEndpoint()
     mockNet.mockUtxoEndpoint()
 
-    const txAux = await wallets.used._prepareTxAux(myAddress, 47)
+    const txAux = await wallets.used.prepareTxAux(myAddress, 47)
 
     // transaction serialization before providing witnesses
     const txAuxSerialized = cbor.encode(txAux).toString('hex')
@@ -198,7 +198,7 @@ describe('transaction serialization', () => {
     mockNet.mockAddressSummaryEndpoint()
     mockNet.mockUtxoEndpoint()
 
-    const txAux = await wallets.smallUtxos._prepareTxAux(myAddress, 1000000)
+    const txAux = await wallets.smallUtxos.prepareTxAux(myAddress, 1000000)
 
     assert.equal(txAux.inputs.length, 2)
   })
@@ -208,7 +208,7 @@ describe('transaction serialization', () => {
     mockNet.mockAddressSummaryEndpoint()
     mockNet.mockUtxoEndpoint()
 
-    const txAux = await wallets.used._prepareTxAux(myAddress, 47)
+    const txAux = await wallets.used.prepareTxAux(myAddress, 47)
     const expectedTxHash = '73131c773879e7e634022f8e0175399b7e7814c42684377cf6f8c7a1adb23112'
 
     assert.equal(txAux.getId(), expectedTxHash)


### PR DESCRIPTION
Closes https://github.com/vacuumlabs/adalite/issues/254.
I couldn't get it to work with the demo wallet, possibly because there weren't enough funds, but at least I refactored the functions to take addresses first and set up the CSS.