### PR TITLE
Introduce explicit Ada vs Lovelace number distinction

### DIFF
--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -22,7 +22,7 @@ import sanitizeMnemonic from './helpers/sanitizeMnemonic'
 import {initialState} from './store'
 import {toCoins, toAda, roundWholeAdas} from './helpers/adaConverters'
 import captureBySentry from './helpers/captureBySentry'
-import {State} from './state'
+import {State, Ada, Lovelace} from './state'
 
 type ThenArg<T> = T extends Promise<infer U> ? U : never
 
@@ -429,7 +429,8 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
 
   const getPercentageDonationProperties = async () => {
     const state = getState()
-    const percentageDonation = roundWholeAdas(state.sendAmount.coins * 0.002)
+    const percentageDonation: Lovelace = roundWholeAdas((state.sendAmount.coins *
+      0.002) as Lovelace)
     const address = state.sendAddress.fieldValue
     const amount = state.sendAmount.coins
     const transactionFee = await wallet.getTxFee(address, amount, true, percentageDonation)
@@ -442,9 +443,9 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
       : {
         text: '0.1%', // exceeded balance, lower to 1% or MIN
         value: Math.max(
-          Math.round(toAda(percentageDonation / 2)),
+          Math.round(toAda((percentageDonation / 2) as Lovelace)),
           ADALITE_CONFIG.ADALITE_MIN_DONATION_VALUE
-        ),
+        ) as Ada,
       }
   }
 
