### PR TITLE
refactor deriveXpub to eliminate repetition from crypto providers

### DIFF
--- a/app/frontend/wallet/cardano-wallet.js
+++ b/app/frontend/wallet/cardano-wallet.js
@@ -328,11 +328,11 @@ const CardanoWallet = async (options) => {
   }
 
   function verifyAddress(addr) {
-    if (!cryptoProvider.trezorVerifyAddress) {
+    if (!cryptoProvider.displayAddressForPath) {
       throw Error('unsupported operation: verifyAddress')
     }
-
-    return cryptoProvider.trezorVerifyAddress(addr, getAddressToAbsPathMapper())
+    const absDerivationPath = getAddressToAbsPathMapper()(addr)
+    return cryptoProvider.displayAddressForPath(absDerivationPath)
   }
 
   async function getNewUtxosFromTxAux(txAux) {

--- a/app/frontend/wallet/helpers/CachedDeriveXpubFactory.js
+++ b/app/frontend/wallet/helpers/CachedDeriveXpubFactory.js
@@ -1,0 +1,41 @@
+const indexIsHardened = require('./indexIsHardened')
+const {derivePublic: deriveChildXpub} = require('cardano-crypto.js')
+
+function CachedDeriveXpubFactory(derivationScheme, deriveXpubHardenedFn) {
+  const derivedXpubs = {}
+
+  async function deriveXpub(absDerivationPath) {
+    const memoKey = JSON.stringify(absDerivationPath)
+
+    if (!derivedXpubs[memoKey]) {
+      const deriveHardened =
+        absDerivationPath.length === 0 || indexIsHardened(absDerivationPath.slice(-1)[0])
+
+      /*
+      * TODO - reset cache if the promise fails, for now it does not matter
+      * since a failure (e.g. rejection by user) there leads to
+      * the creation of a fresh wallet and crypto provider instance
+      */
+      derivedXpubs[memoKey] = deriveHardened
+        ? deriveXpubHardenedFn(absDerivationPath)
+        : deriveXpubNonhardenedFn(absDerivationPath)
+    }
+
+    /*
+    * the derivedXpubs map stores promises instead of direct results
+    * to deal with concurrent requests to derive the same xpub
+    */
+    return await derivedXpubs[memoKey]
+  }
+
+  async function deriveXpubNonhardenedFn(derivationPath) {
+    const lastIndex = derivationPath.slice(-1)[0]
+    const parentXpub = await deriveXpub(derivationPath.slice(0, -1))
+
+    return deriveChildXpub(parentXpub, lastIndex, derivationScheme.number)
+  }
+
+  return deriveXpub
+}
+
+module.exports = CachedDeriveXpubFactory


### PR DESCRIPTION
The purpose of this refactor is to extract the deriveXpub caching logic to a single place and to make clear the (potential) asynchronicity of the operation. I changed the name of the trezorVerifyAddress function as well, to be more abstract, since we may support more hw wallets in the future.