### PR TITLE
Fix errorModal showing on conversionRatesError

### DIFF
--- a/app/frontend/actions.js
+++ b/app/frontend/actions.js
@@ -105,7 +105,6 @@ export default ({setState, getState}) => {
       setState({
         conversionRates: null,
       })
-      throw NamedError('ConversionRatesError', '`Could not fetch conversion rates.')
     }
   }
 

--- a/app/frontend/helpers/NamedError.js
+++ b/app/frontend/helpers/NamedError.js
@@ -1,8 +1,7 @@
-function NamedError(name, message, showHelp) {
-  const e = new Error(message || name || showHelp)
+function NamedError(name, message = '') {
+  const e = new Error(message || name)
   e.name = name
   e.message = message
-  e.showHelp = showHelp
   return e
 }
 


### PR DESCRIPTION
Previously, if request fetching the conversion rates failed, an error was thrown. This error wasnt present in translations so in case it occured, it was considered unexpected so `unexpectedErrorModal` was shown. This has been shown to be happening too often thus bothering the users.