### PR TITLE
Mobile Welcome To Adalite modal

### DIFF
--- a/app/frontend/components/common/modal.js
+++ b/app/frontend/components/common/modal.js
@@ -21,12 +21,13 @@ const Modal = ({children, closeHandler, bodyClass = '', title, showWarning}) =>
       },
       closeHandler &&
         h('button', {'class': 'modal-close', 'onClick': closeHandler, 'aria-label': 'Close dialog'}),
-      h(
-        'div',
-        {class: 'modal-head'},
-        title && h('h2', {class: 'modal-title'}, title),
-        showWarning && h(Tag, {type: 'big warning', text: 'Proceed with caution'})
-      ),
+      title &&
+        h(
+          'div',
+          {class: 'modal-head'},
+          title && h('h2', {class: 'modal-title'}, title),
+          showWarning && h(Tag, {type: 'big warning', text: 'Proceed with caution'})
+        ),
       children
     )
   )

--- a/app/frontend/components/pages/login/welcome.js
+++ b/app/frontend/components/pages/login/welcome.js
@@ -49,7 +49,7 @@ class Welcome extends Component {
   render({closeWelcome}, {dontShowAgainCheckbox}) {
     return h(
       Modal,
-      {closeHandler: closeWelcome},
+      undefined,
       h(
         'section',
         {class: 'welcome'},

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -1615,7 +1615,7 @@ p {
 .page-wrapper {
   display: flex;
   height: 100%;
-  width: var(--width);
+  max-width: var(--width);
   margin: 0 auto;
 }
 
@@ -2530,6 +2530,69 @@ p {
 /* MOBILE MEDIA QUERIES */
 
 @media screen and (max-width: 767px) {
+  /* TYPOGRAPHY */
+
+  h2 {
+    font-size: 24px;
+    line-height: 40px;
+  }
+
+  /* BUTTONS */
+
+  .button {
+    font-size: 14px;
+  }
+
+  /* ALERTS */
+
+  .alert {
+    padding: 16px 24px 16px 60px;
+  }
+
+  /* MODALS */
+
+  .modal-body {
+    width: calc(100% - 32px);
+    max-height: calc(100% - 32px);
+    padding: 40px 16px;
+  }
+
+  /* WELCOME MODAL */
+
+  .welcome-subtitle {
+    white-space: normal;
+  }
+
+  .welcome-articles {
+    margin-top: 40px;
+    grid-template-columns: 1fr;
+    grid-row-gap: 40px;
+  }
+
+  .welcome .credits {
+    margin-left: -16px;
+    margin-right: -16px;
+    padding: 40px 16px;
+    display: block;
+  }
+
+  .credits-paragraph {
+    margin-left: 0;
+    margin-top: 24px;
+  }
+
+  .welcome-footer {
+    display: block;
+    margin-top: 40px;
+    margin-bottom: 16px;
+  }
+
+  .welcome-footer .button {
+    margin-left: 0;
+    margin-top: 24px;
+    width: 100%;
+  }
+
   /* FOOTER */
 
   .footer {


### PR DESCRIPTION
Closes #332 

Removed `closeHandler` and added check for `title` to `Modal`. `closeHandler` is not needed as we don't want the modal to be closeable and the check for the `title` prevents rendering an empty `.modal-head` element.