### PR TITLE
Reset form fields after closing window

### DIFF
--- a/app/frontend/components/common/contactForm.js
+++ b/app/frontend/components/common/contactForm.js
@@ -15,6 +15,7 @@ class ContactForm extends Component {
   }
 
   closeContactFormModal() {
+    this.contactForm.reset()
     this.props.closeContactFormModal()
   }
 
@@ -61,7 +62,6 @@ class ContactForm extends Component {
             action: `//formspree.io/${ADALITE_CONFIG.ADALITE_SUPPORT_EMAIL}`,
             onSubmit: () => {
               this.setState({sumbitted: true})
-              this.contactForm.reset()
             },
             ref: (element) => {
               this.contactForm = element


### PR DESCRIPTION
closes #526 . Fields are now not reset instantly after submitting the form, instead they are reset after closing the modal.