### PR TITLE
Scroll to top on route change

### DIFF
--- a/app/frontend/components/common/navbar/navbarAuth.js
+++ b/app/frontend/components/common/navbar/navbarAuth.js
@@ -1,78 +1,109 @@
-const {h} = require('preact')
+const {h, Component} = require('preact')
 const connect = require('unistore/preact').connect
 const actions = require('../../../actions')
 const APP_VERSION = require('../../../config').ADALITE_CONFIG.ADALITE_APP_VERSION
 
-const NavbarAuth = connect(
-  (state) => ({
-    isDemoWallet: state.isDemoWallet,
-  }),
-  actions
-)(({isDemoWallet, logout, openWelcome}) => {
-  return h(
-    'nav',
-    {class: `navbar authed ${isDemoWallet ? 'demo' : ''}`},
-    h(
-      'div',
-      {class: 'navbar-wrapper'},
-      h(
-        'h1',
-        {class: 'navbar-heading'},
-        h('span', {class: 'navbar-title'}, 'AdaLite - Cardano Wallet'),
-        h(
-          'a',
-          {
-            href: '#',
-            onClick: (e) => {
-              e.preventDefault()
-              window.history.pushState({}, 'txHistory', 'txHistory')
-            },
-          },
-          h('img', {
-            src: 'assets/adalite-logo.svg',
-            alt: 'AdaLite - Cardano Wallet',
-            class: 'navbar-logo',
-          })
-        )
-      ),
-      isDemoWallet && h('div', {class: 'navbar-demo'}, 'Accessing demo wallet'),
-      h('div', {class: 'navbar-version'}, `Ver. ${APP_VERSION}`),
+class NavbarAuth extends Component {
+  constructor(props) {
+    super(props)
+    this.scrollToTop = this.scrollToTop.bind(this)
+  }
+
+  scrollToTop() {
+    if (window.innerWidth < 767) {
+      window.scrollTo(0, this.scrollDestination.offsetHeight)
+    } else {
+      window.scrollTo(0, 0)
+    }
+  }
+
+  componentDidMount() {
+    this.scrollToTop()
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.router.pathname !== prevProps.router.pathname) {
+      this.scrollToTop()
+    }
+  }
+
+  render({isDemoWallet, logout, openWelcome}) {
+    return h(
+      'nav',
+      {
+        class: `navbar authed ${isDemoWallet ? 'demo' : ''}`,
+        ref: (element) => {
+          this.scrollDestination = element
+        },
+      },
       h(
         'div',
-        {class: 'navbar-content'},
+        {class: 'navbar-wrapper'},
         h(
-          'a',
-          {
-            class: 'navbar-link',
-            href: '#',
-            onClick: (e) => {
-              e.preventDefault()
-              openWelcome()
+          'h1',
+          {class: 'navbar-heading'},
+          h('span', {class: 'navbar-title'}, 'AdaLite - Cardano Wallet'),
+          h(
+            'a',
+            {
+              href: '#',
+              onClick: (e) => {
+                e.preventDefault()
+                window.history.pushState({}, 'txHistory', 'txHistory')
+              },
             },
-          },
-          'About'
+            h('img', {
+              src: 'assets/adalite-logo.svg',
+              alt: 'AdaLite - Cardano Wallet',
+              class: 'navbar-logo',
+            })
+          )
+        ),
+        isDemoWallet && h('div', {class: 'navbar-demo'}, 'Accessing demo wallet'),
+        h('div', {class: 'navbar-version'}, `Ver. ${APP_VERSION}`),
+        h(
+          'div',
+          {class: 'navbar-content'},
+          h(
+            'a',
+            {
+              class: 'navbar-link',
+              href: '#',
+              onClick: (e) => {
+                e.preventDefault()
+                openWelcome()
+              },
+            },
+            'About'
+          ),
+          h(
+            'a',
+            {
+              class: 'navbar-link',
+              href: 'https://github.com/vacuumlabs/adalite/wiki/AdaLite-FAQ',
+              target: '_blank',
+              rel: 'noopener',
+            },
+            'Help'
+          )
         ),
         h(
-          'a',
+          'button',
           {
-            class: 'navbar-link',
-            href: 'https://github.com/vacuumlabs/adalite/wiki/AdaLite-FAQ',
-            target: '_blank',
-            rel: 'noopener',
+            class: 'button logout',
+            onClick: () => setTimeout(logout, 100),
           },
-          'Help'
+          'Logout'
         )
-      ),
-      h(
-        'button',
-        {
-          class: 'button logout',
-          onClick: () => setTimeout(logout, 100),
-        },
-        'Logout'
       )
     )
-  )
-})
+  }
+}
 
-module.exports = NavbarAuth
+module.exports = connect(
+  (state) => ({
+    isDemoWallet: state.isDemoWallet,
+    router: state.router,
+  }),
+  actions
+)(NavbarAuth)


### PR DESCRIPTION
Solves #514 

Remembering scroll position is default react behaviour. Therefore we need to reset scroll position when route changes. PR changes inspired by

https://medium.com/@nasir/reset-scroll-position-on-change-of-routes-react-a0bd23093dfe
https://codepen.io/Yuschick/post/react-reset-scroll-position-when-changing-routes
https://github.com/ReactTraining/react-router/issues/4278#issuecomment-267093084

Attached componentDidMount and componentDidUpdate to authNavbar, since every page that this navbar is on, needs special scrolling positions for mobile.