### PR TITLE
Mobile Footer donations fix

### DIFF
--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -3273,6 +3273,10 @@ button[data-balloon] {
     max-width: 100%;
   }
 
+  .donations-item:last-child {
+    margin-right: 0;
+  }
+
   /* CARD */
 
   .card {


### PR DESCRIPTION
The `donations` list was wrapping on smaller devices, removing the `right margin` from the last `donations-item` will give them a bit more space and it's not needed.