### PR TITLE
Add contact form modal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ ADALITE_GAP_LIMIT=20
 ADALITE_STATS_PWD=admin
 ADALITE_DEMO_WALLET_MNEMONIC='civil void tool perfect avocado sweet immense fluid arrow aerobic boil flash'
 ADALITE_LOGOUT_AFTER=900
+ADALITE_SUPPORT_EMAIL='support@test.test'
 
 # mock server config
 ADALITE_ENABLE_SERVER_MOCKING_MODE=false

--- a/app/frontend/actions.js
+++ b/app/frontend/actions.js
@@ -517,6 +517,18 @@ module.exports = ({setState, getState}) => {
     })
   }
 
+  const showContactFormModal = (state) => {
+    setState({
+      showContactFormModal: true,
+    })
+  }
+
+  const closeContactFormModal = (state) => {
+    setState({
+      showContactFormModal: false,
+    })
+  }
+
   const exportJsonWallet = async (state, password, walletName) => {
     const walletExport = JSON.stringify(
       await KeypassJson.exportWalletSecretDef(wallet.getWalletSecretDef(), password, walletName)
@@ -583,5 +595,7 @@ module.exports = ({setState, getState}) => {
     getRawTransaction,
     closeTransactionErrorModal,
     closeWalletLoadingErrorModal,
+    showContactFormModal,
+    closeContactFormModal,
   }
 }

--- a/app/frontend/components/app.js
+++ b/app/frontend/components/app.js
@@ -3,6 +3,7 @@ const connect = require('unistore/preact').connect
 
 const TopLevelRouter = require('./router').TopLevelRouter
 const Welcome = require('./common/welcome')
+const ContactForm = require('./common/contactForm')
 const Footer = require('./common/footer')
 const LoadingOverlay = require('./common/loadingOverlay')
 const NavbarAuth = require('./common/navbar/navbarAuth')
@@ -15,7 +16,10 @@ const Navbar = connect((state) => ({walletIsLoaded: state.walletIsLoaded}))(
   ({walletIsLoaded}) => (walletIsLoaded ? h(NavbarAuth) : h(NavbarUnauth))
 )
 
-const App = connect((state) => ({displayWelcome: state.displayWelcome}))(({displayWelcome}) =>
+const App = connect((state) => ({
+  displayWelcome: state.displayWelcome,
+  showContactFormModal: state.showContactFormModal,
+}))(({displayWelcome, showContactFormModal}) =>
   h(
     'div',
     {class: 'wrap'},
@@ -25,7 +29,8 @@ const App = connect((state) => ({displayWelcome: state.displayWelcome}))(({displ
     h(Footer),
     h(AddressDetailDialog),
     ADALITE_LOGOUT_AFTER > 0 && h(AutoLogout),
-    displayWelcome && h(Welcome)
+    displayWelcome && h(Welcome),
+    showContactFormModal && h(ContactForm)
   )
 )
 

--- a/app/frontend/components/common/contactForm.js
+++ b/app/frontend/components/common/contactForm.js
@@ -1,0 +1,133 @@
+const {h, Component} = require('preact')
+const connect = require('unistore/preact').connect
+const actions = require('../../actions')
+const Modal = require('./modal')
+const {ADALITE_CONFIG} = require('../../config')
+
+class ContactForm extends Component {
+  constructor(props) {
+    super(props)
+    this.closeContactFormModal = this.closeContactFormModal.bind(this)
+  }
+
+  closeContactFormModal() {
+    this.props.closeContactFormModal()
+  }
+
+  render() {
+    return h(
+      Modal,
+      {
+        closeHandler: this.closeContactFormModal,
+      },
+      h(
+        'main',
+        {class: 'contact-modal'},
+        h('h2', {class: 'export-title'}, 'Contact Us'),
+        h(
+          'p',
+          {class: 'instructions'},
+          h('span', {}, 'If you are experiencing problems, please try the following '),
+          h(
+            'a',
+            {
+              href: 'https://github.com/vacuumlabs/adalite/wiki/Troubleshooting',
+              target: '_blank',
+              rel: 'noopener',
+            },
+            'troubleshooting suggestions'
+          ),
+          h('span', {}, ' before contacting us. You can also reach us out via '),
+          h(
+            'a',
+            {
+              href: `mailto:${ADALITE_CONFIG.ADALITE_SUPPORT_EMAIL}`,
+            },
+            ADALITE_CONFIG.ADALITE_SUPPORT_EMAIL
+          ),
+          h('span', {}, '.')
+        ),
+        h(
+          'form',
+          {
+            class: 'contact-form',
+            id: 'contactForm',
+            method: 'POST',
+            target: '_blank',
+            action: `//formspree.io/${ADALITE_CONFIG.ADALITE_SUPPORT_EMAIL}`,
+          },
+          h(
+            'div',
+            {
+              class: 'form-row',
+            },
+            h('input', {
+              type: 'text',
+              autocomplete: 'off',
+              placeholder: 'Your name',
+              name: 'name',
+              class: 'input fullwidth',
+              required: true,
+            }),
+            h('input', {
+              type: 'email',
+              autocomplete: 'off',
+              placeholder: 'Your email',
+              name: '_replyto',
+              class: 'input fullwidth',
+              required: true,
+            })
+          ),
+          h('textarea', {
+            placeholder: 'Your message',
+            autocomplete: 'off',
+            name: 'message',
+            class: 'input fullwidth textarea',
+            required: true,
+          }),
+          h('input', {
+            type: 'text',
+            name: '_gotcha',
+            style: 'display:none',
+          }),
+          h(
+            'div',
+            {
+              class: 'contact-form-bottom',
+            },
+            h(
+              'button',
+              {
+                onClick: this.closeContactFormModal,
+                class: 'button secondary',
+                type: 'button',
+                onKeyDown: (e) => {
+                  e.key === 'Enter' && e.target.click()
+                },
+              },
+              'Back to AdaLite'
+            ),
+            h('input', {
+              class: 'button primary wide modal-button submit',
+              value: 'Submit',
+              type: 'submit',
+            })
+          )
+        ),
+        h('button', {
+          'onClick': this.closeContactFormModal,
+          'class': 'modal-close',
+          'aria-label': 'Close dialog',
+          'onKeyDown': (e) => {
+            e.key === 'Enter' && e.target.click()
+          },
+        })
+      )
+    )
+  }
+}
+
+module.exports = connect(
+  {},
+  actions
+)(ContactForm)

--- a/app/frontend/components/common/footer.js
+++ b/app/frontend/components/common/footer.js
@@ -8,7 +8,6 @@ const {
   ETH_BLOCKCHAIN_EXPLORER,
   ETH_DONATION_ADDRESS,
   ADA_DONATION_ADDRESS,
-  ADALITE_SUPPORT_EMAIL,
 } = require('../../wallet/constants')
 
 const showRatesOn = ['/txHistory', '/send']
@@ -18,7 +17,7 @@ const Footer = connect(
     showConversionRates: showRatesOn.indexOf(state.router.pathname) !== -1 && state.walletIsLoaded,
   }),
   actions
-)(({openAddressDetail, showConversionRates}) =>
+)(({openAddressDetail, showConversionRates, showContactFormModal}) =>
   h(
     'footer',
     {class: 'footer'},
@@ -35,12 +34,10 @@ const Footer = connect(
           h(
             'a',
             {
-              href: `mailto:${ADALITE_SUPPORT_EMAIL}`,
-              target: '_blank',
-              rel: 'noopener',
               class: 'social-link email',
+              onClick: showContactFormModal,
             },
-            ADALITE_SUPPORT_EMAIL
+            'Contact us'
           ),
           h(
             'a',

--- a/app/frontend/components/common/modal.js
+++ b/app/frontend/components/common/modal.js
@@ -29,16 +29,26 @@ class Modal extends Component {
             e.key === 'Escape' && closeHandler()
           },
         },
-        closeHandler &&
-          h('button', {'class': 'modal-close', 'onClick': closeHandler, 'aria-label': 'Close dialog'}),
-        title &&
-          h(
-            'div',
-            {class: 'modal-head'},
-            title && h('h2', {class: 'modal-title'}, title),
-            showWarning && h(Tag, {type: 'big warning', text: 'Proceed with caution'})
-          ),
-        children
+        h(
+          'div',
+          {
+            class: 'modal-content',
+          },
+          closeHandler &&
+            h('button', {
+              'class': 'modal-close',
+              'onClick': closeHandler,
+              'aria-label': 'Close dialog',
+            }),
+          title &&
+            h(
+              'div',
+              {class: 'modal-head'},
+              title && h('h2', {class: 'modal-title'}, title),
+              showWarning && h(Tag, {type: 'big warning', text: 'Proceed with caution'})
+            ),
+          children
+        )
       )
     )
   }

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -118,6 +118,7 @@ p {
   border: 1px solid var(--color-border);
   padding: 12px 16px;
   font-size: 14px;
+  font-family: JTMarnie, Arial, Helvetica, sans-serif;
   line-height: 32px;
   color: var(--color-text);
   background-color: white;
@@ -193,6 +194,10 @@ p {
   right: 16px;
 }
 
+.textarea {
+  font-family: JTMarnie, Arial, Helvetica, sans-serif;
+}
+
 /* BUTTONS */
 
 .button {
@@ -221,6 +226,15 @@ p {
 .button.primary:disabled {
   background-color: var(--color-brand-light);
   color: white;
+}
+
+.button.secondary {
+  padding: 10px 24px;
+  color: var(--color-grey);
+  border: 2px solid var(--color-border);
+  font-weight: normal;
+  background-color: white;
+  font-size: 14px;
 }
 
 .button.outline {
@@ -716,13 +730,16 @@ button[data-balloon] {
   z-index: 21;
   background-color: white;
   margin: auto;
-  padding: 56px;
   width: 100%;
   max-width: 952px;
   max-height: 95%;
   box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0);
   border-radius: 2px;
   overflow-y: auto;
+}
+
+.modal-content {
+  padding: 56px;
 }
 
 .modal-close {
@@ -2004,6 +2021,33 @@ button[data-balloon] {
   background-image: url('../assets/checkbox_checked.svg');
 }
 
+/* CONTACT MODAL */
+
+.contact-form .input {
+  margin-bottom: 24px;
+}
+
+.contact-form .textarea {
+  min-width: 100%;
+  max-width: 100%;
+  min-height: 170px;
+}
+
+.contact-form-bottom {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.contact-form .button + .button {
+  margin-left: 25px;
+}
+
+.contact-modal .instructions {
+  margin-top: 20px;
+  margin-bottom: 20px;
+}
+
 /* TRANSACTIONS */
 
 .transactions {
@@ -2556,6 +2600,17 @@ button[data-balloon] {
   border: none;
 }
 
+/* FORM GLOBAL */
+
+.form-row {
+  display: flex;
+  justify-content: space-between;
+}
+
+.form-row .input {
+  width: 49%;
+}
+
 .dashboard-content {
   width: 100%;
 }
@@ -2762,6 +2817,9 @@ button[data-balloon] {
   .modal-body {
     width: calc(100% - 32px);
     max-height: calc(100% - 32px);
+  }
+
+  .modal-content {
     padding: 40px 16px;
   }
 
@@ -2804,6 +2862,16 @@ button[data-balloon] {
     right: 24px;
   }
 
+  /* FORM GLOBAL */
+
+  .form-row {
+    display: block;
+  }
+
+  .form-row .input {
+    width: 100%;
+  }
+
   /* WELCOME MODAL */
 
   .welcome-subtitle {
@@ -2838,6 +2906,22 @@ button[data-balloon] {
     margin-left: 0;
     margin-top: 24px;
     width: 100%;
+  }
+
+  /* CONTACT MODAL */
+
+  .contact-form-bottom {
+    align-items: stretch;
+  }
+
+  .contact-form .button {
+    flex: 1;
+    white-space: nowrap;
+    padding: 10px 15px;
+  }
+
+  .contact-form .button + .button {
+    margin-left: 15px;
   }
 
   /* FOOTER */

--- a/server/helpers/loadConfig.js
+++ b/server/helpers/loadConfig.js
@@ -24,6 +24,7 @@ const checkMap = check.map(process.env, {
   ADALITE_ENABLE_SERVER_MOCKING_MODE: isBoolString,
   ADALITE_MOCK_TX_SUBMISSION_SUCCESS: isBoolString,
   ADALITE_MOCK_TX_SUMMARY_SUCCESS: isBoolString,
+  ADALITE_SUPPORT_EMAIL: check.nonEmptyString,
 })
 
 const {
@@ -41,6 +42,7 @@ const {
   ADALITE_MOCK_TX_SUBMISSION_SUCCESS,
   ADALITE_MOCK_TX_SUMMARY_SUCCESS,
   ADALITE_TREZOR_CONNECT_URL,
+  ADALITE_SUPPORT_EMAIL,
 } = process.env
 
 if (!check.all(checkMap)) {
@@ -60,9 +62,9 @@ if (!check.all(checkMap)) {
 const frontendConfig = {
   ADALITE_SERVER_URL,
   /*
-  * if mocking is enabled, blockchain url is replaced with server url so the server is
-  * able to intercept the requests from the frontend and mock the responses
-  */
+   * if mocking is enabled, blockchain url is replaced with server url so the server is
+   * able to intercept the requests from the frontend and mock the responses
+   */
   ADALITE_BLOCKCHAIN_EXPLORER_URL:
     ADALITE_ENABLE_SERVER_MOCKING_MODE === 'true'
       ? ADALITE_SERVER_URL
@@ -74,6 +76,7 @@ const frontendConfig = {
   ADALITE_APP_VERSION: appVersion,
   ADALITE_LOGOUT_AFTER,
   ADALITE_TREZOR_CONNECT_URL,
+  ADALITE_SUPPORT_EMAIL,
 }
 
 const backendConfig = {


### PR DESCRIPTION
Add a contact form modal which can be opened by a link in the footer.
The modal contains some hints that can make self-diagnosis easier.
The user can also send a message to the support email via Formspree.
The support email address is stored in .env. Closes #473 