### PR TITLE
Fix balance error and current delegation grid arrangement

### DIFF
--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -112,7 +112,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
       setState({
         conversionRates: null,
       })
-      throw NamedError('ConversionRatesError', '`Could not fetch conversion rates.')
+      // throw NamedError('ConversionRatesError', '`Could not fetch conversion rates.')
     }
   }
 

--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -523,8 +523,9 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
         }
       })
       : []
-    const balance =
-      state.shelleyBalances.stakingBalance - state.shelleyBalances.rewardsAccountBalance
+    // const balance =
+    //   state.shelleyBalances.stakingBalance - state.shelleyBalances.rewardsAccountBalance
+    const balance = state.balance
     let plan
     try {
       plan = await wallet.getTxPlan({amount: null, pools, balance}, 'delegation')

--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -511,7 +511,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
     let plan
     try {
       plan = await wallet.getTxPlan({amount: null, pools, balance}, 'delegation')
-      if (!plan || balance < plan.fee) {
+      if (!plan || !plan.fee || balance < plan.fee) {
         throw NamedError('DelegationAccountBalanceError')
       }
     } catch (e) {

--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -539,12 +539,13 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
         },
         {
           calculatingDelegationFee: false,
+          showTxSuccess: state.showTxSuccess === 'send' ? state.showTxSuccess : '',
         }
       )
       return
     }
     setState({
-      showTxSuccess: state.showTxSuccess === 'stake' ? '' : state.showTxSuccess,
+      showTxSuccess: state.showTxSuccess === 'send' ? state.showTxSuccess : '',
     })
     setState({
       shelleyDelegation: {

--- a/app/frontend/components/pages/dashboard/dashboardPage.tsx
+++ b/app/frontend/components/pages/dashboard/dashboardPage.tsx
@@ -22,11 +22,11 @@ const StakingPage = () => {
   return (
     <div className="dashboard desktop">
       <div className="dashboard-column">
-        <ShelleyBalances />,
+        <ShelleyBalances />
         <CurrentDelegationPage />
       </div>
       <div className="dashboard-column">
-        <DelegatePage />,
+        <DelegatePage />
         {/* <DelegationHistory /> */}
       </div>
     </div>
@@ -37,12 +37,12 @@ const SendingPage = ({showExportOption}) => {
   return (
     <div className="dashboard desktop">
       <div className="dashboard-column">
-        <Balance />,
-        <TransactionHistory />,
+        <Balance />
+        <TransactionHistory />
       </div>
       <div className="dashboard-column">
-        <SendAdaPage />,
-        <MyAddresses />,
+        <SendAdaPage />
+        <MyAddresses />
         {showExportOption && <ExportCard />}
       </div>
     </div>

--- a/app/frontend/components/pages/delegations/currentDelegationPage.tsx
+++ b/app/frontend/components/pages/delegations/currentDelegationPage.tsx
@@ -3,7 +3,12 @@ import {connect} from '../../../libs/unistore/preact'
 import actions from '../../../actions'
 import printAda from '../../../helpers/printAda'
 
-const CurrentDelegationPage = ({currentDelegation, revokeDelegation, delegationValidationError, calculatingDelegationFee}) => {
+const CurrentDelegationPage = ({
+  currentDelegation,
+  revokeDelegation,
+  delegationValidationError,
+  calculatingDelegationFee,
+}) => {
   return (
     <div className="current-delegation card">
       <h2 className="card-title">Current delegation</h2>
@@ -32,7 +37,7 @@ const CurrentDelegationPage = ({currentDelegation, revokeDelegation, delegationV
               </div>,
             ])}
           </div>
-          <button 
+          <button
             className="button primary revoke-delegation"
             onClick={revokeDelegation}
             disabled={delegationValidationError || calculatingDelegationFee}

--- a/app/frontend/components/pages/delegations/currentDelegationPage.tsx
+++ b/app/frontend/components/pages/delegations/currentDelegationPage.tsx
@@ -18,9 +18,7 @@ const CurrentDelegationPage = ({currentDelegation, revokeDelegation}) => {
               <div className="delegation-history-name">{pool.name}</div>,
               <div className="delegation-history-percent">{`${pool.ratio} %`}</div>,
               <div className="delegation-history-id">{pool.pool_id}</div>,
-              <div />,
               <div className="delegation-history-id">{`Ticker: ${pool.ticker}`}</div>,
-              <div />,
               <div className="delegation-history-id">
                 {`
                 Tax: ${(pool.rewards.ratio[0] * 100) / pool.rewards.ratio[1] || ''}%
@@ -28,12 +26,10 @@ const CurrentDelegationPage = ({currentDelegation, revokeDelegation}) => {
                 ${pool.rewards.limit ? ` , ${`Limit: ${printAda(pool.rewards.limit)}`}` : ''}
               `}
               </div>,
-              <div />,
               <div className="delegation-history-id">
                 {'Homepage: '}
                 <a href={pool.homepage}>{pool.homepage}</a>
               </div>,
-              <div />,
             ])}
           </div>
           <button className="button primary revoke-delegation" onClick={revokeDelegation}>

--- a/app/frontend/components/pages/delegations/currentDelegationPage.tsx
+++ b/app/frontend/components/pages/delegations/currentDelegationPage.tsx
@@ -3,7 +3,7 @@ import {connect} from '../../../libs/unistore/preact'
 import actions from '../../../actions'
 import printAda from '../../../helpers/printAda'
 
-const CurrentDelegationPage = ({currentDelegation, revokeDelegation}) => {
+const CurrentDelegationPage = ({currentDelegation, revokeDelegation, delegationValidationError, calculatingDelegationFee}) => {
   return (
     <div className="current-delegation card">
       <h2 className="card-title">Current delegation</h2>
@@ -32,7 +32,11 @@ const CurrentDelegationPage = ({currentDelegation, revokeDelegation}) => {
               </div>,
             ])}
           </div>
-          <button className="button primary revoke-delegation" onClick={revokeDelegation}>
+          <button 
+            className="button primary revoke-delegation"
+            onClick={revokeDelegation}
+            disabled={delegationValidationError || calculatingDelegationFee}
+          >
             Revoke current delegation
           </button>
         </div>
@@ -46,6 +50,8 @@ const CurrentDelegationPage = ({currentDelegation, revokeDelegation}) => {
 export default connect(
   (state) => ({
     currentDelegation: state.shelleyAccountInfo.delegation,
+    delegationValidationError: state.delegationValidationError,
+    calculatingDelegationFee: state.calculatingDelegationFee,
   }),
   actions
 )(CurrentDelegationPage)

--- a/app/frontend/components/pages/delegations/delegatePage.tsx
+++ b/app/frontend/components/pages/delegations/delegatePage.tsx
@@ -12,11 +12,13 @@ import ConfirmTransactionDialog from '../../pages/sendAda/confirmTransactionDial
 const CalculatingFee = () => <div className="validation-message send">Calculating fee...</div>
 
 const DelegationValidation = ({delegationValidationError, showTxSuccess}) =>
-  delegationValidationError ? (
-    <div className="validation-message error">{getTranslation(delegationValidationError.code)}</div>
+  showTxSuccess === 'stake' ? (
+    <div className="validation-message transaction-success">Transaction successful!</div>
   ) : (
-    showTxSuccess === 'stake' && (
-      <div className="validation-message transaction-success">Transaction successful!</div>
+    delegationValidationError && (
+      <div className="validation-message error">
+        {getTranslation(delegationValidationError.code)}
+      </div>
     )
   )
 
@@ -99,7 +101,6 @@ class Delegate extends Component<Props> {
     const delegationHandler = async () => {
       await confirmTransaction('delegate')
     }
-    console.log(showTxSuccess)
     return (
       <div className="delegate card">
         <h2 className="card-title">Delegate Stake</h2>

--- a/app/frontend/components/pages/sendAda/sendAdaPage.tsx
+++ b/app/frontend/components/pages/sendAda/sendAdaPage.tsx
@@ -19,30 +19,20 @@ import tooltip from '../../common/tooltip'
 
 const {ADALITE_MIN_DONATION_VALUE} = ADALITE_CONFIG
 
-const CalculatingFee = () => (
-  <div className="validation-message send">Calculating fee...</div>
-)
+const CalculatingFee = () => <div className="validation-message send">Calculating fee...</div>
 
 const SendFormErrorMessage = ({sendFormValidationError}) => (
-  <span>
-    {getTranslation(
-      sendFormValidationError.code,
-      sendFormValidationError.params
-    )}
-  </span>
+  <span>{getTranslation(sendFormValidationError.code, sendFormValidationError.params)}</span>
 )
 
-const SendValidation = ({sendFormValidationError, sendResponse}) =>
+const SendValidation = ({sendFormValidationError, showTxSuccess}) =>
   sendFormValidationError ? (
     <div className="validation-message send error">
       <SendFormErrorMessage sendFormValidationError={sendFormValidationError} />
     </div>
   ) : (
-    sendResponse &&
-    sendResponse.success && (
-      <div className="validation-message transaction-success">
-        Transaction successful!
-      </div>
+    showTxSuccess === 'send' && (
+      <div className="validation-message transaction-success">Transaction successful!</div>
     )
   )
 
@@ -99,16 +89,14 @@ class SendAdaPage extends Component<Props> {
     maxDonationAmount,
     conversionRates,
     sendTransactionSummary: summary,
-    transactionFee
+    transactionFee,
+    showTxSuccess,
   }) {
     const sendFormValidationError =
-      sendAddressValidationError ||
-      sendAmountValidationError ||
-      donationAmountValidationError
+      sendAddressValidationError || sendAmountValidationError || donationAmountValidationError
 
     const enableSubmit = sendAmount && sendAddress && !sendFormValidationError
-    const isDonationSufficient =
-      maxDonationAmount >= toCoins(ADALITE_MIN_DONATION_VALUE)
+    const isDonationSufficient = maxDonationAmount >= toCoins(ADALITE_MIN_DONATION_VALUE)
     const isSendAddressValid = !sendAddressValidationError && sendAddress !== ''
     const total = summary.amount + transactionFee + summary.donation
 
@@ -128,7 +116,7 @@ class SendAdaPage extends Component<Props> {
           value={sendAddress}
           onInput={updateAddress}
           autoComplete="off"
-          onKeyDown={e => e.key === 'Enter' && this.amountField.focus()}
+          onKeyDown={(e) => e.key === 'Enter' && this.amountField.focus()}
         />
         <div className="send-values">
           <label className="ada-label amount" htmlFor="send-amount">
@@ -142,10 +130,11 @@ class SendAdaPage extends Component<Props> {
               placeholder="0.000000"
               value={sendAmount}
               onInput={updateAmount}
-              ref={element => {
+              autoComplete="off"
+              ref={(element) => {
                 this.amountField = element
               }}
-              onKeyDown={e => {
+              onKeyDown={(e) => {
                 if (e.key === 'Enter' && this.submitTxBtn) {
                   this.submitTxBtn.click()
                   e.preventDefault()
@@ -160,10 +149,7 @@ class SendAdaPage extends Component<Props> {
               Max
             </button>
           </div>
-          <label
-            className="ada-label amount donation"
-            htmlFor="donation-amount"
-          >
+          <label className="ada-label amount donation" htmlFor="donation-amount">
             Donate<a
               {...tooltip(
                 'Your donation is very much appreciated and will be used for further development of AdaLite',
@@ -174,18 +160,12 @@ class SendAdaPage extends Component<Props> {
             </a>
           </label>
           {!isDonationSufficient && (
-            <div className="send-donate-msg">
-              Insufficient balance for a donation.
-            </div>
+            <div className="send-donate-msg">Insufficient balance for a donation.</div>
           )}
           {!showCustomDonationInput &&
-            isDonationSufficient && (
-              <DonationButtons isSendAddressValid={isSendAddressValid} />
-            )}
+            isDonationSufficient && <DonationButtons isSendAddressValid={isSendAddressValid} />}
           {showCustomDonationInput &&
-            isDonationSufficient && (
-              <CustomDonationInput isSendAddressValid={isSendAddressValid} />
-            )}
+            isDonationSufficient && <CustomDonationInput isSendAddressValid={isSendAddressValid} />}
           <div className="ada-label">Fee</div>
           <div className="send-fee">{printAda(transactionFee)}</div>
         </div>
@@ -193,9 +173,7 @@ class SendAdaPage extends Component<Props> {
           <div className="send-total-title">Total</div>
           <div className="send-total-inner">
             <div className="send-total-ada">{printAda(total)}</div>
-            {conversionRates && (
-              <Conversions balance={total} conversionRates={conversionRates} />
-            )}
+            {conversionRates && <Conversions balance={total} conversionRates={conversionRates} />}
           </div>
         </div>
         <div className="validation-row">
@@ -203,7 +181,7 @@ class SendAdaPage extends Component<Props> {
             className="button primary"
             disabled={!enableSubmit || feeRecalculating}
             onClick={submitHandler}
-            ref={element => {
+            ref={(element) => {
               this.submitTxBtn = element
             }}
           >
@@ -214,7 +192,7 @@ class SendAdaPage extends Component<Props> {
           ) : (
             <SendValidation
               sendFormValidationError={sendFormValidationError}
-              sendResponse={sendResponse}
+              showTxSuccess={showTxSuccess}
             />
           )}
         </div>
@@ -230,9 +208,7 @@ class SendAdaPage extends Component<Props> {
         )}
         {showConfirmTransactionDialog && <ConfirmTransactionDialog />}
         {showThanksForDonation && (
-          <DonateThanksModal
-            closeThanksForDonationModal={closeThanksForDonationModal}
-          />
+          <DonateThanksModal closeThanksForDonationModal={closeThanksForDonationModal} />
         )}
       </div>
     )
@@ -240,7 +216,7 @@ class SendAdaPage extends Component<Props> {
 }
 
 export default connect(
-  state => ({
+  (state) => ({
     transactionSubmissionError: state.transactionSubmissionError,
     sendResponse: state.sendResponse,
     sendAddressValidationError: state.sendAddressValidationError,
@@ -257,7 +233,8 @@ export default connect(
     maxDonationAmount: state.maxDonationAmount,
     conversionRates: state.conversionRates && state.conversionRates.data,
     sendTransactionSummary: state.sendTransactionSummary,
-    transactionFee: state.transactionFee
+    transactionFee: state.transactionFee,
+    showTxSuccess: state.showTxSuccess,
   }),
   actions
 )(SendAdaPage)

--- a/app/frontend/components/pages/sendAda/sendAdaPage.tsx
+++ b/app/frontend/components/pages/sendAda/sendAdaPage.tsx
@@ -26,13 +26,13 @@ const SendFormErrorMessage = ({sendFormValidationError}) => (
 )
 
 const SendValidation = ({sendFormValidationError, showTxSuccess}) =>
-  sendFormValidationError ? (
-    <div className="validation-message send error">
-      <SendFormErrorMessage sendFormValidationError={sendFormValidationError} />
-    </div>
+  showTxSuccess === 'send' ? (
+    <div className="validation-message transaction-success">Transaction successful!</div>
   ) : (
-    showTxSuccess === 'send' && (
-      <div className="validation-message transaction-success">Transaction successful!</div>
+    sendFormValidationError && (
+      <div className="validation-message send error">
+        <SendFormErrorMessage sendFormValidationError={sendFormValidationError} />
+      </div>
     )
   )
 

--- a/app/frontend/components/pages/txHistory/transactionHistory.tsx
+++ b/app/frontend/components/pages/txHistory/transactionHistory.tsx
@@ -1,4 +1,4 @@
-import {h} from 'preact'
+import {h, Component} from 'preact'
 import printAda from '../../../helpers/printAda'
 import formatDate from '../../../helpers/formatDate'
 import {Lovelace} from '../../../state'
@@ -60,25 +60,64 @@ const Transaction = ({txid}) => (
   </div>
 )
 
-const TransactionHistory = ({transactionHistory}) => (
-  <div className="transactions card">
-    <h2 className="card-title">Transaction History</h2>
-    {transactionHistory.length === 0 ? (
-      <div className="transactions-empty">No transactions found</div>
-    ) : (
-      <ul className="transactions-content">
-        {transactionHistory.map((transaction) => (
-          <li key={transaction.ctbId} className="transaction-item">
-            <div className="transaction-date">{formatDate(transaction.ctbTimeIssued)}</div>
-            <FormattedAmount amount={transaction.effect} />
-            <Transaction txid={transaction.ctbId} />
-            <FormattedFee fee={transaction.fee} />
-          </li>
-        ))}
-      </ul>
-    )}
-  </div>
-)
+interface Props {
+  transactionHistory: any
+}
+
+class TransactionHistory extends Component<Props> {
+  constructor(props) {
+    super(props)
+  }
+  render({transactionHistory}) {
+    console.log('render', transactionHistory.map((tx) => tx.effect))
+    return (
+      <div className="transactions card">
+        <h2 className="card-title">Transaction History</h2>
+        {transactionHistory.length === 0 ? (
+          <div className="transactions-empty">No transactions found</div>
+        ) : (
+          <ul className="transactions-content">
+            {transactionHistory.map((transaction) => (
+              <li key={transaction.ctbId} className="transaction-item">
+                <div className="transaction-date">{formatDate(transaction.ctbTimeIssued)}</div>
+                <FormattedAmount amount={transaction.effect} />
+                <Transaction txid={transaction.ctbId} />
+                <FormattedFee fee={transaction.fee} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    )
+  }
+}
+
+// const TransactionHistory2 = ({transactionHistory}) => (
+//   <div className="transactions card">
+//     <h2 className="card-title">Transaction History</h2>
+//     {transactionHistory.length === 0 ? (
+//       <div className="transactions-empty">No transactions found</div>
+//     ) : (
+//       <ul className="transactions-content">
+//         {transactionHistory.map((transaction) => (
+//           <li key={transaction.ctbId} className="transaction-item">
+//             <div className="transaction-date">{formatDate(transaction.ctbTimeIssued)}</div>
+//             <FormattedAmount amount={transaction.effect} />
+//             <Transaction txid={transaction.ctbId} />
+//             <FormattedFee fee={transaction.fee} />
+//           </li>
+//         ))}
+//       </ul>
+//     )}
+//   </div>
+// )
+
+// export default connect(
+//   (state) => ({
+//     transactionHistory: state.transactionHistory,
+//   }),
+//   actions
+// )(TransactionHistory)
 
 export default connect(
   (state) => ({

--- a/app/frontend/components/pages/txHistory/transactionHistory.tsx
+++ b/app/frontend/components/pages/txHistory/transactionHistory.tsx
@@ -69,7 +69,6 @@ class TransactionHistory extends Component<Props> {
     super(props)
   }
   render({transactionHistory}) {
-    console.log('render', transactionHistory.map((tx) => tx.effect))
     return (
       <div className="transactions card">
         <h2 className="card-title">Transaction History</h2>

--- a/app/frontend/state.ts
+++ b/app/frontend/state.ts
@@ -10,6 +10,7 @@ export interface SendTransactionSummary {
   donation?: Lovelace
   fee: Lovelace
   plan: any
+  type?: any
 }
 
 export interface State {
@@ -121,6 +122,7 @@ export interface State {
     }
   }
   txConfirmType: string
+  showTxSuccess: string
 }
 
 const initialState: State = {
@@ -200,6 +202,7 @@ const initialState: State = {
     },
   },
   txConfirmType: '',
+  showTxSuccess: '',
 }
 
 export {initialState}

--- a/app/frontend/translations.ts
+++ b/app/frontend/translations.ts
@@ -23,6 +23,7 @@ const translations = {
   RudundantStakePool: () => 'This stake pool is already chosen.',
   DelegationAccountBalanceError: () => 'Not enough funds to pay the delegation fee.',
   DelegationFeeError: () => 'Unsuccessful delegation fee calculation.',
+  NonStakingConversionError: () => 'Insufficient balance: Not enough funds to pay the conversion fee.',
 
   InvalidMnemonic: () => 'Invalid mnemonic, check your mnemonic for typos and try again.',
   AddressNotInBlockchain: () => 'Wallet is not shelley compatible. Restore your wallet first.',

--- a/app/frontend/translations.ts
+++ b/app/frontend/translations.ts
@@ -23,7 +23,8 @@ const translations = {
   RudundantStakePool: () => 'This stake pool is already chosen.',
   DelegationAccountBalanceError: () => 'Not enough funds to pay the delegation fee.',
   DelegationFeeError: () => 'Unsuccessful delegation fee calculation.',
-  NonStakingConversionError: () => 'Insufficient balance: Not enough funds to pay the conversion fee.',
+  NonStakingConversionError: () =>
+    'Insufficient balance: Not enough funds to pay the conversion fee.',
 
   InvalidMnemonic: () => 'Invalid mnemonic, check your mnemonic for typos and try again.',
   AddressNotInBlockchain: () => 'Wallet is not shelley compatible. Restore your wallet first.',

--- a/app/frontend/wallet/blockchain-explorer.ts
+++ b/app/frontend/wallet/blockchain-explorer.ts
@@ -31,11 +31,11 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
     return result.Right
   }
 
-  const getAddressInfos = cacheResults(15000)(_fetchBulkAddressInfo)
+  // const getAddressInfos = cacheResults(15000)(_fetchBulkAddressInfo)
+  const getAddressInfos = _fetchBulkAddressInfo
 
   async function getTxHistory(addresses) {
     const transactions = []
-
     const chunks = range(0, Math.ceil(addresses.length / gapLimit))
     const addressInfos = (await Promise.all(
       chunks.map(async (index) => {

--- a/app/frontend/wallet/blockchain-explorer.ts
+++ b/app/frontend/wallet/blockchain-explorer.ts
@@ -31,13 +31,12 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
     return result.Right
   }
 
-  // const getAddressInfos = cacheResults(15000)(_fetchBulkAddressInfo)
-  const getAddressInfos = _fetchBulkAddressInfo
+  const getAddressInfos = cacheResults(15000)(_fetchBulkAddressInfo)
 
   async function getTxHistory(addresses) {
     const transactions = []
     const chunks = range(0, Math.ceil(addresses.length / gapLimit))
-    const addressInfos = (await Promise.all(
+    const cachedAddressInfos = (await Promise.all(
       chunks.map(async (index) => {
         const beginIndex = index * gapLimit
         return await getAddressInfos(addresses.slice(beginIndex, beginIndex + gapLimit))
@@ -50,6 +49,9 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
       },
       {caTxList: []}
     )
+    // create a deep copy of address infos since
+    // we are mutating effect and fee
+    const addressInfos = JSON.parse(JSON.stringify(cachedAddressInfos))
     addressInfos.caTxList.forEach((tx) => {
       transactions[tx.ctbId] = tx
     })

--- a/app/frontend/wallet/shelley-wallet.ts
+++ b/app/frontend/wallet/shelley-wallet.ts
@@ -17,7 +17,7 @@ import {selectMinimalTxPlan, computeAccountTxPlan} from './shelley/build-transac
 import shuffleArray from './helpers/shuffleArray'
 import {MaxAmountCalculator} from './max-amount-calculator'
 import {ByronAddressProvider} from './byron/byron-address-provider'
-import {isShelleyAddress, bechAddressToHex, isGroup} from './shelley/helpers/addresses'
+import {isShelleyAddress, bechAddressToHex, isGroup, isSingle} from './shelley/helpers/addresses'
 import request from './helpers/request'
 import {ADALITE_CONFIG} from '../config'
 
@@ -26,6 +26,8 @@ const isUtxoProfitable = () => true
 const isUtxoNonStaking = ({address}) => !isGroup(address)
 
 const isUtxoStaking = ({address}) => isGroup(address)
+
+const isShelleyUtxo = ({address}) => isGroup(address) || isSingle(address)
 
 const MyAddresses = ({accountIndex, cryptoProvider, gapLimit, blockchainExplorer}) => {
   const legacyExtManager = AddressManager({
@@ -300,7 +302,7 @@ const ShelleyWallet = ({config, randomInputSeed, randomChangeSeed, cryptoProvide
   const uTxOTxPlanner = async (args, txType) => {
     const {address, coins, donationAmount, pools} = args
     const utxoFilters = {
-      delegation: isUtxoStaking,
+      delegation: isShelleyUtxo,
       nonStakingConversion: isUtxoNonStaking,
       utxo: () => true,
     }

--- a/app/frontend/wallet/shelley-wallet.ts
+++ b/app/frontend/wallet/shelley-wallet.ts
@@ -439,7 +439,7 @@ const ShelleyWallet = ({config, randomInputSeed, randomChangeSeed, cryptoProvide
     const group = await myAddresses.groupExtManager.discoverAddressesWithMeta()
     // TODO why not get also the account address
     // need to change the ..withMeta function to do that
-    return [...single, ...group] //filterUnusedEndAddresses(addresses, config.ADALITE_DEFAULT_ADDRESS_COUNT)
+    return [...group, ...single] //filterUnusedEndAddresses(addresses, config.ADALITE_DEFAULT_ADDRESS_COUNT)
   }
 
   async function verifyAddress(addr: string) {

--- a/app/frontend/wallet/shelley/helpers/addresses.ts
+++ b/app/frontend/wallet/shelley/helpers/addresses.ts
@@ -76,3 +76,10 @@ export const isGroup = (address: string): boolean => {
     : Address.from_bytes(Buffer.from(address, 'hex'))
   return wasmAddr.get_kind() === AddressKind.Group
 }
+
+export const isSingle = (address: string): boolean => {
+  const wasmAddr = isShelleyAddress(address)
+    ? Address.from_string(address)
+    : Address.from_bytes(Buffer.from(address, 'hex'))
+  return wasmAddr.get_kind() === AddressKind.Single
+}

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -1202,7 +1202,7 @@ li.main-tab label {
   box-sizing: border-box;
   display: inline-block;
   padding: 15px 25px;
-  color: #000;
+  color: var(--color-grey);
   width: 50%;
   text-align: center;
 }
@@ -2778,6 +2778,9 @@ input:checked + .slider:before {
   margin-bottom: 4px;
   justify-self: start;
   color: rgba(96, 106, 113, 0.64);
+  grid-column-start: 1;
+  grid-column-end: 3;
+  word-break: break-all;
 }
 
 /* TRANSACTIONS */
@@ -4192,6 +4195,7 @@ input:checked + .slider:before {
     box-shadow: unset;
     border-radius: unset;
     border-bottom: 1px transparent;
+    color: var(--color-black);
   }
 
   li.main-tab input + label.selected::before {
@@ -4205,6 +4209,10 @@ input:checked + .slider:before {
     background: #fff;
     box-shadow: unset;
   }
+  li.main-tab input + label {
+    color: var(--color-grey);
+  }
+  
 
   /* SEND ADA */
 

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -2673,6 +2673,10 @@ input:checked + .slider:before {
   background-color: var(--color-staking-dark);
 }
 
+.button.revoke-delegation:disabled {
+  background-color: var(--color-staking-light);
+}
+
 .stake-pool-list {
   padding: 0 0 8px 0;
   margin: 0;


### PR DESCRIPTION
- fixes problem with no enough balance to change delegation
- fixes css grid so pool id doesnt break the whole viewport
- make unselected tabs colored grey
- disables revoke and throws error when converting legacy if not enough balance to pay the fee
- remove conversionRates error throwing
- disables addressInfos catching as aj temporary solution to tx history bug
- separetes tx success message on both tabs
- adds single address utxos to possible utxos when changing delegation