### PR TITLE
use old utxo endpoint again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package.json" }}-{{ checksum "app/package.json"}}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+          - v1-dependencies-{{ checksum "yarn.lock" }}-{{ checksum "app/yarn.lock"}}
 
       - run: cp .env.example .env
       - run: yarn install
@@ -34,7 +32,7 @@ jobs:
           paths:
             - node_modules
             - app/node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}-{{ checksum "app/package.json"}}
+          key: v1-dependencies-{{ checksum "yarn.lock" }}-{{ checksum "app/yarn.lock"}}
 
       # run tests!
       - run: yarn eslint

--- a/app/frontend/wallet/blockchain-explorer.js
+++ b/app/frontend/wallet/blockchain-explorer.js
@@ -132,29 +132,22 @@ const blockchainExplorer = (ADALITE_CONFIG, walletState) => {
     const nonemptyAddresses = await selectNonemptyAddresses(addresses)
     const chunks = range(0, Math.ceil(nonemptyAddresses.length / 10))
 
-    const url = 'https://iohk-mainnet.yoroiwallet.com/api/txs/utxoForAddresses'
+    const url = `${ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL}/api/bulk/addresses/utxo`
     const response = (await Promise.all(
       chunks.map(async (index) => {
-        return await request(
-          url,
-          'POST',
-          JSON.stringify({
-            addresses: nonemptyAddresses.slice(index, 10),
-          }),
-          {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json',
-          }
-        )
+        return (await request(url, 'POST', JSON.stringify(nonemptyAddresses.slice(index, 10)), {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json',
+        })).Right
       })
     )).reduce((acc, cur) => acc.concat(cur), [])
 
     return response.map((elem) => {
       return {
-        txHash: elem.tx_hash,
-        address: elem.receiver,
-        coins: parseInt(elem.amount, 10),
-        outputIndex: elem.tx_index,
+        txHash: elem.cuId,
+        address: elem.cuAddress,
+        coins: parseInt(elem.cuCoins.getCoin, 10),
+        outputIndex: elem.cuOutIndex,
       }
     })
   }

--- a/app/package.json
+++ b/app/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "bip39-light": "^1.0.7",
-    "borc": "^2.0.4",
+    "borc": "^2.1.0",
     "cardano-crypto.js": "^5.0.0",
     "file-saver": "^1.3.8",
     "preact": "^8.2.7",

