### PR TITLE
Refactor - rename Modal's closeHandler to onRequestClose

### DIFF
--- a/app/frontend/components/common/addressDetailDialog.tsx
+++ b/app/frontend/components/common/addressDetailDialog.tsx
@@ -41,7 +41,7 @@ class AddressDetailDialogClass extends Component<Props, {showCopyMessage: boolea
   ) {
     return (
       showDetail && (
-        <Modal closeHandler={closeAddressDetail}>
+        <Modal onRequestClose={closeAddressDetail}>
           <div className="detail">
             <div className="detail-content">
               <div className="detail-label">Address</div>

--- a/app/frontend/components/common/contactForm.tsx
+++ b/app/frontend/components/common/contactForm.tsx
@@ -27,7 +27,7 @@ class ContactForm extends Component<Props, {submitted: boolean}> {
 
   render() {
     return (
-      <Modal closeHandler={this.closeContactFormModal}>
+      <Modal onRequestClose={this.closeContactFormModal}>
         <main className="contact-modal">
           <h2 className="export-title">Contact Us</h2>
           <p className="instructions">

--- a/app/frontend/components/common/errorModal.tsx
+++ b/app/frontend/components/common/errorModal.tsx
@@ -5,19 +5,25 @@ import Alert from './alert'
 import HelpSection from './helpSection'
 
 interface Props {
-  closeHandler: () => void
+  onRequestClose: () => void
   title: string
   buttonTitle: string
   errorMessage: string
   showHelp?: boolean
 }
 
-const ErrorModal = ({closeHandler, title, buttonTitle, errorMessage, showHelp = false}: Props) => (
-  <Modal closeHandler={closeHandler} title={title} showWarning={false} bodyClass="">
+const ErrorModal = ({
+  onRequestClose,
+  title,
+  buttonTitle,
+  errorMessage,
+  showHelp = false,
+}: Props) => (
+  <Modal onRequestClose={onRequestClose} title={title} showWarning={false} bodyClass="">
     <Alert alertType="error">{errorMessage}</Alert>
-    {showHelp && <HelpSection closeHandler={closeHandler} />}
+    {showHelp && <HelpSection closeHandler={onRequestClose} />}
     <div className="modal-footer">
-      <button className="button primary" onClick={closeHandler}>
+      <button className="button primary" onClick={onRequestClose}>
         {buttonTitle}
       </button>
     </div>

--- a/app/frontend/components/common/modal.tsx
+++ b/app/frontend/components/common/modal.tsx
@@ -3,7 +3,7 @@ import {h, Component} from 'preact'
 import Tag from './tag'
 
 interface Props {
-  closeHandler?: () => void
+  onRequestClose?: () => void
   children?: any
   bodyClass?: string
   title?: string
@@ -19,21 +19,21 @@ class Modal extends Component<Props, {}> {
     document.body.classList.remove('no-scroll')
   }
 
-  render({children, closeHandler, bodyClass = '', title = '', showWarning = false}) {
+  render({children, onRequestClose, bodyClass = '', title = '', showWarning = false}) {
     return (
       <div className="modal">
-        <div className="modal-overlay" onClick={closeHandler} />
+        <div className="modal-overlay" onClick={onRequestClose} />
         <div
           className={`modal-body ${bodyClass}`}
           onKeyDown={(e) => {
-            e.key === 'Escape' && closeHandler()
+            e.key === 'Escape' && onRequestClose()
           }}
         >
           <div className="modal-content">
-            {closeHandler && (
+            {onRequestClose && (
               <button
                 className="button close modal-close"
-                onClick={closeHandler}
+                onClick={onRequestClose}
                 {
                 ...{ariaLabel: 'Close dialog'} /* fix ts error*/
                 }

--- a/app/frontend/components/common/unexpectedErrorModal.tsx
+++ b/app/frontend/components/common/unexpectedErrorModal.tsx
@@ -26,7 +26,7 @@ class UnexpectedErrorModal extends Component<Props, {}> {
 
   render({sendSentry}) {
     return (
-      <Modal closeHandler={() => this.closeAndResolve(false)} title="Something went wrong.">
+      <Modal onRequestClose={() => this.closeAndResolve(false)} title="Something went wrong.">
         <div className="modal-section">
           <p className="instruction">Do you want to inform Adalite about this error?</p>
           <p className="instruction">Tell us what happened!</p>

--- a/app/frontend/components/pages/login/demoWalletWarningDialog.tsx
+++ b/app/frontend/components/pages/login/demoWalletWarningDialog.tsx
@@ -11,7 +11,7 @@ class DemoWalletWarningDialogClass {
   render({closeDemoWalletWarningDialog}: Props) {
     return (
       <Modal
-        closeHandler={closeDemoWalletWarningDialog}
+        onRequestClose={closeDemoWalletWarningDialog}
         title="Accessing the demo wallet"
         showWarning
       >

--- a/app/frontend/components/pages/login/generateMnemonicDialog.tsx
+++ b/app/frontend/components/pages/login/generateMnemonicDialog.tsx
@@ -11,7 +11,7 @@ interface Props {
 class GenerateMnemonicDialogClass {
   render({confirmGenerateMnemonicDialog, newWalletMnemonic, closeGenerateMnemonicDialog}: Props) {
     return (
-      <Modal closeHandler={closeGenerateMnemonicDialog} title="Create a New Wallet" showWarning>
+      <Modal onRequestClose={closeGenerateMnemonicDialog} title="Create a New Wallet" showWarning>
         <p className="modal-paragraph">
           The new wallet is created together with a mnemonic phrase. Write the mnemonic phrase down,
           you will need it to access your wallet.{' '}

--- a/app/frontend/components/pages/login/loginPage.tsx
+++ b/app/frontend/components/pages/login/loginPage.tsx
@@ -160,7 +160,7 @@ class LoginPage extends Component<Props, {isDropdownOpen: boolean}> {
     )
     return (
       <div className="page-wrapper">
-        {showStakingBanner && <StakingBanner closeBanner={this.closeStakingBannerClick} />}
+        {showStakingBanner && <StakingBanner onRequestClose={this.closeStakingBannerClick} />}
         <div className="page-inner">
           <main className="page-main">
             {authMethod === '' ? <AuthCardInitial /> : <AuthCard />}
@@ -177,7 +177,7 @@ class LoginPage extends Component<Props, {isDropdownOpen: boolean}> {
           {logoutNotificationOpen && <LogoutNotification />}
           {showWalletLoadingErrorModal && (
             <WalletLoadingErrorModal
-              closeHandler={closeWalletLoadingErrorModal}
+              onRequestClose={closeWalletLoadingErrorModal}
               errorMessage={getTranslation(walletLoadingError.code, walletLoadingError.params)}
               showHelp={errorHasHelp(walletLoadingError.code)}
             />

--- a/app/frontend/components/pages/login/logoutNotification.tsx
+++ b/app/frontend/components/pages/login/logoutNotification.tsx
@@ -13,7 +13,7 @@ class LogoutNotification {
   render({setLogoutNotificationOpen}) {
     return (
       <Modal
-        closeHandler={() => setLogoutNotificationOpen(false)}
+        onRequestClose={() => setLogoutNotificationOpen(false)}
         title="You’ve been logged out"
         bodyClass="centered"
       >

--- a/app/frontend/components/pages/login/stakingBanner.tsx
+++ b/app/frontend/components/pages/login/stakingBanner.tsx
@@ -1,10 +1,10 @@
 import {h} from 'preact'
 
 interface Props {
-  closeBanner: () => void
+  onRequestClose: () => void
 }
 
-const StakingBanner = ({closeBanner}: Props) => (
+const StakingBanner = ({onRequestClose}: Props) => (
   <div className="banner">
     <div className="banner-text">
       AdaLite will support staking. We've just released balance check for incentivized testnet.{' '}
@@ -24,7 +24,7 @@ const StakingBanner = ({closeBanner}: Props) => (
       ...{ariaLabel: 'Close banner'} /* silence ts*/
       }
       onClick={(e) => {
-        closeBanner()
+        onRequestClose()
       }}
     />
   </div>

--- a/app/frontend/components/pages/login/walletLoadingErrorModal.tsx
+++ b/app/frontend/components/pages/login/walletLoadingErrorModal.tsx
@@ -1,14 +1,14 @@
 import ErrorModal from '../../common/errorModal'
 
 interface Props {
-  closeHandler: () => void
+  onRequestClose: () => void
   errorMessage: string
   showHelp?: boolean
 }
 
-const WalletLoadingErrorModal = ({closeHandler, errorMessage, showHelp}: Props) =>
+const WalletLoadingErrorModal = ({onRequestClose, errorMessage, showHelp}: Props) =>
   ErrorModal({
-    closeHandler,
+    onRequestClose,
     errorMessage,
     title: 'Error loading wallet',
     buttonTitle: 'OK',

--- a/app/frontend/components/pages/sendAda/confirmTransactionDialog.tsx
+++ b/app/frontend/components/pages/sendAda/confirmTransactionDialog.tsx
@@ -31,7 +31,7 @@ class ConfirmTransactionDialogClass extends Component<Props, {}> {
     total,
   }) {
     return (
-      <Modal closeHandler={cancelTransaction} title="Transaction review">
+      <Modal onRequestClose={cancelTransaction} title="Transaction review">
         <div className="review">
           <div className="review-label">Address</div>
           <div className="review-address">{sendAddress}</div>

--- a/app/frontend/components/pages/sendAda/donateThanksModal.tsx
+++ b/app/frontend/components/pages/sendAda/donateThanksModal.tsx
@@ -3,7 +3,7 @@ import {h} from 'preact'
 import Modal from '../../common/modal'
 
 const DonateThanksModal = ({closeThanksForDonationModal}) => (
-  <Modal closeHandler={closeThanksForDonationModal} title="Thank you!" bodyClass="centered">
+  <Modal onRequestClose={closeThanksForDonationModal} title="Thank you!" bodyClass="centered">
     <p className="modal-paragraph">
       Thank you for your donation which has allowed us to sustain our efforts in making a difference
       in the Cardano community. We appreciate your kindness.

--- a/app/frontend/components/pages/sendAda/rawTransactionModal.tsx
+++ b/app/frontend/components/pages/sendAda/rawTransactionModal.tsx
@@ -6,7 +6,7 @@ import Modal from '../../common/modal'
 class RawTransactionModal {
   render({rawTransaction, setRawTransactionOpen}) {
     return (
-      <Modal closeHandler={() => setRawTransactionOpen(false)} bodyClass="width-auto">
+      <Modal onRequestClose={() => setRawTransactionOpen(false)} bodyClass="width-auto">
         <div className="width-auto">
           <h4>Raw unsigned transaction</h4>
           <div className="raw-transaction one-click-select">{rawTransaction}</div>

--- a/app/frontend/components/pages/sendAda/sendAdaPage.tsx
+++ b/app/frontend/components/pages/sendAda/sendAdaPage.tsx
@@ -216,7 +216,7 @@ class SendAdaPage extends Component<Props> {
         )}
         {showTransactionErrorModal && (
           <TransactionErrorModal
-            closeHandler={closeTransactionErrorModal}
+            onRequestClose={closeTransactionErrorModal}
             errorMessage={getTranslation(
               transactionSubmissionError.code,
               transactionSubmissionError.params

--- a/app/frontend/components/pages/sendAda/transactionErrorModal.tsx
+++ b/app/frontend/components/pages/sendAda/transactionErrorModal.tsx
@@ -1,8 +1,8 @@
 import ErrorModal from '../../common/errorModal'
 
-const TransactionErrorModal = ({closeHandler, errorMessage, showHelp}) =>
+const TransactionErrorModal = ({onRequestClose, errorMessage, showHelp}) =>
   ErrorModal({
-    closeHandler,
+    onRequestClose,
     errorMessage,
     title: 'Transaction error',
     buttonTitle: 'OK',


### PR DESCRIPTION
- This better describes the intent and is in line with React Native's modal