@@ -460,9 +461,9 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
     setState({
       donationAmount: {fieldValue: '', coins: 0},
       sendTransactionSummary: {
-        amount: 0,
-        donation: 0,
-        fee: 0,
+        amount: 0 as Lovelace,
+        donation: 0 as Lovelace,
+        fee: 0 as Lovelace,
       },
       maxDonationAmount: Infinity,
       checkedDonationType: '',
@@ -538,7 +539,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
   }
 
   const getProperTextAndVal = async (coins) => {
-    if (coins < toCoins(500 * ADALITE_CONFIG.ADALITE_MIN_DONATION_VALUE)) {
+    if (coins < toCoins((500 * ADALITE_CONFIG.ADALITE_MIN_DONATION_VALUE) as Ada)) {
       //because 0.2%
       return {
         text: 'Min',

--- a/app/frontend/components/common/balance.tsx
+++ b/app/frontend/components/common/balance.tsx
@@ -1,9 +1,10 @@
 import {h} from 'preact'
 import printAda from '../../helpers/printAda'
 import Conversions from './conversions'
+import {Lovelace} from '../../state'
 
 interface Props {
-  balance: number
+  balance: Lovelace
   reloadWalletInfo: (state: any) => void
   conversionRates: any
 }

--- a/app/frontend/components/pages/txHistory/transactionHistory.tsx
+++ b/app/frontend/components/pages/txHistory/transactionHistory.tsx
@@ -1,9 +1,10 @@
 import {h} from 'preact'
 import printAda from '../../../helpers/printAda'
 import formatDate from '../../../helpers/formatDate'
+import {Lovelace} from '../../../state'
 
-const FormattedAmount = ({amount}) => {
-  const value = printAda(Math.abs(amount))
+const FormattedAmount = ({amount}: {amount: Lovelace}) => {
+  const value = printAda(Math.abs(amount) as Lovelace)
   const number = `${value}`.indexOf('.') === -1 ? `${value}.0` : `${value}`
   return (
     <div className={`transaction-amount ${amount > 0 ? 'credit' : 'debit'}`}>
@@ -12,7 +13,7 @@ const FormattedAmount = ({amount}) => {
   )
 }
 
-const FormattedFee = ({fee}) => {
+const FormattedFee = ({fee}: {fee: Lovelace}) => {
   const value = printAda(fee)
   return <div className="transaction-fee">{`Fee: ${value}`}</div>
 }

--- a/app/frontend/helpers/adaConverters.ts
+++ b/app/frontend/helpers/adaConverters.ts
@@ -1,5 +1,7 @@
-const toCoins = (value) => value * 1000000
-const toAda = (value) => value * 0.000001
-const roundWholeAdas = (value) => toCoins(Math.round(toAda(value)))
+import {Lovelace, Ada} from '../state'
+
+const toCoins = (value: Ada): Lovelace => (value * 1000000) as Lovelace
+const toAda = (value: Lovelace): Ada => (value * 0.000001) as Ada
+const roundWholeAdas = (value: Lovelace): Lovelace => toCoins(Math.round(toAda(value)) as Ada)
 
 export {toCoins, toAda, roundWholeAdas}

--- a/app/frontend/helpers/printAda.ts
+++ b/app/frontend/helpers/printAda.ts
@@ -1,1 +1,3 @@
-export default (coins) => (parseInt(coins, 10) * 0.000001).toFixed(6)
+// eslint-disable-next-line no-unused-vars
+import {Lovelace} from '../state'
+export default (coins: Lovelace): string => (coins * 0.000001).toFixed(6)

--- a/app/frontend/helpers/validators.ts
+++ b/app/frontend/helpers/validators.ts
@@ -2,9 +2,10 @@ import {isValidAddress} from 'cardano-crypto.js'
 import {ADALITE_CONFIG} from '../config'
 import {toCoins} from './adaConverters'
 import {validateMnemonic} from '../wallet/mnemonic'
+import {Lovelace, Ada} from '../state'
 
 const {ADALITE_MIN_DONATION_VALUE} = ADALITE_CONFIG
-const parseCoins = (str) => Math.trunc(toCoins(parseFloat(str)))
+const parseToLovelace = (str): Lovelace => Math.trunc(toCoins(parseFloat(str) as Ada)) as Lovelace
 
 const sendAddressValidator = (fieldValue) =>
   !isValidAddress(fieldValue) && fieldValue !== '' ? {code: 'SendAddressInvalidAddress'} : null
@@ -74,7 +75,7 @@ const mnemonicValidator = (mnemonic) => {
 }
 
 export {
-  parseCoins,
+  parseToLovelace as parseCoins,
   sendAddressValidator,
   sendAmountValidator,
   feeValidator,

--- a/app/frontend/state.ts
+++ b/app/frontend/state.ts
@@ -4,6 +4,15 @@ interface Transaction {}
 
 type AuthMethodEnum = '' | 'hw-wallet' | 'mnemonic' // TODO
 
+export type Ada = number & {__typeAda: any}
+export type Lovelace = number & {__typeLovelace: any}
+
+export interface SendTransactionSummary {
+  amount: Lovelace
+  donation: Lovelace
+  fee: Lovelace
+}
+
 export interface State {
   loading: boolean
   loadingMessage: string
@@ -16,11 +25,7 @@ export interface State {
   sendAddress: any // TODO
   sendAmount: any // TODO
 
-  sendTransactionSummary: {
-    amount: number
-    donation: number
-    fee: number
-  }
+  sendTransactionSummary: SendTransactionSummary
 
   router: {
     pathname: string
@@ -107,9 +112,9 @@ const initialState: State = {
   sendAddress: {fieldValue: ''},
   sendAmount: {fieldValue: 0, coins: 0},
   sendTransactionSummary: {
-    amount: 0,
-    fee: 0,
-    donation: 0,
+    amount: 0 as Lovelace,
+    fee: 0 as Lovelace,
+    donation: 0 as Lovelace,
   },
   router: {
     pathname: window.location.pathname,

--- a/app/frontend/translations.ts
+++ b/app/frontend/translations.ts
@@ -1,6 +1,8 @@
 import printAda from './helpers/printAda'
 import debugLog from './helpers/debugLog'
 import {ADALITE_CONFIG} from './config'
+import {Lovelace} from './state'
+
 const {ADALITE_MIN_DONATION_VALUE} = ADALITE_CONFIG
 
 const translations = {
@@ -13,7 +15,7 @@ const translations = {
     'Sending funds is not possible since there is not enough balance to pay the transaction fee',
   SendAmountPrecisionLimit: () => 'Invalid format: Maximum allowed precision is 0.000001',
   SendAmountIsTooBig: () =>
-    `Invalid format: Amount cannot exceed ${printAda(Number.MAX_SAFE_INTEGER)}`,
+    `Invalid format: Amount cannot exceed ${printAda(Number.MAX_SAFE_INTEGER as Lovelace)}`,
   DonationAmountTooLow: () => `Minimum donation is ${ADALITE_MIN_DONATION_VALUE} ADA`,
   DonationInsufficientBalance: () => 'Insufficient balance for the donation.',
 


### PR DESCRIPTION
With a small hack called "tagged types", typescript can be convinced to check we have correct Ada/Lovelace units