### PR TITLE
Style SendADA & Loader

### DIFF
--- a/app/frontend/actions.js
+++ b/app/frontend/actions.js
@@ -378,6 +378,7 @@ module.exports = ({setState, getState}) => {
       transactionFee: 0,
       loading: false,
       showConfirmTransactionDialog: false,
+      showTransactionErrorModal: false,
     })
   }
 
@@ -444,6 +445,7 @@ module.exports = ({setState, getState}) => {
       sendResponse = {
         success: false,
         error: e.name,
+        showTransactionErrorModal: true,
       }
     } finally {
       resetSendForm(state)
@@ -457,6 +459,12 @@ module.exports = ({setState, getState}) => {
   const closeThanksForDonationModal = (state) => {
     setState({
       showThanksForDonation: false,
+    })
+  }
+
+  const closeTransactionErrorModal = (state) => {
+    setState({
+      showTransactionErrorModal: false,
     })
   }
 
@@ -523,5 +531,6 @@ module.exports = ({setState, getState}) => {
     setLogoutNotificationOpen,
     setRawTransactionOpen,
     getRawTransaction,
+    closeTransactionErrorModal,
   }
 }

--- a/app/frontend/actions.js
+++ b/app/frontend/actions.js
@@ -413,7 +413,9 @@ module.exports = ({setState, getState}) => {
 
   const submitTransaction = async (state) => {
     if (state.usingTrezor) {
+      /* TODO: Check if waitingForTrezor can be deleted safely */
       setState({waitingForTrezor: true})
+      loadingAction(state, 'Waiting for Trezor...')
     } else {
       loadingAction(state, 'Submitting transaction...')
     }

--- a/app/frontend/components/common/loadingOverlay.js
+++ b/app/frontend/components/common/loadingOverlay.js
@@ -6,9 +6,9 @@ const LoadingOverlay = connect(['loadingMessage', 'loading'])(
     loading
       ? h(
         'div',
-        {class: 'overlay ontop'},
-        h('div', {class: 'loading'}),
-        loadingMessage ? h('p', undefined, loadingMessage) : ''
+        {class: 'loading'},
+        h('div', {class: 'spinner'}, h('span', undefined)),
+        loadingMessage ? h('p', {class: 'loading-message'}, loadingMessage) : ''
       )
       : null
 )

--- a/app/frontend/components/pages/sendAda/confirmTransactionDialog.js
+++ b/app/frontend/components/pages/sendAda/confirmTransactionDialog.js
@@ -23,87 +23,46 @@ class ConfirmTransactionDialogClass {
       Modal,
       {
         closeHandler: cancelTransaction,
-        bodyClass: 'width-auto',
+        title: 'Transaction review',
       },
       h(
         'div',
-        {class: 'width-auto'},
-        h('h4', undefined, 'Review transaction'),
-        h(
-          'div',
-          {class: 'review-transaction-container'},
-          h('div', {class: 'review-transaction-row'}, h('span', undefined, 'Adress: ')),
-          h(
-            'div',
-            {class: 'review-transaction-row'},
-            h('span', {class: 'full-address'}, sendAddress)
-          ),
-          h(
-            'div',
-            {class: 'review-transaction-row'},
-            'Amout: ',
-            h('b', undefined, printAda(sendAmount))
-          ),
-          h(
-            'div',
-            {class: 'review-transaction-row'},
-            'Transaction fee: ',
-            h('b', undefined, printAda(transactionFee))
-          ),
-          h(
-            'div',
-            {class: 'review-transaction-total-row'},
-            h('b', {class: 'review-transaction-total-label'}, 'TOTAL (ADA)'),
-            h('b', {class: 'review-transaction-total'}, printAda(total))
-          ),
-          h(
-            'div',
-            {class: 'flex-align'},
-            h(
-              'button',
-              {
-                class: `${usingTrezor && waitingForTrezor ? 'waiting-for-trezor-button' : ''}`,
-                onClick: submitTransaction,
-                ref: (element) => {
-                  this.confirmTx = element
-                },
-                onKeyDown: (e) => {
-                  e.key === 'Enter' && e.target.click()
-                  if (['Tab', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
-                    this.cancelTx.focus()
-                    e.preventDefault()
-                  }
-                },
-              },
-              h('div', {
-                class: `${usingTrezor && waitingForTrezor ? 'loading-inside-button' : ''}`,
-              }),
-              usingTrezor && waitingForTrezor ? 'Waiting' : 'Confirm'
-            ),
-            h(
-              'button',
-              {
-                class: 'cancel',
-                onClick: cancelTransaction,
-                ref: (element) => {
-                  this.cancelTx = element
-                },
-                onKeyDown: (e) => {
-                  e.key === 'Enter' && e.target.click()
-                  if (['Tab', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
-                    this.confirmTx.focus()
-                    e.preventDefault()
-                  }
-                },
-              },
-              'Cancel'
-            )
-          )
-        )
+        {class: 'review'},
+        h('div', {class: 'review-label'}, 'Address'),
+        h('div', {class: 'review-address'}, sendAddress),
+        h('div', {class: 'ada-label'}, 'Amount'),
+        h('div', {class: 'review-amount'}, printAda(sendAmount)),
+        h('div', {class: 'ada-label'}, 'Fee'),
+        h('div', {class: 'review-fee'}, printAda(transactionFee)),
+        h('div', {class: 'ada-label'}, 'Total'),
+        h('div', {class: 'review-total'}, printAda(total))
       ),
-      usingTrezor &&
-        waitingForTrezor &&
-        h('div', {class: 'transparent-overlay', onClick: (e) => e.stopPropagation()})
+      h(
+        'div',
+        {class: 'review-bottom'},
+        h(
+          'button',
+          {
+            class: 'button primary',
+            onClick: submitTransaction,
+          },
+          'Confirm Transaction'
+        ),
+        h(
+          'a',
+          {
+            class: 'review-cancel',
+            onClick: cancelTransaction,
+            ref: (element) => {
+              this.cancelTx = element
+            },
+            onKeyDown: (e) => {
+              e.key === 'Enter' && e.target.click()
+            },
+          },
+          'Cancel Transaction'
+        )
+      )
     )
   }
 }
@@ -113,8 +72,6 @@ module.exports = connect(
     sendAddress: state.sendAddress.fieldValue,
     sendAmount: state.sendAmountForTransactionFee,
     transactionFee: state.transactionFee,
-    waitingForTrezor: state.waitingForTrezor,
-    usingTrezor: state.usingTrezor,
   }),
   actions
 )(ConfirmTransactionDialogClass)

--- a/app/frontend/components/pages/sendAda/confirmTransactionDialog.js
+++ b/app/frontend/components/pages/sendAda/confirmTransactionDialog.js
@@ -9,15 +9,7 @@ class ConfirmTransactionDialogClass {
     this.cancelTx.focus()
   }
 
-  render({
-    sendAddress,
-    sendAmount,
-    transactionFee,
-    submitTransaction,
-    cancelTransaction,
-    waitingForTrezor,
-    usingTrezor,
-  }) {
+  render({sendAddress, sendAmount, transactionFee, submitTransaction, cancelTransaction}) {
     const total = sendAmount + transactionFee
     return h(
       Modal,

--- a/app/frontend/components/pages/sendAda/donateThanksModal.js
+++ b/app/frontend/components/pages/sendAda/donateThanksModal.js
@@ -8,7 +8,7 @@ const DonateThanksModal = ({closeThanksForDonationModal}) =>
     {
       closeHandler: closeThanksForDonationModal,
       title: 'Thank you!',
-      bodyClass: 'donation',
+      bodyClass: 'centered',
     },
     /* TODO: Change copy */
     h(
@@ -17,12 +17,16 @@ const DonateThanksModal = ({closeThanksForDonationModal}) =>
       'Your support helps us in many ways. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi bibendum condimentum feugiat. Etiam vel vulputate lorem.'
     ),
     h(
-      'button',
-      {
-        class: 'button primary',
-        onClick: closeThanksForDonationModal,
-      },
-      "You're welcome"
+      'div',
+      {class: 'modal-footer'},
+      h(
+        'button',
+        {
+          class: 'button primary',
+          onClick: closeThanksForDonationModal,
+        },
+        "You're welcome"
+      )
     )
   )
 

--- a/app/frontend/components/pages/sendAda/donateThanksModal.js
+++ b/app/frontend/components/pages/sendAda/donateThanksModal.js
@@ -1,0 +1,31 @@
+const {h} = require('preact')
+
+const Modal = require('../../common/modal')
+
+const DonateThanksModal = ({closeThanksForDonationModal}) =>
+  h(
+    Modal,
+    {
+      closeHanlder: closeThanksForDonationModal,
+    },
+    h(
+      'div',
+      {
+        class: 'centered-row',
+      },
+      h('h3', undefined, 'Thank you for supporting AdaLite developers!')
+    ),
+    h(
+      'div',
+      {class: 'centered-row margin-top'},
+      h(
+        'button',
+        {
+          onClick: closeThanksForDonationModal,
+        },
+        'OK'
+      )
+    )
+  )
+
+module.exports = DonateThanksModal

--- a/app/frontend/components/pages/sendAda/donateThanksModal.js
+++ b/app/frontend/components/pages/sendAda/donateThanksModal.js
@@ -6,25 +6,23 @@ const DonateThanksModal = ({closeThanksForDonationModal}) =>
   h(
     Modal,
     {
-      closeHanlder: closeThanksForDonationModal,
+      closeHandler: closeThanksForDonationModal,
+      title: 'Thank you!',
+      bodyClass: 'donation',
     },
+    /* TODO: Change copy */
     h(
-      'div',
-      {
-        class: 'centered-row',
-      },
-      h('h3', undefined, 'Thank you for supporting AdaLite developers!')
+      'p',
+      {class: 'modal-paragraph'},
+      'Your support helps us in many ways. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi bibendum condimentum feugiat. Etiam vel vulputate lorem.'
     ),
     h(
-      'div',
-      {class: 'centered-row margin-top'},
-      h(
-        'button',
-        {
-          onClick: closeThanksForDonationModal,
-        },
-        'OK'
-      )
+      'button',
+      {
+        class: 'button primary',
+        onClick: closeThanksForDonationModal,
+      },
+      "You're welcome"
     )
   )
 

--- a/app/frontend/components/pages/sendAda/sendAdaPage.js
+++ b/app/frontend/components/pages/sendAda/sendAdaPage.js
@@ -1,4 +1,4 @@
-const {h, Component} = require('preact')
+const {h} = require('preact')
 const connect = require('unistore/preact').connect
 const actions = require('../../../actions')
 

--- a/app/frontend/components/pages/sendAda/sendAdaPage.js
+++ b/app/frontend/components/pages/sendAda/sendAdaPage.js
@@ -4,284 +4,181 @@ const actions = require('../../../actions')
 
 const {getTranslation} = require('../../../translations')
 const printAda = require('../../../helpers/printAda')
-const printConversionRates = require('../../../helpers/printConversionRates')
 
-const Balance = require('../../common/balance')
-const Modal = require('../../common/modal')
 const ConfirmTransactionDialog = require('./confirmTransactionDialog')
 const RawTransactionModal = require('./rawTransactionModal')
+const DonateThanksModal = require('./donateThanksModal')
 
-class ThanksForDonationModal extends Component {
-  componentDidMount() {
-    this.thanksForDonationBtn.focus()
-  }
+const CalculatingFee = () => h('div', {class: 'validation-message'}, 'Calculating fee')
 
-  render({closeThanksForDonationModal}) {
-    return h(
-      Modal,
-      {
-        closeHanlder: closeThanksForDonationModal,
-      },
+const AmountErrorMessage = ({sendAmount, sendAmountValidationError}) =>
+  sendAmountValidationError &&
+  h(
+    'span',
+    undefined,
+    sendAmountValidationError.code === 'SendAmountCantSendMaxFunds'
+      ? getTranslation(sendAmountValidationError.code, sendAmountValidationError.params)
+      : sendAmount !== '' &&
+        getTranslation(sendAmountValidationError.code, sendAmountValidationError.params)
+  )
+
+const AddressErrorMessage = ({sendAddress, sendAddressValidationError}) =>
+  sendAddressValidationError &&
+  sendAddress !== '' &&
+  h('span', undefined, getTranslation(sendAddressValidationError.code))
+
+const SendValidation = ({
+  sendAmount,
+  sendAmountValidationError,
+  sendAddress,
+  sendAddressValidationError,
+  sendResponse,
+}) =>
+  sendAmountValidationError || sendAddressValidationError
+    ? h(
+      'div',
+      {class: 'validation-message error'},
+      h(AddressErrorMessage, {sendAddress, sendAddressValidationError}),
+      h(AmountErrorMessage, {sendAmount, sendAmountValidationError})
+    )
+    : sendResponse &&
       h(
         'div',
+        {class: `validation-message ${sendResponse.success ? 'success' : 'error'}`},
+        sendResponse.success ? 'Transaction successful' : 'Transaction failed'
+      )
+
+const SendAdaPage = ({
+  sendResponse,
+  sendAddress,
+  sendAddressValidationError,
+  sendAmount,
+  sendAmountValidationError,
+  updateAddress,
+  updateAmount,
+  transactionFee,
+  confirmTransaction,
+  showConfirmTransactionDialog,
+  feeRecalculating,
+  sendMaxFunds,
+  showThanksForDonation,
+  closeThanksForDonationModal,
+  getRawTransaction,
+  rawTransactionOpen,
+  setRawTransactionOpen,
+  rawTransaction,
+}) => {
+  const enableSubmit =
+    sendAmount && !sendAmountValidationError && sendAddress && !sendAddressValidationError
+
+  const isSendAddressValid = !sendAddressValidationError && sendAddress !== ''
+
+  return h(
+    'div',
+    {class: 'send card'},
+    h('h2', {class: 'card-title'}, 'Send ADA'),
+    h('input', {
+      type: 'text',
+      id: 'send-address',
+      class: 'input send-address',
+      name: 'send-address',
+      placeholder: 'Receiving address',
+      value: sendAddress,
+      onInput: updateAddress,
+      autocomplete: 'off',
+      onKeyDown: (e) => e.key === 'Enter' && this.amountField.focus(),
+    }),
+    h(
+      'div',
+      {class: 'send-values'},
+      h(
+        'label',
         {
-          class: 'centered-row',
+          class: 'send-label',
+          for: 'send-amount',
         },
-        h('h3', undefined, 'Thank you for supporting AdaLite developers!')
+        'Amount'
       ),
       h(
         'div',
-        {class: 'centered-row margin-top'},
+        {class: 'input-wrapper'},
+        h('input', {
+          class: 'input send-amount',
+          id: 'send-amount',
+          name: 'send-amount',
+          placeholder: '0.000000',
+          value: sendAmount,
+          onInput: updateAmount,
+          ref: (element) => {
+            this.amountField = element
+          },
+          onKeyDown: (e) => {
+            if (e.key === 'Enter' && this.submitTxBtn) {
+              this.submitTxBtn.click()
+              e.preventDefault()
+            }
+          },
+        }),
         h(
           'button',
           {
-            ref: (element) => {
-              this.thanksForDonationBtn = element
-            },
-            onClick: closeThanksForDonationModal,
-            onKeyDown: (e) => e.key === 'Enter' && e.target.click(),
+            class: 'button send-max',
+            onClick: sendMaxFunds,
           },
-          'OK'
+          'MAX'
         )
-      )
-    )
-  }
-}
-
-class SendAdaPage extends Component {
-  componentDidMount() {
-    this.addressField.focus()
-  }
-
-  render({
-    balance,
-    reloadWalletInfo,
-    sendResponse,
-    sendAddress,
-    sendAddressValidationError,
-    sendAmount,
-    coinsAmount,
-    sendAmountValidationError,
-    updateAddress,
-    updateAmount,
-    transactionFee,
-    confirmTransaction,
-    showConfirmTransactionDialog,
-    feeRecalculating,
-    sendMaxFunds,
-    totalAmount,
-    showThanksForDonation,
-    closeThanksForDonationModal,
-    conversionRates,
-    getRawTransaction,
-    rawTransactionOpen,
-    setRawTransactionOpen,
-    rawTransaction,
-  }) {
-    const enableSubmit =
-      sendAmount && !sendAmountValidationError && sendAddress && !sendAddressValidationError
-
-    const isSendAddressValid = !sendAddressValidationError && sendAddress !== ''
-
-    const displayTransactionFee =
-      isSendAddressValid &&
-      sendAmount !== '' &&
-      transactionFee > 0 &&
-      !feeRecalculating &&
-      (!sendAmountValidationError ||
-        sendAmountValidationError.code === 'SendAmountInsufficientFunds')
-
-    return h(
-      'div',
-      {class: 'content-wrapper'},
-      h(Balance, {balance, reloadWalletInfo, conversionRates}),
+      ),
       h(
         'div',
-        undefined,
-        h('h2', undefined, 'Send Ada'),
-        sendResponse !== ''
-          ? h(
-            'div',
-            {
-              id: 'transacton-submitted',
-              class: `alert ${sendResponse.success ? 'success' : 'error'}`,
-            },
-            'Transaction ',
-            sendResponse.success
-              ? h('b', undefined, 'successful')
-              : h(
-                'span',
-                undefined,
-                h('b', undefined, 'failed'),
-                `: ${getTranslation(sendResponse.error, {sendResponse})}`
-              )
-          )
-          : '',
-        h(
-          'div',
-          {class: 'row'},
-          h('label', undefined, h('span', undefined, 'Receiving address')),
-          sendAddressValidationError &&
-            sendAddress !== '' &&
-            h('span', {class: 'validationMsg'}, getTranslation(sendAddressValidationError.code))
-        ),
-        h('input', {
-          type: 'text',
-          id: 'send-address',
-          class: 'styled-input-nodiv styled-send-input',
-          name: 'send-address',
-          placeholder: 'Address',
-          size: '28',
-          value: sendAddress,
-          onInput: updateAddress,
-          autocomplete: 'nope',
+        {
+          class: 'send-label',
+        },
+        'Fee'
+      ),
+      h('div', {class: 'send-fee'}, printAda(transactionFee))
+    ),
+    h(
+      'div',
+      {class: 'validation-row'},
+      h(
+        'button',
+        {
+          class: 'button primary',
+          disabled: !enableSubmit,
+          onClick: confirmTransaction,
           ref: (element) => {
-            this.addressField = element
+            this.submitTxBtn = element
           },
-          onKeyDown: (e) => e.key === 'Enter' && this.amountField.focus(),
-        }),
-        h(
-          'div',
-          {class: 'amount-label-row'},
-          h('div', {class: 'row'}, h('label', undefined, h('span', undefined, 'Amount'))),
-          displayTransactionFee &&
-            h('span', {class: 'transaction-fee'}, `+ ${printAda(transactionFee)} tx fee`)
-        ),
-        h(
-          'div',
-          {
-            class: 'send-amount-input-group',
-          },
-          h(
-            'div',
-            {
-              class: `send-max-funds-btn send-max-funds-btn-${
-                isSendAddressValid ? 'enabled' : 'disabled'
-              }`,
-              onClick: sendMaxFunds,
-            },
-            'MAX'
-          ),
-          h(
-            'div',
-            {class: 'styled-input send-input'},
-            h('input', {
-              id: 'send-amount',
-              name: 'send-amount',
-              placeholder: 'Amount',
-              size: '28',
-              value: sendAmount,
-              onInput: updateAmount,
-              autocomplete: 'nope',
-              ref: (element) => {
-                this.amountField = element
-              },
-              onKeyDown: (e) => {
-                if (e.key === 'Tab') {
-                  enableSubmit && this.submitTxBtn
-                    ? this.submitTxBtn.focus()
-                    : this.addressField.focus()
-                  e.preventDefault()
-                }
-                if (e.key === 'Enter' && this.submitTxBtn) {
-                  this.submitTxBtn.click()
-                  e.preventDefault()
-                }
-              },
-            }),
-            displayTransactionFee &&
-              h(
-                'span',
-                {
-                  class: `transaction-fee-text ${
-                    feeRecalculating || !enableSubmit ? 'red' : 'green'
-                  }`,
-                },
-                `= ${printAda(totalAmount)} ADA`
-              )
-          )
-        ),
-        displayTransactionFee &&
-          conversionRates &&
-          h(
-            'span',
-            {
-              class: 'total-other-currencies',
-            },
-            `(${printConversionRates(totalAmount, conversionRates)})`
-          ),
-        sendAmountValidationError &&
-          (sendAmount !== '' || sendAmountValidationError.code === 'SendAmountCantSendMaxFunds') &&
-          h(
-            'p',
-            {class: 'validationMsg send-amount-validation-error'},
-            getTranslation(sendAmountValidationError.code, sendAmountValidationError.params)
-          ),
-        h(
-          'div',
-          {class: 'submit-row'},
-          h(
-            'span',
-            {
-              onClick: async () => {
-                await getRawTransaction(sendAddress, coinsAmount)
-                setRawTransactionOpen(true)
-              },
-              class: `link raw-transaction-link${
-                !enableSubmit || feeRecalculating ? '-disabled' : ''
-              }`,
-            },
-            'Raw unsigned transaction'
-          ),
-          feeRecalculating
-            ? h(
-              'button',
-              {disabled: true, class: 'submit-button'},
-              h('div', {class: 'loading-inside-button'}),
-              'Calculating Fee'
-            )
-            : h(
-              'button',
-              {
-                class: 'submit-button',
-                disabled: !enableSubmit,
-                onClick: confirmTransaction,
-                onKeyDown: (e) => {
-                  if (e.key === 'Tab') {
-                    this.addressField.focus()
-                    e.preventDefault()
-                  }
-                },
-                ref: (element) => {
-                  this.submitTxBtn = element
-                },
-              },
-              'Submit'
-            )
-        ),
-        rawTransactionOpen && h(RawTransactionModal),
-        showConfirmTransactionDialog && h(ConfirmTransactionDialog),
-        showThanksForDonation && h(ThanksForDonationModal, {closeThanksForDonationModal})
-      )
-    )
-  }
+        },
+        'Send ADA'
+      ),
+      feeRecalculating
+        ? h(CalculatingFee)
+        : h(SendValidation, {
+          sendAmount,
+          sendAmountValidationError,
+          sendAddress,
+          sendAddressValidationError,
+          sendResponse,
+        })
+    ),
+    rawTransactionOpen && h(RawTransactionModal),
+    showConfirmTransactionDialog && h(ConfirmTransactionDialog),
+    showThanksForDonation && h(DonateThanksModal, {closeThanksForDonationModal})
+  )
 }
 
 module.exports = connect(
   (state) => ({
-    balance: state.balance,
     sendResponse: state.sendResponse,
     sendAddressValidationError: state.sendAddress.validationError,
     sendAddress: state.sendAddress.fieldValue,
     sendAmountValidationError: state.sendAmount.validationError,
     sendAmount: state.sendAmount.fieldValue,
-    coinsAmount: state.sendAmount.coins,
     transactionFee: state.transactionFee,
     showConfirmTransactionDialog: state.showConfirmTransactionDialog,
     feeRecalculating: state.calculatingFee,
-    totalAmount: state.sendAmountForTransactionFee + state.transactionFee,
     showThanksForDonation: state.showThanksForDonation,
-    conversionRates: state.conversionRates && state.conversionRates.data,
     rawTransaction: state.rawTransaction,
     rawTransactionOpen: state.rawTransactionOpen,
   }),

--- a/app/frontend/components/pages/sendAda/sendAdaPage.js
+++ b/app/frontend/components/pages/sendAda/sendAdaPage.js
@@ -96,16 +96,12 @@ const SendAdaPage = ({
       'div',
       {class: 'send-values'},
       h(
-        'div',
-        undefined,
-        h(
-          'label',
-          {
-            class: 'send-label',
-            for: 'send-amount',
-          },
-          'Amount'
-        )
+        'label',
+        {
+          class: 'ada-label',
+          for: 'send-amount',
+        },
+        'Amount'
       ),
       h(
         'div',
@@ -138,14 +134,10 @@ const SendAdaPage = ({
       ),
       h(
         'div',
-        undefined,
-        h(
-          'div',
-          {
-            class: 'send-label',
-          },
-          'Fee'
-        )
+        {
+          class: 'ada-label',
+        },
+        'Fee'
       ),
       h('div', {class: 'send-fee'}, printAda(transactionFee))
     ),

--- a/app/frontend/components/pages/sendAda/sendAdaPage.js
+++ b/app/frontend/components/pages/sendAda/sendAdaPage.js
@@ -8,6 +8,7 @@ const printAda = require('../../../helpers/printAda')
 const ConfirmTransactionDialog = require('./confirmTransactionDialog')
 const RawTransactionModal = require('./rawTransactionModal')
 const DonateThanksModal = require('./donateThanksModal')
+const TransactionErrorModal = require('./transactionErrorModal')
 
 const CalculatingFee = () => h('div', {class: 'validation-message send'}, 'Calculating fee')
 
@@ -41,12 +42,8 @@ const SendValidation = ({
       h(AddressErrorMessage, {sendAddress, sendAddressValidationError}),
       h(AmountErrorMessage, {sendAmount, sendAmountValidationError})
     )
-    : sendResponse &&
-      h(
-        'div',
-        {class: `validation-message send ${sendResponse.success ? 'success' : 'error'}`},
-        sendResponse.success ? 'Transaction successful' : 'Transaction failed'
-      )
+    : sendResponse.success &&
+      h('div', {class: 'validation-message send success'}, 'Transaction successful')
 
 const SendAdaPage = ({
   sendResponse,
@@ -63,6 +60,8 @@ const SendAdaPage = ({
   sendMaxFunds,
   showThanksForDonation,
   closeThanksForDonationModal,
+  closeTransactionErrorModal,
+  showTransactionErrorModal,
   getRawTransaction,
   rawTransactionOpen,
   setRawTransactionOpen,
@@ -98,7 +97,7 @@ const SendAdaPage = ({
       h(
         'label',
         {
-          class: 'ada-label',
+          class: 'ada-label amount',
           for: 'send-amount',
         },
         'Amount'
@@ -164,6 +163,7 @@ const SendAdaPage = ({
           sendAddress,
           sendAddressValidationError,
           sendResponse,
+          closeTransactionErrorModal,
         })
     ),
     h(
@@ -175,6 +175,11 @@ const SendAdaPage = ({
       },
       'Raw unsigned transaction'
     ),
+    showTransactionErrorModal &&
+      h(TransactionErrorModal, {
+        closeTransactionErrorModal,
+        errorMessage: getTranslation(sendResponse.error, {sendResponse}),
+      }),
     rawTransactionOpen && h(RawTransactionModal),
     showConfirmTransactionDialog && h(ConfirmTransactionDialog),
     showThanksForDonation && h(DonateThanksModal, {closeThanksForDonationModal})
@@ -190,6 +195,7 @@ module.exports = connect(
     sendAmount: state.sendAmount.fieldValue,
     transactionFee: state.transactionFee,
     showConfirmTransactionDialog: state.showConfirmTransactionDialog,
+    showTransactionErrorModal: state.showTransactionErrorModal,
     feeRecalculating: state.calculatingFee,
     showThanksForDonation: state.showThanksForDonation,
     rawTransaction: state.rawTransaction,

--- a/app/frontend/components/pages/sendAda/sendAdaPage.js
+++ b/app/frontend/components/pages/sendAda/sendAdaPage.js
@@ -67,11 +67,15 @@ const SendAdaPage = ({
   rawTransactionOpen,
   setRawTransactionOpen,
   rawTransaction,
+  coinsAmount,
 }) => {
   const enableSubmit =
     sendAmount && !sendAmountValidationError && sendAddress && !sendAddressValidationError
 
-  const isSendAddressValid = !sendAddressValidationError && sendAddress !== ''
+  const rawTransactionHandler = async () => {
+    await getRawTransaction(sendAddress, coinsAmount)
+    setRawTransactionOpen(true)
+  }
 
   return h(
     'div',
@@ -152,7 +156,7 @@ const SendAdaPage = ({
         'button',
         {
           class: 'button primary',
-          disabled: !enableSubmit,
+          disabled: !enableSubmit || feeRecalculating,
           onClick: confirmTransaction,
           ref: (element) => {
             this.submitTxBtn = element
@@ -169,6 +173,15 @@ const SendAdaPage = ({
           sendAddressValidationError,
           sendResponse,
         })
+    ),
+    h(
+      'a',
+      {
+        href: '#',
+        class: 'send-raw',
+        onClick: enableSubmit && !feeRecalculating && rawTransactionHandler,
+      },
+      'Raw unsigned transaction'
     ),
     rawTransactionOpen && h(RawTransactionModal),
     showConfirmTransactionDialog && h(ConfirmTransactionDialog),
@@ -189,6 +202,7 @@ module.exports = connect(
     showThanksForDonation: state.showThanksForDonation,
     rawTransaction: state.rawTransaction,
     rawTransactionOpen: state.rawTransactionOpen,
+    coinsAmount: state.sendAmount.coins,
   }),
   actions
 )(SendAdaPage)

--- a/app/frontend/components/pages/sendAda/sendAdaPage.js
+++ b/app/frontend/components/pages/sendAda/sendAdaPage.js
@@ -9,7 +9,7 @@ const ConfirmTransactionDialog = require('./confirmTransactionDialog')
 const RawTransactionModal = require('./rawTransactionModal')
 const DonateThanksModal = require('./donateThanksModal')
 
-const CalculatingFee = () => h('div', {class: 'validation-message'}, 'Calculating fee')
+const CalculatingFee = () => h('div', {class: 'validation-message send'}, 'Calculating fee')
 
 const AmountErrorMessage = ({sendAmount, sendAmountValidationError}) =>
   sendAmountValidationError &&
@@ -37,14 +37,14 @@ const SendValidation = ({
   sendAmountValidationError || sendAddressValidationError
     ? h(
       'div',
-      {class: 'validation-message error'},
+      {class: 'validation-message send error'},
       h(AddressErrorMessage, {sendAddress, sendAddressValidationError}),
       h(AmountErrorMessage, {sendAmount, sendAmountValidationError})
     )
     : sendResponse &&
       h(
         'div',
-        {class: `validation-message ${sendResponse.success ? 'success' : 'error'}`},
+        {class: `validation-message send ${sendResponse.success ? 'success' : 'error'}`},
         sendResponse.success ? 'Transaction successful' : 'Transaction failed'
       )
 
@@ -80,7 +80,7 @@ const SendAdaPage = ({
     h('input', {
       type: 'text',
       id: 'send-address',
-      class: 'input send-address',
+      class: 'input send-address fullwidth',
       name: 'send-address',
       placeholder: 'Receiving address',
       value: sendAddress,
@@ -92,12 +92,16 @@ const SendAdaPage = ({
       'div',
       {class: 'send-values'},
       h(
-        'label',
-        {
-          class: 'send-label',
-          for: 'send-amount',
-        },
-        'Amount'
+        'div',
+        undefined,
+        h(
+          'label',
+          {
+            class: 'send-label',
+            for: 'send-amount',
+          },
+          'Amount'
+        )
       ),
       h(
         'div',
@@ -125,15 +129,19 @@ const SendAdaPage = ({
             class: 'button send-max',
             onClick: sendMaxFunds,
           },
-          'MAX'
+          'Max'
         )
       ),
       h(
         'div',
-        {
-          class: 'send-label',
-        },
-        'Fee'
+        undefined,
+        h(
+          'div',
+          {
+            class: 'send-label',
+          },
+          'Fee'
+        )
       ),
       h('div', {class: 'send-fee'}, printAda(transactionFee))
     ),

--- a/app/frontend/components/pages/sendAda/sendAdaPage.js
+++ b/app/frontend/components/pages/sendAda/sendAdaPage.js
@@ -43,7 +43,7 @@ const SendValidation = ({
       h(AmountErrorMessage, {sendAmount, sendAmountValidationError})
     )
     : sendResponse.success &&
-      h('div', {class: 'validation-message send success'}, 'Transaction successful')
+      h('div', {class: 'validation-message transaction-success'}, 'Transaction successful!')
 
 const SendAdaPage = ({
   sendResponse,

--- a/app/frontend/components/pages/sendAda/transactionErrorModal.js
+++ b/app/frontend/components/pages/sendAda/transactionErrorModal.js
@@ -1,0 +1,34 @@
+const {h} = require('preact')
+
+const Modal = require('../../common/modal')
+const Alert = require('../../common/alert')
+
+const TransactionErrorModal = ({closeTransactionErrorModal, errorMessage}) =>
+  h(
+    Modal,
+    {
+      closeHandler: closeTransactionErrorModal,
+      title: 'Transaction error',
+    },
+    h(
+      Alert,
+      {
+        alertType: 'error',
+      },
+      errorMessage
+    ),
+    h(
+      'div',
+      {class: 'modal-footer'},
+      h(
+        'button',
+        {
+          class: 'button primary',
+          onClick: closeTransactionErrorModal,
+        },
+        'I understand, continue to the demo wallet'
+      )
+    )
+  )
+
+module.exports = TransactionErrorModal

--- a/app/public/assets/ada_symbol_grey.svg
+++ b/app/public/assets/ada_symbol_grey.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="10px" height="11px" viewBox="0 0 10 11" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 52.6 (67491) - http://www.bohemiancoding.com/sketch -->
+    <title>Group 2</title>
+    <desc>Created with Sketch.</desc>
+    <g id="✅--Done" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+        <g id="02-01-dashboard" transform="translate(-933.000000, -500.000000)" stroke="#606A71">
+            <g id="Group-10" transform="translate(828.000000, 216.000000)">
+                <g id="Group-6" transform="translate(72.000000, 272.000000)">
+                    <g id="Group-2" transform="translate(34.000000, 12.000000)">
+                        <polyline id="Path-2" points="0 10.1917225 4 0.195409255 8 10.1917225"></polyline>
+                        <path d="M1,4.5 L6.99733,4.5" id="Path-3"></path>
+                        <path d="M0,6.5 L8,6.5" id="Path-3"></path>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -181,14 +181,6 @@
   font-size: 16px;
 }
 
-@keyframes fade-in {
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
-}
 @keyframes loading-spin {
   0% {
     transform: rotate(0deg);
@@ -196,15 +188,6 @@
   100% {
     transform: rotate(360deg);
   }
-}
-.loading {
-  display: inline-block;
-  border: 8px solid rgba(150, 150, 150, 0.4);
-  border-left-color: var(--brand);
-  border-radius: 50%;
-  width: 60px;
-  height: 60px;
-  animation: loading-spin 1s linear infinite;
 }
 
 .ontop {
@@ -2707,7 +2690,6 @@ button[data-balloon] {
 .review-bottom .button:first-child {
   margin-bottom: 32px;
 }
-<<<<<<< HEAD
 
 /* ANIMATIONS */
 
@@ -3474,5 +3456,3 @@ button[data-balloon] {
     margin: 0;
   }
 }
-=======
->>>>>>> Styled Transaction review

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -2707,6 +2707,7 @@ button[data-balloon] {
 .review-bottom .button:first-child {
   margin-bottom: 32px;
 }
+<<<<<<< HEAD
 
 /* ANIMATIONS */
 
@@ -3473,3 +3474,5 @@ button[data-balloon] {
     margin: 0;
   }
 }
+=======
+>>>>>>> Styled Transaction review

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -982,6 +982,28 @@ p {
   margin-bottom: 32px;
 }
 
+.input.send-address {
+  margin-bottom: 32px;
+}
+
+.input.send-amount {
+  border: none;
+  padding: 0;
+  flex: 1;
+  color: var(--color-grey);
+}
+
+.input.send-amount:focus {
+  box-shadow: none;
+}
+
+.input-wrapper {
+  border-radius: 4px;
+  border: 1px solid var(--color-border);
+  padding: 12px 16px;
+  display: flex;
+}
+
 /* BUTTONS */
 
 .button {
@@ -1146,6 +1168,15 @@ p {
   background-repeat: no-repeat;
   background-size: contain;
   background-image: url('../assets/caret_down_symbol.svg');
+}
+
+.button.send-max {
+  padding: 0;
+  background: none;
+  font-size: 14px;
+  color: var(--color-brand);
+  text-decoration: underline;
+  margin-left: 16px;
 }
 
 /* TOOLTIP */
@@ -2201,8 +2232,31 @@ button[data-balloon] {
   flex: 1;
 }
 
+.validation-message.send {
+  padding-left: 64px;
+  color: var(--color-grey);
+}
+
 .validation-message.error {
   color: var(--color-error);
+}
+
+.validation-message.transaction-success {
+  padding-left: 104px;
+  position: relative;
+  color: var(--color-success);
+}
+
+.validation-message.transaction-success::before {
+  content: '';
+  position: absolute;
+  left: 67px;
+  width: 24px;
+  height: 24px;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
+  background-image: url('../assets/alert_icon_success.svg');
 }
 
 /* SIDEBAR */
@@ -2534,6 +2588,233 @@ button[data-balloon] {
   text-align: center;
   padding-top: 40px;
   border-top: 1px solid var(--color-border);
+}
+
+/* SEND */
+
+.send-values {
+  margin-bottom: 32px;
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  grid-row-gap: 32px;
+  grid-column-gap: 96px;
+  align-items: center;
+  color: var(--color-grey);
+}
+
+.ada-label {
+  padding-right: 16px;
+  position: relative;
+  color: var(--color-grey);
+  font-size: 14px;
+  line-height: 32px;
+}
+
+.ada-label::after {
+  content: '';
+  position: absolute;
+  width: 9px;
+  height: 12px;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  margin: auto;
+  margin-left: 8px;
+  background-repeat: no-repeat;
+  background-size: contain;
+  background-position: center;
+  background-image: url('../assets/ada_symbol_grey.svg');
+}
+
+.send-values .ada-label {
+  justify-self: start;
+  align-self: start;
+}
+
+.ada-label.amount {
+  align-self: center;
+}
+
+.send-fee {
+  padding-left: 16px;
+}
+
+.send-raw {
+  color: rgba(96, 106, 113, 0.64);
+  margin-top: 40px;
+  display: inline-block;
+}
+
+.review {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  grid-row-gap: 8px;
+  grid-column-gap: 56px;
+  line-height: 32px;
+  margin: 32px 0 64px 0;
+}
+
+.review-label {
+  color: var(--color-grey);
+  font-size: 14px;
+  line-height: 32px;
+}
+
+.review .ada-label {
+  align-self: start;
+  justify-self: start;
+}
+
+.review-address {
+  margin-bottom: 24px;
+  word-break: break-all;
+}
+
+.review-fee {
+  margin-bottom: 24px;
+  position: relative;
+}
+
+.review-fee::before {
+  content: '';
+  height: 1px;
+  width: 200px;
+  position: absolute;
+  left: -136px;
+  bottom: -16px;
+  background-color: var(--color-grey-light);
+}
+
+.review-total {
+  font-weight: bold;
+  color: var(--color-grey-dark);
+}
+
+.review-bottom {
+  text-align: center;
+}
+
+.review-bottom .button {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.review-cancel {
+  color: var(--color-grey);
+}
+
+.review-bottom .button:first-child {
+  margin-bottom: 32px;
+}
+
+/* ANIMATIONS */
+
+@-webkit-keyframes rotate {
+  0% {
+    -webkit-transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+  }
+}
+
+@keyframes rotate {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes fade-in {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+/* LOADING OVERLAY */
+
+.loading {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  animation: fade-in 0.5s;
+  background-color: rgba(32, 50, 64, 0.64);
+}
+
+.loading-message {
+  margin-top: 16px;
+  font-size: 16px;
+  line-height: 32px;
+  font-weight: bold;
+  color: white;
+}
+
+.spinner {
+  display: block;
+  height: 40px;
+  width: 40px;
+  -webkit-animation: rotate 2s linear infinite;
+  animation: rotate 2s linear infinite;
+}
+
+.spinner span {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  margin: auto;
+  height: 40px;
+  width: 40px;
+  clip: rect(24px, 40px, 40px, 0);
+  -webkit-animation: rotate 2s cubic-bezier(0.77, 0, 0.175, 1) infinite;
+  animation: rotate 2s cubic-bezier(0.77, 0, 0.175, 1) infinite;
+}
+
+.spinner span::before {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  margin: auto;
+  height: 40px;
+  width: 40px;
+  border: 3px solid transparent;
+  border-top-color: #fff;
+  border-radius: 50%;
+  -webkit-animation: rotate 2s cubic-bezier(0.77, 0, 0.175, 1) infinite;
+  animation: rotate 2s cubic-bezier(0.77, 0, 0.175, 1) infinite;
+}
+
+.spinner span::after {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  margin: auto;
+  height: 40px;
+  width: 40px;
+  border: 3px solid rgba(255, 255, 255, 0.5);
+  border-radius: 50%;
 }
 
 /* EXPORT */


### PR DESCRIPTION
Closes #342

Styled `SendADA` component, removed unnecessary components & code, added missing modals, changed styling of the `LoadingOverlay`.

Added `showTransactionErrorModal & closeTransactionErrorModal` handlers. Removed `waitingForTrezor` from the submit button as a loading overlay makes more sense.

Should wait for copy by @kuchtee as some modals have incorrect or just `lorem` texts (left a `TODO`).