### PR TITLE
Temporarily add AdaScan links

### DIFF
--- a/app/frontend/components/pages/receiveAda/addressItem.js
+++ b/app/frontend/components/pages/receiveAda/addressItem.js
@@ -19,21 +19,39 @@ const AddressItem = connect(
     ),
     h(
       'div',
-      {class: 'address-links'},
+      {class: 'address-links blockexplorer-link'},
       h(CopyOnClick, {
         value: address,
         elementClass: 'address-link',
         text: 'Copy Address',
       }),
       h(
-        'a',
-        {
-          class: 'address-link',
-          href: `https://seiza.com/blockchain/address/${address}`,
-          target: '_blank',
-          rel: 'noopener',
-        },
-        'View on Seiza'
+        'div',
+        {},
+        h('span', {}, 'View on '),
+        h(
+          'a',
+          {
+            class: 'address-link',
+            href: `https://seiza.com/blockchain/address/${address}`,
+            style: 'margin-right:0',
+            target: '_blank',
+            rel: 'noopener',
+          },
+          'Seiza'
+        ),
+        h('span', {}, ' | '),
+        h(
+          'a',
+          {
+            class: 'address-link',
+            href: `https://adascan.net/address/${address}`,
+            style: 'margin-right:24px',
+            target: '_blank',
+            rel: 'noopener',
+          },
+          'AdaScan'
+        )
       ),
       h(
         'a',

--- a/app/frontend/components/pages/txHistory/transactionHistory.js
+++ b/app/frontend/components/pages/txHistory/transactionHistory.js
@@ -27,14 +27,30 @@ const FormattedFee = ({fee}) => {
 
 const TransactionAddress = ({address}) =>
   h(
-    'a',
-    {
-      class: 'transaction-address',
-      href: `https://seiza.com/blockchain/transaction/${address}`,
-      target: '_blank',
-      rel: 'noopener',
-    },
-    'View on Seiza'
+    'div',
+    {class: 'blockexplorer-link'},
+    h('span', {}, 'View on '),
+    h(
+      'a',
+      {
+        class: 'transaction-address',
+        href: `https://seiza.com/blockchain/transaction/${address}`,
+        target: '_blank',
+        rel: 'noopener',
+      },
+      'Seiza'
+    ),
+    h('span', {}, ' | '),
+    h(
+      'a',
+      {
+        class: 'transaction-address',
+        href: `https://adascan.net/transaction/${address}`,
+        target: '_blank',
+        rel: 'noopener',
+      },
+      'AdaScan'
+    )
   )
 
 const TransactionHistory = ({transactionHistory}) =>

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -2861,6 +2861,10 @@ button[data-balloon] {
 
   /* CARD */
 
+  .blockexplorer-link {
+    white-space: nowrap;
+  }
+
   .card {
     box-shadow: none;
     padding: 40px 16px;


### PR DESCRIPTION
Temporarily add AdaScan links for transaction history and addresses on
top of Seiza links.