### PR TITLE
Mobile Transactions

### DIFF
--- a/app/frontend/components/pages/txHistory/transactionHistory.js
+++ b/app/frontend/components/pages/txHistory/transactionHistory.js
@@ -27,18 +27,14 @@ const FormattedFee = ({fee}) => {
 
 const TransactionAddress = ({address}) =>
   h(
-    'div',
-    undefined,
-    h(
-      'a',
-      {
-        class: 'transaction-address',
-        href: `https://adascan.net/transaction/${address}`,
-        target: '_blank',
-        rel: 'noopener',
-      },
-      'View details'
-    )
+    'a',
+    {
+      class: 'transaction-address',
+      href: `https://adascan.net/transaction/${address}`,
+      target: '_blank',
+      rel: 'noopener',
+    },
+    'View details'
   )
 
 const TransactionHistory = ({transactionHistory}) =>

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -2485,6 +2485,7 @@ p {
 }
 
 .transaction-address {
+  justify-self: start;
   color: rgba(96, 106, 113, 0.64);
 }
 
@@ -2950,5 +2951,21 @@ p {
 
   .page-demo {
     margin-top: 40px;
+  }
+
+  /* TRANSACTIONS */
+
+  .transaction-address {
+    order: 1;
+    align-self: center;
+  }
+  .transaction-amount {
+    order: 2;
+  }
+  .transaction-date {
+    order: 3;
+  }
+  .transaction-fee {
+    order: 4;
   }
 }


### PR DESCRIPTION
Closes #348

Refactored `.transaction-address` - removed the outer `div` as it was not needed.