### PR TITLE
Disable u2f transport for ledger due to its sunsetting

### DIFF
--- a/app/frontend/actions.js
+++ b/app/frontend/actions.js
@@ -80,6 +80,7 @@ module.exports = ({setState, getState}) => {
       let code
       const params = {}
       switch (e.name) {
+        case 'TransportOpenUserCancelled':
         case 'TransportError':
           params.message = e.message
           code = 'WalletInitializationError'

--- a/app/frontend/wallet/cardano-ledger-crypto-provider.js
+++ b/app/frontend/wallet/cardano-ledger-crypto-provider.js
@@ -1,24 +1,23 @@
-const LedgerTransportU2F = require('@ledgerhq/hw-transport-u2f').default
 const LedgerTransportWebusb = require('@ledgerhq/hw-transport-webusb').default
 const Ledger = require('@cardano-foundation/ledgerjs-hw-app-cardano').default
 const cbor = require('borc')
 const CachedDeriveXpubFactory = require('./helpers/CachedDeriveXpubFactory')
-const debugLog = require('../helpers/debugLog')
 const {TxWitness, SignedTransactionStructured} = require('./transaction')
 const derivationSchemes = require('./derivation-schemes')
+const NamedError = require('../helpers/NamedError')
+
+const checkWebusbSupportOrFail = () => {
+  if (!navigator.usb) {
+    throw NamedError(
+      'TransportError',
+      'WebUSB support is needed for Ledger. ' + 'Please use Chrome or Opera.'
+    )
+  }
+}
 
 const CardanoLedgerCryptoProvider = async (ADALITE_CONFIG, walletState) => {
-  let transport
-  try {
-    transport = await LedgerTransportU2F.create()
-  } catch (u2fError) {
-    try {
-      transport = await LedgerTransportWebusb.create()
-    } catch (webUsbError) {
-      debugLog(webUsbError)
-      throw u2fError
-    }
-  }
+  checkWebusbSupportOrFail()
+  const transport = await LedgerTransportWebusb.create()
   transport.setExchangeTimeout(ADALITE_CONFIG.ADALITE_LOGOUT_AFTER * 1000)
   const ledger = new Ledger(transport)
   const state = Object.assign(walletState, {

--- a/app/package.json
+++ b/app/package.json
@@ -24,9 +24,8 @@
   },
   "dependencies": {
     "@cardano-foundation/ledgerjs-hw-app-cardano": "^1.0.6",
-    "@ledgerhq/hw-transport": "^4.48.0",
-    "@ledgerhq/hw-transport-u2f": "^4.48.0",
-    "@ledgerhq/hw-transport-webusb": "^4.48.0",
+    "@ledgerhq/hw-transport": "^4.60.2",
+    "@ledgerhq/hw-transport-webusb": "^4.60.2",
     "babel-regenerator-runtime": "^6.5.0",
     "bip39-light": "^1.0.7",
     "borc": "^2.1.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -19,44 +19,43 @@
     base-x "^3.0.5"
     node-int64 "^0.4.0"
 
-"@ledgerhq/devices@^4.48.0":
-  version "4.48.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-4.48.0.tgz#b62cce08dd49a8bd4cbf0eda0e09bf8610e42b56"
-  integrity sha512-Rs0zhkjzJTps1hoHlwGLhPM8Poo8EzE55QGLWk4Q6oXoO/Nk6MRUrFaz2UuCBVQU5RaI2JPhDbwO9bPd9cVH1Q==
+"@ledgerhq/devices@^4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-4.60.2.tgz#dbb2232b12e104bc53e9fdd278b29a5323aa931e"
+  integrity sha512-taHh6DpnqmI0u9TqK5AtHMoIcLCTuEKT4sk/77f7wdhoBBjgbX6qX807h2qxO6vS/AM6td+HXaOC//eZLkhkSQ==
   dependencies:
-    "@ledgerhq/errors" "^4.48.0"
+    "@ledgerhq/errors" "^4.60.0"
+    "@ledgerhq/logs" "^4.60.2"
+    rxjs "^6.5.2"
 
-"@ledgerhq/errors@^4.48.0":
-  version "4.48.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.48.0.tgz#3a2a65862de72641095db8ef72739d105524a68f"
-  integrity sha512-MM5Tvo+KBr+dQyc6F2d93eyepZdHCmrR9KjwuB2W8pjPBG9jYmtPM/+I72k9o22YXQ9FIyd1WJJaARJoOzWXOA==
+"@ledgerhq/errors@^4.60.0":
+  version "4.60.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.60.0.tgz#3c46161041823d0f70ff920a4696fd662609e40e"
+  integrity sha512-jGbDAuNw1KNB23osgK9RDa6jXNoz3QaSeaiJZjwYpCWSTH6v0vW5y5LPe9lomg5BcW2r65kNe1feLfZ4wJuu5A==
 
-"@ledgerhq/hw-transport-u2f@^4.48.0":
-  version "4.48.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-4.48.0.tgz#0419f7d54c989d6119450d9e505aa54a5d701c1f"
-  integrity sha512-qqKlLWDDibwKGWIcL3c9DLr9DdA+71AS5GwWGIJaKaOyGYeMK6uuJrqPphXO2xvHkPNG1B56vpAFy3ojp1mtMA==
+"@ledgerhq/hw-transport-webusb@^4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-webusb/-/hw-transport-webusb-4.60.2.tgz#13d32987a62bec913c1ed250d7b66a6ebaaf2b1a"
+  integrity sha512-LtidBtbgmZtI0Hfh4+gxong2Lj93PHDl3k35rTO6oSW+5xiuFoDo6/9LX70ty755fcrNmLll17wLu91G97Qq3g==
   dependencies:
-    "@ledgerhq/errors" "^4.48.0"
-    "@ledgerhq/hw-transport" "^4.48.0"
-    u2f-api "0.2.7"
+    "@ledgerhq/devices" "^4.60.2"
+    "@ledgerhq/errors" "^4.60.0"
+    "@ledgerhq/hw-transport" "^4.60.2"
+    "@ledgerhq/logs" "^4.60.2"
 
-"@ledgerhq/hw-transport-webusb@^4.48.0":
-  version "4.48.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-webusb/-/hw-transport-webusb-4.48.0.tgz#1b52ea983a96241a056306267533c3596a2498de"
-  integrity sha512-D39yUyLLMamymLVF0OW6oNDORvgjjGwMBCbewoodSn5+89aZOLBglXfV+YBE4LDhKb7ziwk5112ut7Bk61j62Q==
+"@ledgerhq/hw-transport@^4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.60.2.tgz#926b6e8d2852306eb189bf9451d0996bcb8cabab"
+  integrity sha512-JSMtKeMtqyDlggXgBjyFM+Qj/eosE29Be+WZzXoO4ltjmF/z6D3XkTVSf6wJgeRoxE6+W5BmCwaFJWejlgqCxg==
   dependencies:
-    "@ledgerhq/devices" "^4.48.0"
-    "@ledgerhq/errors" "^4.48.0"
-    "@ledgerhq/hw-transport" "^4.48.0"
-
-"@ledgerhq/hw-transport@^4.48.0":
-  version "4.48.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.48.0.tgz#8fa09e46d9d9aab35db5679e0970e7fed2ee73bf"
-  integrity sha512-dZH/3dTXlhe3IFl+MRFePcC0TnSeQcaBuiq5t3yDA68qw7WZCbON9GKSO5Rex4yNx5v6BCHyzz1myBFJ7895iw==
-  dependencies:
-    "@ledgerhq/devices" "^4.48.0"
-    "@ledgerhq/errors" "^4.48.0"
+    "@ledgerhq/devices" "^4.60.2"
+    "@ledgerhq/errors" "^4.60.0"
     events "^3.0.0"
+
+"@ledgerhq/logs@^4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-4.60.2.tgz#f59207c43a60b789be07dd31bbd01cdda5b62ffe"
+  integrity sha512-+gMbjDIjQghwoFH/IF3j86knsHuUFO3kdYxdh9iIJAFyz3OPyHcQIjQDGL0AmnG6LU7CIMYdHcJ5NEiQyunUfg==
 
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.0.2", "@sinonjs/commons@^1.4.0":
   version "1.4.0"
@@ -2809,6 +2808,13 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
+rxjs@^6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.2.tgz#2e35ce815cd46d84d02a209fb4e5921e051dbec7"
+  integrity sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==
+  dependencies:
+    tslib "^1.9.0"
+
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -3195,11 +3201,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-
-u2f-api@0.2.7:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/u2f-api/-/u2f-api-0.2.7.tgz#17bf196b242f6bf72353d9858e6a7566cc192720"
-  integrity sha512-fqLNg8vpvLOD5J/z4B6wpPg4Lvowz1nJ9xdHcCzdUPKcFE/qNCceV2gNZxSJd5vhAZemHr/K/hbzVA0zxB5mkg==
 
 uglify-es@^3.3.4:
   version "3.3.9"


### PR DESCRIPTION
U2F support is being discontinued by Ledger due to the problems with Chrome and Windows 10 that recently appeared: https://www.ledger.com/2019/05/17/windows-10-update-sunsetting-u2f-tunnel-transport-for-ledger-devices/ therefore only webusb will be kept as recommended