--- a/app/tests/src/common/mock.js
+++ b/app/tests/src/common/mock.js
@@ -1581,68 +1581,72 @@ const mock = (ADALITE_CONFIG) => {
     fetchMock.config.overwriteRoutes = true
 
     const requestsAndResponses = {
-      '{"addresses":["DdzFFzCqrhsjeiN7xW9DpwoPh13BMwDctP9RrufwAMa1dRmFaR9puCyckq4mXkjeZk1VsEJqxkb89z636SsGQ4x54boVoX3DRW3QC9g5","DdzFFzCqrhtCrR5oxyvhmRCfwFJ4tKXo7xocEXGoEMruhp23eddcuZVegJiiyJtuY5NDgG9eoe7CHVDRcszfKTKcHAxccvDVs1xwK7Gz"]}': [
-        {
-          tx_hash: '6ca5fde47f4ff7f256a7464dbf0cb9b4fb6bce9049eee1067eed65cf5d6e2765',
-          tx_index: 0,
-          receiver:
-            'DdzFFzCqrhsjeiN7xW9DpwoPh13BMwDctP9RrufwAMa1dRmFaR9puCyckq4mXkjeZk1VsEJqxkb89z636SsGQ4x54boVoX3DRW3QC9g5',
-          amount: '100000',
-        },
-        {
-          tx_hash: '6ca5fde47f4ff7f256a7464dbf0cb9b4fb6bce9049eee1067eed65cf5d6e2765',
-          tx_index: 1,
-          receiver:
-            'DdzFFzCqrhtCrR5oxyvhmRCfwFJ4tKXo7xocEXGoEMruhp23eddcuZVegJiiyJtuY5NDgG9eoe7CHVDRcszfKTKcHAxccvDVs1xwK7Gz',
-          amount: '2867795',
-        },
-      ],
-      '{"addresses":["DdzFFzCqrhsvrNGcR93DW8cmrPVVbP6vFxcL1i92WzvqcHrp1K1of4DQ8t8cr3oQgsMbbY1eXKWhrcpfnTohNqrr6zPdLeE3AYBtxxZZ","DdzFFzCqrhtA8C86FGbYkcnHuu8uNmjZ4M6pDKKYXAwZRYr1Q8mXHmUFhgjcTCkuSDnx8xA7tu75727wAc6Ki5nM2PDFK3JXfdYfbvHC"]}': [
-        {
-          tx_hash: '6ca5fde47f4ff7f256a7464dbf0cb9b4fb6bce9049eee1067eed65cf5d6e2765',
-          tx_index: 0,
-          receiver:
-            'DdzFFzCqrhsvrNGcR93DW8cmrPVVbP6vFxcL1i92WzvqcHrp1K1of4DQ8t8cr3oQgsMbbY1eXKWhrcpfnTohNqrr6zPdLeE3AYBtxxZZ',
-          amount: '500000',
-        },
-        {
-          tx_hash: '6ca5fde47f4ff7f256a7464dbf0cb9b4fb6bce9049eee1067eed65cf5d6e2765',
-          tx_index: 1,
-          receiver:
-            'DdzFFzCqrhtA8C86FGbYkcnHuu8uNmjZ4M6pDKKYXAwZRYr1Q8mXHmUFhgjcTCkuSDnx8xA7tu75727wAc6Ki5nM2PDFK3JXfdYfbvHC',
-          amount: '1000000',
-        },
-        {
-          tx_hash: 'aa22f977c2671836647d347ebe23822269ce21cd22f231e1279018b569dcd48c',
-          tx_index: 0,
-          receiver:
-            'DdzFFzCqrhtA8C86FGbYkcnHuu8uNmjZ4M6pDKKYXAwZRYr1Q8mXHmUFhgjcTCkuSDnx8xA7tu75727wAc6Ki5nM2PDFK3JXfdYfbvHC',
-          amount: '6000',
-        },
-        {
-          tx_hash: '73131c773879e7e634022f8e0175399b7e7814c42684377cf6f8c7a1adb23112',
-          tx_index: 1,
-          receiver:
-            'DdzFFzCqrhtA8C86FGbYkcnHuu8uNmjZ4M6pDKKYXAwZRYr1Q8mXHmUFhgjcTCkuSDnx8xA7tu75727wAc6Ki5nM2PDFK3JXfdYfbvHC',
-          amount: '125',
-        },
-        {
-          tx_hash: '1ce7a1e2606271a7f085262fb7c509c98d60912a943c9be3871ac3ace48ae6d6',
-          tx_index: 1,
-          receiver:
-            'DdzFFzCqrhtA8C86FGbYkcnHuu8uNmjZ4M6pDKKYXAwZRYr1Q8mXHmUFhgjcTCkuSDnx8xA7tu75727wAc6Ki5nM2PDFK3JXfdYfbvHC',
-          amount: '5000',
-        },
-      ],
+      '["DdzFFzCqrhsjeiN7xW9DpwoPh13BMwDctP9RrufwAMa1dRmFaR9puCyckq4mXkjeZk1VsEJqxkb89z636SsGQ4x54boVoX3DRW3QC9g5","DdzFFzCqrhtCrR5oxyvhmRCfwFJ4tKXo7xocEXGoEMruhp23eddcuZVegJiiyJtuY5NDgG9eoe7CHVDRcszfKTKcHAxccvDVs1xwK7Gz"]': {
+        Right: [
+          {
+            cuId: '6ca5fde47f4ff7f256a7464dbf0cb9b4fb6bce9049eee1067eed65cf5d6e2765',
+            cuOutIndex: 0,
+            cuAddress:
+              'DdzFFzCqrhsjeiN7xW9DpwoPh13BMwDctP9RrufwAMa1dRmFaR9puCyckq4mXkjeZk1VsEJqxkb89z636SsGQ4x54boVoX3DRW3QC9g5',
+            cuCoins: {getCoin: '100000'},
+          },
+          {
+            cuId: '6ca5fde47f4ff7f256a7464dbf0cb9b4fb6bce9049eee1067eed65cf5d6e2765',
+            cuOutIndex: 1,
+            cuAddress:
+              'DdzFFzCqrhtCrR5oxyvhmRCfwFJ4tKXo7xocEXGoEMruhp23eddcuZVegJiiyJtuY5NDgG9eoe7CHVDRcszfKTKcHAxccvDVs1xwK7Gz',
+            cuCoins: {getCoin: '2867795'},
+          },
+        ],
+      },
+      '["DdzFFzCqrhsvrNGcR93DW8cmrPVVbP6vFxcL1i92WzvqcHrp1K1of4DQ8t8cr3oQgsMbbY1eXKWhrcpfnTohNqrr6zPdLeE3AYBtxxZZ","DdzFFzCqrhtA8C86FGbYkcnHuu8uNmjZ4M6pDKKYXAwZRYr1Q8mXHmUFhgjcTCkuSDnx8xA7tu75727wAc6Ki5nM2PDFK3JXfdYfbvHC"]': {
+        Right: [
+          {
+            cuId: '6ca5fde47f4ff7f256a7464dbf0cb9b4fb6bce9049eee1067eed65cf5d6e2765',
+            cuOutIndex: 0,
+            cuAddress:
+              'DdzFFzCqrhsvrNGcR93DW8cmrPVVbP6vFxcL1i92WzvqcHrp1K1of4DQ8t8cr3oQgsMbbY1eXKWhrcpfnTohNqrr6zPdLeE3AYBtxxZZ',
+            cuCoins: {getCoin: '500000'},
+          },
+          {
+            cuId: '6ca5fde47f4ff7f256a7464dbf0cb9b4fb6bce9049eee1067eed65cf5d6e2765',
+            cuOutIndex: 1,
+            cuAddress:
+              'DdzFFzCqrhtA8C86FGbYkcnHuu8uNmjZ4M6pDKKYXAwZRYr1Q8mXHmUFhgjcTCkuSDnx8xA7tu75727wAc6Ki5nM2PDFK3JXfdYfbvHC',
+            cuCoins: {getCoin: '1000000'},
+          },
+          {
+            cuId: 'aa22f977c2671836647d347ebe23822269ce21cd22f231e1279018b569dcd48c',
+            cuOutIndex: 0,
+            cuAddress:
+              'DdzFFzCqrhtA8C86FGbYkcnHuu8uNmjZ4M6pDKKYXAwZRYr1Q8mXHmUFhgjcTCkuSDnx8xA7tu75727wAc6Ki5nM2PDFK3JXfdYfbvHC',
+            cuCoins: {getCoin: '6000'},
+          },
+          {
+            cuId: '73131c773879e7e634022f8e0175399b7e7814c42684377cf6f8c7a1adb23112',
+            cuOutIndex: 1,
+            cuAddress:
+              'DdzFFzCqrhtA8C86FGbYkcnHuu8uNmjZ4M6pDKKYXAwZRYr1Q8mXHmUFhgjcTCkuSDnx8xA7tu75727wAc6Ki5nM2PDFK3JXfdYfbvHC',
+            cuCoins: {getCoin: '125'},
+          },
+          {
+            cuId: '1ce7a1e2606271a7f085262fb7c509c98d60912a943c9be3871ac3ace48ae6d6',
+            cuOutIndex: 1,
+            cuAddress:
+              'DdzFFzCqrhtA8C86FGbYkcnHuu8uNmjZ4M6pDKKYXAwZRYr1Q8mXHmUFhgjcTCkuSDnx8xA7tu75727wAc6Ki5nM2PDFK3JXfdYfbvHC',
+            cuCoins: {getCoin: '5000'},
+          },
+        ],
+      },
     }
 
     // eslint-disable-next-line guard-for-in
     for (const request in requestsAndResponses) {
       fetchMock.post({
-        name: `https://iohk-mainnet.yoroiwallet.com/api/txs/utxoForAddresses${request}`,
+        name: `${ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL}/api/bulk/addresses/utxo${request}`,
         matcher: (url, opts) => {
           return (
-            url === 'https://iohk-mainnet.yoroiwallet.com/api/txs/utxoForAddresses' &&
+            url === `${ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL}/api/bulk/addresses/utxo` &&
             opts &&
             opts.body === request
           )

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1116,6 +1116,11 @@ bignumber.js@^7.2.1:
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-7.2.1.tgz#80c048759d826800807c4bfd521e50edbba57a5f"
   integrity sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==
 
+bignumber.js@^8.0.1:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-8.0.2.tgz#d8c4e1874359573b1ef03011a2d861214aeef137"
+  integrity sha512-EiuvFrnbv0jFixEQ9f58jo7X0qI2lNGIr/MxntmVzQc5JUweDSh8y8hbTCAomFtqwUPIOWcLXP0VEOSZTG7FFw==
+
 binary-extensions@^1.0.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
@@ -1153,6 +1158,17 @@ borc@^2.0.4:
     commander "^2.15.0"
     ieee754 "^1.1.8"
     json-text-sequence "^0.1"
+
+borc@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/borc/-/borc-2.1.0.tgz#2def2fc69868633b965a9750e7f210d778190303"
+  integrity sha512-hKTxeYt3AIzIG45epJHv8xJYSF0ktp7nZgFsqi5cPzoL3T8qKMPeUlqydORy6j3NWZvRDANx30PjpTmGho69Gw==
+  dependencies:
+    bignumber.js "^8.0.1"
+    commander "^2.15.0"
+    ieee754 "^1.1.8"
+    iso-url "~0.4.4"
+    json-text-sequence "~0.1.0"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -3050,6 +3066,11 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
+iso-url@~0.4.4:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/iso-url/-/iso-url-0.4.6.tgz#45005c4af4984cad4f8753da411b41b74cf0a8a6"
+  integrity sha512-YQO7+aIe6l1aSJUKOx+Vrv08DlhZeLFIVfehG2L29KLSEb9RszqPXilxJRVpp57px36BddKR5ZsebacO5qG0tg==
+
 isobject@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
@@ -3161,7 +3182,7 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
-json-text-sequence@^0.1:
+json-text-sequence@^0.1, json-text-sequence@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/json-text-sequence/-/json-text-sequence-0.1.1.tgz#a72f217dc4afc4629fff5feb304dc1bd51a2f3d2"
   integrity sha1-py8hfcSvxGKf/1/rME3BvVGi89I=


### PR DESCRIPTION
since the new backend is ready, we can revert to our own utxo endpoint, which won't be lagging anymore.

I fixed circleci dependencies caching along the way, and updated borc package, as a "hack" to bump the circleci cache. If I understand right, circleci was caching old node_modules, because it was caching based on package.json instead of yarn.lock and it also attempted to fallback to old cache if no cache entry was present, which also caused old node modules to be present.