### PR TITLE
Remove `disableCaching` from AddressGenerator

### DIFF
--- a/app/frontend/wallet/address-manager.ts
+++ b/app/frontend/wallet/address-manager.ts
@@ -22,12 +22,7 @@ const ByronAddressGenerator = (cryptoProvider, accountIndex: number, isChange: b
   }
 }
 
-const _AddressManager = ({
-  addrGen,
-  gapLimit,
-  disableCaching, // good for tests
-  blockchainExplorer,
-}) => {
+const _AddressManager = ({addrGen, gapLimit, blockchainExplorer}) => {
   if (!gapLimit) {
     throw NamedError('ParamsValidationError', `Invalid gap limit: ${gapLimit}`)
   }
@@ -37,7 +32,7 @@ const _AddressManager = ({
   async function cachedDeriveAddress(index: number) {
     const memoKey = index
 
-    if (!deriveAddressMemo[memoKey] || disableCaching) {
+    if (!deriveAddressMemo[memoKey]) {
       deriveAddressMemo[memoKey] = await addrGen(index)
     }
 
@@ -105,7 +100,6 @@ const AddressManager = ({
   gapLimit,
   defaultAddressCount,
   cryptoProvider,
-  disableCaching, // good for tests
   isChange,
   blockchainExplorer,
 }) => {
@@ -118,7 +112,6 @@ const AddressManager = ({
   return _AddressManager({
     addrGen: ByronAddressGenerator(cryptoProvider, accountIndex, isChange),
     gapLimit,
-    disableCaching, // good for tests
     blockchainExplorer,
   })
 }

--- a/app/frontend/wallet/cardano-wallet.ts
+++ b/app/frontend/wallet/cardano-wallet.ts
@@ -193,7 +193,6 @@ const CardanoWallet = async (options) => {
     cryptoProvider,
     isChange: false,
     blockchainExplorer,
-    disableCaching: false,
   })
 
   const changeAddressManager = AddressManager({
@@ -203,7 +202,6 @@ const CardanoWallet = async (options) => {
     cryptoProvider,
     isChange: true,
     blockchainExplorer,
-    disableCaching: false,
   })
 
   function isHwWallet() {

--- a/app/tests/src/address-manager.js
+++ b/app/tests/src/address-manager.js
@@ -71,7 +71,6 @@ const initAddressManager = async (settings, i) => {
     defaultAddressCount: mockConfig.ADALITE_DEFAULT_ADDRESS_COUNT,
     gapLimit: mockConfig.ADALITE_GAP_LIMIT,
     cryptoProvider: cryptoProviders[i],
-    disableCaching: true,
     isChange,
     blockchainExplorer,
   })


### PR DESCRIPTION
I believe this option was relevant only in the past
when the code was complected with blockchain explorer.