### PR TITLE
Adjusted styling for Balance on mobile

### DIFF
--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -2779,6 +2779,16 @@ p {
     font-size: 14px;
   }
 
+  .button.refresh {
+    text-indent: -9999em;
+    padding-left: 24px;
+  }
+
+  .button.refresh::before {
+    left: 0;
+    right: 0;
+  }
+
   /* NAVBAR */
 
   .navbar {
@@ -2977,6 +2987,10 @@ p {
 
   .card.authentication {
     border: 0;
+  }
+
+  .card-title {
+    font-size: 14px;
   }
 
   /* INPUTS */


### PR DESCRIPTION
Closes #346 

Adjusted styling on `.card` as all the `.card` elements seem to lose the shadow and gain a bottom border on mobile. Adjusted `refresh` button.