### PR TITLE
Fix paper wallet mnemonic validation

### DIFF
--- a/app/frontend/helpers/validators.js
+++ b/app/frontend/helpers/validators.js
@@ -1,6 +1,6 @@
 const {isValidAddress} = require('cardano-crypto.js')
 
-const {validateMnemonic, validatePaperWalletMnemonic} = require('../wallet/mnemonic')
+const {validateMnemonic} = require('../wallet/mnemonic')
 
 const parseCoins = (str) => Math.trunc(parseFloat(str) * 1000000)
 
@@ -44,10 +44,10 @@ const feeValidator = (sendAmount, transactionFee, balance) => {
   return validationError
 }
 
-const mnemonicValidator = async (mnemonic) => {
+const mnemonicValidator = (mnemonic) => {
   let validationError = null
 
-  if (!validateMnemonic(mnemonic) && !(await validatePaperWalletMnemonic(mnemonic))) {
+  if (!validateMnemonic(mnemonic)) {
     validationError = {
       code: 'InvalidMnemonic',
     }

--- a/app/frontend/wallet/mnemonic.js
+++ b/app/frontend/wallet/mnemonic.js
@@ -13,7 +13,7 @@ function generateMnemonic(wordCount) {
 function validateMnemonic(mnemonic) {
   try {
     return (
-      !!mnemonic && (bip39.validateMnemonic(mnemonic) || isMnemonicInPaperWalletFormat(mnemonic))
+      !!mnemonic && (bip39.validateMnemonic(mnemonic) || validatePaperWalletMnemonic(mnemonic))
     )
   } catch (e) {
     return false


### PR DESCRIPTION
Fix a bug that caused any mnemonic with 27 words to be considered valid.
Currently, every word of the mnemonic needs to be in the bip39
dictionary, but the paper wallet mnemonic is not decoded. Mnemonic
validator was simplified.