### PR TITLE
Refactor testnet functionality

### DIFF
--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -745,7 +745,8 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
   const convertNonStakingUtxos = async (state) => {
     loadingAction(state, 'Preparing transaction...')
     const address = await wallet.getChangeAddress()
-    const {sendAmount: coins} = await wallet.getMaxNonStakingAmount(address)
+    const maxAmount = await wallet.getMaxNonStakingAmount(address)
+    const coins = maxAmount && maxAmount.sendAmount
     const balance = state.balance
     let plan
     try {
@@ -1025,11 +1026,11 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
         showTransactionErrorModal: true,
       })
     } finally {
+      resetTransactionSummary(state)
       resetSendFormFields(state)
       resetSendFormState(state)
       resetAmountFields(state)
       resetDelegationToAdalite()
-      resetTransactionSummary(state)
       wallet.generateNewSeeds()
       await reloadWalletInfo(state)
       setState({

--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -454,6 +454,19 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
     })
   }
 
+  const resetDelegation = () => {
+    setState({
+      shelleyDelegation: {
+        delegationFee: 0,
+        selectedPools: [
+          {
+            poolIdentifier: '',
+          },
+        ],
+      },
+    })
+  }
+
   const validateSendForm = (state) => {
     setErrorState('sendAddressValidationError', sendAddressValidator(state.sendAddress.fieldValue))
     setErrorState(
@@ -485,6 +498,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
     } catch (e) {
       stopLoadingAction(state, {})
       resetAmountFields(state)
+      resetDelegation()
       setState({
         calculatingDelegationFee: false,
         calculatingFee: false,
@@ -808,9 +822,9 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
     const state = getState()
     //TODO: some validation in case poolIdentifier changed(hasPoolIdentifierChanged)
     const pools = !revoke
-      ? state.shelleyDelegation.selectedPools.map(({pool_id, ratio}) => {
+      ? state.shelleyDelegation.selectedPools.map(({pool_id: id, ratio}) => {
         return {
-          id: pool_id,
+          id,
           ratio,
         }
       })
@@ -939,19 +953,6 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
     selectAdaliteStakepool()
   }
 
-  const resetDelegation = () => {
-    setState({
-      shelleyDelegation: {
-        delegationFee: 0,
-        selectedPools: [
-          {
-            poolIdentifier: '',
-          },
-        ],
-      },
-    })
-  }
-
   /* SUBMIT TX */
 
   const waitForTxToAppearOnBlockchain = async (state, txHash, pollingInterval, maxRetries) => {
@@ -1054,7 +1055,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
 
   /* GENERAL */
 
-  const openWelcome = async (state) => {
+  const openWelcome = (state) => {
     setState({
       displayWelcome: true,
     })
@@ -1075,7 +1076,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
     })
   }
 
-  const showContactFormModal = async (state) => {
+  const showContactFormModal = (state) => {
     setState({
       showContactFormModal: true,
     })
@@ -1093,7 +1094,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
     })
   }
 
-  const toggleDisplayStakingPage = async (state, value) => {
+  const toggleDisplayStakingPage = (state, value) => {
     setState({displayStakingPage: value})
     resetTransactionSummary()
     resetSendFormFields(state)

--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -711,11 +711,11 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
   const convertNonStakingUtxos = async (state) => {
     loadingAction(state, 'Preparing transaction...')
     const address = await wallet.getChangeAddress()
-    const {sendAmount} = await wallet.getMaxNonStakingAmount(address)
+    const {sendAmount: coins} = await wallet.getMaxNonStakingAmount(address)
     const balance = state.balance
     const plan = await prepareTxPlan({
       address,
-      coins: sendAmount,
+      coins,
       donationAmount: null,
       txType: 'convert',
     })
@@ -730,7 +730,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
       stopLoadingAction(state, {})
       return
     }
-    setTransactionSummary('stake', plan, sendAmount)
+    setTransactionSummary('stake', plan, coins)
     confirmTransaction(getState(), 'convert')
     stopLoadingAction(state, {})
   }
@@ -985,8 +985,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
       txSubmitResult = await wallet.submitTx(signedTx)
 
       if (!txSubmitResult) {
-        // TODO: cant we check and throw this in submitTx method
-        debugLog(txSubmitResult)
+        // TODO: this seems useless here
         throw NamedError('TransactionRejectedByNetwork')
       }
 

--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -524,7 +524,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
     let plan
     const address = state.sendAddress.fieldValue
     try {
-      plan = await wallet.getTxPlan({address, coins: amount, donationAmount}, 'utxo')
+      plan = await wallet.getTxPlan({address, coins: amount, donationAmount, txType: 'sendAda'})
     } catch (e) {
       setErrorState('sendAmountValidationError', {code: e.name})
       setState({
@@ -698,15 +698,12 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
     const balance = state.balance
     let plan
     try {
-      plan = await wallet.getTxPlan(
-        {
-          address,
-          coins: sendAmount,
-          donationAmount: null,
-          nonStaking: true,
-        },
-        'nonStakingConversion'
-      )
+      plan = await wallet.getTxPlan({
+        address,
+        coins: sendAmount,
+        donationAmount: null,
+        txType: 'convert',
+      })
       if (!plan || !plan.fee || balance < plan.fee) {
         throw NamedError('NonStakingConversionError')
       }
@@ -716,7 +713,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
           donation: 0 as Lovelace,
           fee: plan.fee != null ? plan.fee : plan.estimatedFee,
           plan: plan.fee != null ? plan : null,
-          type: 'stake',
+          type: 'stake', // TODO(merc): this has nothing to de in here
         },
       })
       confirmTransaction(getState(), 'convert')
@@ -752,7 +749,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
     const balance = state.balance
     let plan
     try {
-      plan = await wallet.getTxPlan({amount: null, pools, balance}, 'delegation')
+      plan = await wallet.getTxPlan({coins: null, pools, txType: 'delegate'})
       if (!plan || !plan.fee || balance < plan.fee) {
         throw NamedError('DelegationAccountBalanceError')
       }

--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -400,14 +400,14 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
     })
   }
 
-  const resetTransactionSummary = () => {
+  const resetTransactionSummary = (state) => {
     setState({
       sendTransactionSummary: {
         amount: 0 as Lovelace,
         fee: 0 as Lovelace,
         donation: 0 as Lovelace,
         plan: null,
-        tab: '',
+        tab: state.sendTransactionSummary.tab,
       },
     })
   }
@@ -562,7 +562,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
 
   const validateSendFormAndCalculateFee = () => {
     validateSendForm(getState())
-    resetTransactionSummary()
+    resetTransactionSummary(getState())
     setState({transactionFee: 0})
     const state = getState()
     if (isSendFormFilledAndValid(state)) {
@@ -1029,7 +1029,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
       resetSendFormState(state)
       resetAmountFields(state)
       resetDelegationToAdalite()
-      resetTransactionSummary()
+      resetTransactionSummary(state)
       wallet.generateNewSeeds()
       await reloadWalletInfo(state)
       setState({
@@ -1096,7 +1096,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
 
   const toggleDisplayStakingPage = (state, value) => {
     setState({displayStakingPage: value})
-    resetTransactionSummary()
+    resetTransactionSummary(state)
     resetSendFormFields(state)
   }
 

--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -70,8 +70,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
       )
     )
   }
-  // TODO rename to setErrorState
-  const handleError = (errorName: string, e: any, options?: any) => {
+  const setErrorState = (errorName: string, e: any, options?: any) => {
     if (e && e.name) {
       // TODO find a better way to distict
       // is a error
@@ -188,7 +187,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
       setState({
         loading: false,
       })
-      handleError('walletLoadingError', e)
+      setErrorState('walletLoadingError', e)
       setState({
         showWalletLoadingErrorModal: true,
       })
@@ -303,7 +302,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
         setState({
           waitingForHwWallet: false,
         })
-        handleError('addressVerificationError', true)
+        setErrorState('addressVerificationError', true)
       }
     }
   }
@@ -360,7 +359,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
       setState({
         loading: false,
       })
-      handleError('walletLoadingError', e)
+      setErrorState('walletLoadingError', e)
       setState({
         showWalletLoadingErrorModal: true,
       })
@@ -389,12 +388,12 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
   }
 
   const validateSendForm = (state) => {
-    handleError('sendAddressValidationError', sendAddressValidator(state.sendAddress.fieldValue))
-    handleError(
+    setErrorState('sendAddressValidationError', sendAddressValidator(state.sendAddress.fieldValue))
+    setErrorState(
       'sendAmountValidationError',
       sendAmountValidator(state.sendAmount.fieldValue, state.sendAmount.coins)
     )
-    handleError(
+    setErrorState(
       'donationAmountValidationError',
       donationAmountValidator(state.donationAmount.fieldValue, state.donationAmount.coins)
     )
@@ -425,7 +424,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
     try {
       plan = await wallet.getTxPlan({address, coins: amount, donationAmount}, 'utxo')
     } catch (e) {
-      handleError('sendAmountValidationError', {code: e.name})
+      setErrorState('sendAmountValidationError', {code: e.name})
       setState({
         calculatingFee: false,
       })
@@ -452,7 +451,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
       },
       transactionFee: plan.fee != null ? plan.fee : plan.estimatedFee,
     })
-    handleError(
+    setErrorState(
       'sendAmountValidationError',
       feeValidator(
         amount,
@@ -506,7 +505,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
       stopLoadingAction(state, {})
     } catch (e) {
       stopLoadingAction(state, {})
-      handleError('transactionSubmissionError', e)
+      setErrorState('transactionSubmissionError', e)
       setState({
         showTransactionErrorModal: true,
       })
@@ -533,7 +532,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
         throw NamedError('DelegationAccountBalanceError')
       }
     } catch (e) {
-      handleError(
+      setErrorState(
         'delegationValidationError',
         {
           code: e.name === 'DelegationAccountBalanceError' ? e.name : 'DelegationFeeError',
@@ -571,7 +570,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
     const delegationValidationError = state.shelleyDelegation.selectedPools.every(
       (pool) => pool.validationError || pool.poolIdentifier === ''
     )
-    handleError('delegationValidationError', delegationValidationError)
+    setErrorState('delegationValidationError', delegationValidationError)
     setState({
       delegationValidationError,
     })
@@ -869,7 +868,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
         setState({
           calculatingFee: false,
         })
-        handleError('sendAmountValidationError', {code: e.name})
+        setErrorState('sendAmountValidationError', {code: e.name})
         return
       })
     validateAndSetMaxFunds(state, maxAmounts)
@@ -939,7 +938,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
         setState({showThanksForDonation: true})
       }
     } catch (e) {
-      handleError('transactionSubmissionError', e, {
+      setErrorState('transactionSubmissionError', e, {
         txHash: txSubmitResult && txSubmitResult.txHash,
       })
       setState({

--- a/app/frontend/components/pages/dashboard/dashboardPage.tsx
+++ b/app/frontend/components/pages/dashboard/dashboardPage.tsx
@@ -71,8 +71,13 @@ class DashboardPage extends Component<Props> {
       <div className="page-wrapper">
         {ADALITE_CONFIG.ADALITE_CARDANO_VERSION === 'shelley' && (
           <ul className="tabinator">
-            {mainTabs.map((name) => (
-              <MainTab name={name} selectedTab={selectedMainTab} selectTab={this.selectMainTab} />
+            {mainTabs.map((name, i) => (
+              <MainTab
+                key={i}
+                name={name}
+                selectedTab={selectedMainTab}
+                selectTab={this.selectMainTab}
+              />
             ))}
           </ul>
         )}
@@ -125,8 +130,13 @@ class DashboardMobileContent extends Component<Props> {
     return (
       <div className="dashboard-content">
         <ul className="dashboard-tabs">
-          {(displayStakingPage ? stakingTabs : sendingTabs).map((name) => (
-            <SubTab name={name} selectedTab={selectedSubTab} selectTab={this.selectSubTab} />
+          {(displayStakingPage ? stakingTabs : sendingTabs).map((name, i) => (
+            <SubTab
+              key={i}
+              name={name}
+              selectedTab={selectedSubTab}
+              selectTab={this.selectSubTab}
+            />
           ))}
         </ul>
         <Page />

--- a/app/frontend/components/pages/dashboard/tabs.tsx
+++ b/app/frontend/components/pages/dashboard/tabs.tsx
@@ -1,6 +1,4 @@
-import {h, Component} from 'preact'
-import {connect} from '../../../helpers/connect'
-import actions from '../../../actions'
+import {h} from 'preact'
 
 export const MainTab = ({name, selectedTab, selectTab}) => {
   return (

--- a/app/frontend/components/pages/delegations/currentDelegationPage.tsx
+++ b/app/frontend/components/pages/delegations/currentDelegationPage.tsx
@@ -15,10 +15,6 @@ const CurrentDelegationPage = ({
       {currentDelegation.length ? (
         <div>
           <div className="current-delegation-wrapper">
-            {/* <div className="delegation-history-time">
-              {formatDelegationDate(currentDelegation[0].time)}
-            </div>]
-            <div /> */}
             {currentDelegation.map((pool, i) => [
               <div key={i} className="delegation-history-name">
                 {pool.name}

--- a/app/frontend/components/pages/delegations/currentDelegationPage.tsx
+++ b/app/frontend/components/pages/delegations/currentDelegationPage.tsx
@@ -1,4 +1,4 @@
-import {h, Fragment} from 'preact'
+import {h} from 'preact'
 import {connect} from '../../../libs/unistore/preact'
 import actions from '../../../actions'
 import printAda from '../../../helpers/printAda'
@@ -17,21 +17,25 @@ const CurrentDelegationPage = ({
           <div className="current-delegation-wrapper">
             {/* <div className="delegation-history-time">
               {formatDelegationDate(currentDelegation[0].time)}
-            </div>
+            </div>]
             <div /> */}
-            {currentDelegation.map((pool) => [
-              <div className="delegation-history-name">{pool.name}</div>,
-              <div className="delegation-history-percent">{`${pool.ratio} %`}</div>,
-              <div className="delegation-history-id">{pool.pool_id}</div>,
-              <div className="delegation-history-id">{`Ticker: ${pool.ticker}`}</div>,
-              <div className="delegation-history-id">
+            {currentDelegation.map((pool, i) => [
+              <div key={i} className="delegation-history-name">
+                {pool.name}
+              </div>,
+              <div key={i} className="delegation-history-percent">{`${pool.ratio} %`}</div>,
+              <div key={i} className="delegation-history-id">
+                {pool.pool_id}
+              </div>,
+              <div key={i} className="delegation-history-id">{`Ticker: ${pool.ticker}`}</div>,
+              <div key={i} className="delegation-history-id">
                 {`
                 Tax: ${(pool.rewards.ratio[0] * 100) / pool.rewards.ratio[1] || ''}%
                 ${pool.rewards.fixed ? ` , ${`Fixed: ${printAda(pool.rewards.fixed)}`}` : ''}
                 ${pool.rewards.limit ? ` , ${`Limit: ${printAda(pool.rewards.limit)}`}` : ''}
               `}
               </div>,
-              <div className="delegation-history-id">
+              <div key={i} className="delegation-history-id">
                 {'Homepage: '}
                 <a href={pool.homepage}>{pool.homepage}</a>
               </div>,

--- a/app/frontend/components/pages/delegations/delegatePage.tsx
+++ b/app/frontend/components/pages/delegations/delegatePage.tsx
@@ -11,8 +11,8 @@ import ConfirmTransactionDialog from '../../pages/sendAda/confirmTransactionDial
 
 const CalculatingFee = () => <div className="validation-message send">Calculating fee...</div>
 
-const DelegationValidation = ({delegationValidationError, showTxSuccess}) =>
-  showTxSuccess === 'stake' ? (
+const DelegationValidation = ({delegationValidationError, txSuccessTab}) =>
+  txSuccessTab === 'stake' ? (
     <div className="validation-message transaction-success">Transaction successful!</div>
   ) : (
     delegationValidationError && (
@@ -68,7 +68,7 @@ interface Props {
   showTransactionErrorModal: any
   selectAdaliteStakepool: any
   showConfirmTransactionDialog: any
-  showTxSuccess: any
+  txSuccessTab: any
 }
 
 class Delegate extends Component<Props> {
@@ -96,7 +96,7 @@ class Delegate extends Component<Props> {
     transactionSubmissionError,
     showTransactionErrorModal,
     showConfirmTransactionDialog,
-    showTxSuccess,
+    txSuccessTab,
   }) {
     const delegationHandler = async () => {
       await confirmTransaction('delegate')
@@ -185,7 +185,7 @@ class Delegate extends Component<Props> {
             ) : (
               <DelegationValidation
                 delegationValidationError={delegationValidationError}
-                showTxSuccess={showTxSuccess}
+                txSuccessTab={txSuccessTab}
               />
             ),
           ]}
@@ -215,7 +215,7 @@ export default connect(
     showTransactionErrorModal: state.showTransactionErrorModal,
     transactionSubmissionError: state.transactionSubmissionError,
     showConfirmTransactionDialog: state.showConfirmTransactionDialog,
-    showTxSuccess: state.showTxSuccess,
+    txSuccessTab: state.txSuccessTab,
   }),
   actions
 )(Delegate)

--- a/app/frontend/components/pages/delegations/delegationHistory.tsx
+++ b/app/frontend/components/pages/delegations/delegationHistory.tsx
@@ -11,21 +11,29 @@ const DelegationHistory = ({delegationHistory}) => {
         <div className="delegation-history-empty">No delegations found</div>
       ) : (
         <ul className="delegation-history-content">
-          {delegationHistory.map((entry) => (
-            <li className="delegation-history-item">
+          {delegationHistory.map((entry, i) => (
+            <li key={i} className="delegation-history-item">
               <div className="delegation-history-time">{entry.timeIssued}</div>
               <div className={`delegation-history-title ${entry.entryType}`}>{entry.entryType}</div>
               {entry.entryType === 'delegation' ? (
-                entry.stakePools.map((pool) => [
-                  <div className="delegation-history-name">{pool.name}</div>,
-                  <div className="delegation-history-percent">{`${pool.ratio} %`}</div>,
-                  <div className="delegation-history-id">{pool.id}</div>,
-                  <div />,
+                entry.stakePools.map((pool, i) => [
+                  <div key={i} className="delegation-history-name">
+                    {pool.name}
+                  </div>,
+                  <div key={i} className="delegation-history-percent">{`${pool.ratio} %`}</div>,
+                  <div key={i} className="delegation-history-id">
+                    {pool.id}
+                  </div>,
+                  <div key={i} />,
                 ])
               ) : entry.entryType === 'reward' ? (
                 [
-                  <div className="delegation-history-reward-info">{entry.info}</div>,
-                  <div className="delegation-history-amount">{printAda(entry.amount)}</div>,
+                  <div key={i} className="delegation-history-reward-info">
+                    {entry.info}
+                  </div>,
+                  <div key={i} className="delegation-history-amount">
+                    {printAda(entry.amount)}
+                  </div>,
                 ]
               ) : (
                 <div />

--- a/app/frontend/components/pages/login/loginPage.tsx
+++ b/app/frontend/components/pages/login/loginPage.tsx
@@ -5,7 +5,7 @@ import isLeftClick from '../../../helpers/isLeftClick'
 
 import KeyFileAuth from './keyFileAuth'
 import MnemonicAuth from './mnemonicAuth'
-import HardwareAuth from './hardwareAuth'
+// import HardwareAuth from './hardwareAuth'
 import DemoWalletWarningDialog from './demoWalletWarningDialog'
 import GenerateMnemonicDialog from './generateMnemonicDialog'
 import LogoutNotification from './logoutNotification'

--- a/app/frontend/components/pages/login/loginPage.tsx
+++ b/app/frontend/components/pages/login/loginPage.tsx
@@ -5,7 +5,6 @@ import isLeftClick from '../../../helpers/isLeftClick'
 
 import KeyFileAuth from './keyFileAuth'
 import MnemonicAuth from './mnemonicAuth'
-// import HardwareAuth from './hardwareAuth'
 import DemoWalletWarningDialog from './demoWalletWarningDialog'
 import GenerateMnemonicDialog from './generateMnemonicDialog'
 import LogoutNotification from './logoutNotification'
@@ -129,11 +128,6 @@ class LoginPage extends Component<Props, {isDropdownOpen: boolean}> {
         <h2 className="authentication-title">How do you want to access your Cardano Wallet?</h2>
         <div className="auth-options">
           {AuthOption('mnemonic', ['12, 15 or 27 word passphrase'], 'fastest')}
-          {/* {AuthOption(
-            'hw-wallet',
-            ['Trezor T', 'Ledger Nano S/X', 'Android device & Ledger'],
-            'recommended'
-          )} */}
           {AuthOption('file', ['Encrypted .JSON file'], '')}
         </div>
       </div>
@@ -149,12 +143,10 @@ class LoginPage extends Component<Props, {isDropdownOpen: boolean}> {
           {CurrentDropdownItem(authMethod)}
           <ul className="dropdown-items">
             {DropdownItem('mnemonic')}
-            {/* {DropdownItem('hw-wallet', true)} */}
             {DropdownItem('file')}
           </ul>
         </div>
         {authMethod === 'mnemonic' && <MnemonicAuth />}
-        {/* {authMethod === 'hw-wallet' && <HardwareAuth loadWallet={loadWallet} />} */}
         {authMethod === 'file' && <KeyFileAuth />}
       </div>
     )

--- a/app/frontend/components/pages/sendAda/confirmTransactionDialog.tsx
+++ b/app/frontend/components/pages/sendAda/confirmTransactionDialog.tsx
@@ -4,6 +4,7 @@ import actions from '../../../actions'
 import printAda from '../../../helpers/printAda'
 import Modal from '../../common/modal'
 import RawTransactionModal from './rawTransactionModal'
+import roundNumber from '../../../helpers/roundNumber'
 
 interface Props {
   sendAddress: any
@@ -76,7 +77,7 @@ class ConfirmTransactionDialogClass extends Component<Props, {}> {
                 <div className="review-amount">{pool.ticker}</div>
                 <div className="review-label">Tax</div>
                 <div className="review-amount">
-                  {pool.rewards && (pool.rewards.ratio[0] * 100) / pool.rewards.ratio[1]}%
+                  {pool.rewards && roundNumber(pool.rewards.ratio[0] * 100) / pool.rewards.ratio[1]}%
                 </div>
                 <div className="review-label">Homepage</div>
                 <div className="review-amount">{pool.homepage}</div>

--- a/app/frontend/components/pages/sendAda/confirmTransactionDialog.tsx
+++ b/app/frontend/components/pages/sendAda/confirmTransactionDialog.tsx
@@ -31,14 +31,14 @@ class ConfirmTransactionDialogClass extends Component<Props, {}> {
     setRawTransactionOpen,
     rawTransactionOpen,
     stakePools,
-    txConfirmType
+    txConfirmType,
   }) {
     const total = summary.amount + summary.donation + summary.fee
     const titleMap = {
       delegate: 'Delegation review',
       revoke: 'Delegation revocation review',
       send: 'Transaction review',
-      convert: 'Stakable balance conversion review'
+      convert: 'Stakable balance conversion review',
     }
 
     return (
@@ -67,7 +67,7 @@ class ConfirmTransactionDialogClass extends Component<Props, {}> {
 
           {txConfirmType === 'delegate' &&
             stakePools.map((pool, i) => (
-              <Fragment>
+              <Fragment key={i}>
                 <div className="review-label">Pool ID</div>
                 <div className="review-amount">{pool.poolIdentifier}</div>
                 <div className="review-label">Pool Name</div>
@@ -76,8 +76,7 @@ class ConfirmTransactionDialogClass extends Component<Props, {}> {
                 <div className="review-amount">{pool.ticker}</div>
                 <div className="review-label">Tax</div>
                 <div className="review-amount">
-                  {pool.rewards &&
-                    (pool.rewards.ratio[0] * 100) / pool.rewards.ratio[1]}%
+                  {pool.rewards && (pool.rewards.ratio[0] * 100) / pool.rewards.ratio[1]}%
                 </div>
                 <div className="review-label">Homepage</div>
                 <div className="review-amount">{pool.homepage}</div>
@@ -97,10 +96,10 @@ class ConfirmTransactionDialogClass extends Component<Props, {}> {
           <a
             className="review-cancel"
             onClick={cancelTransaction}
-            ref={element => {
+            ref={(element) => {
               this.cancelTx = element
             }}
-            onKeyDown={e => {
+            onKeyDown={(e) => {
               e.key === 'Enter' && (e.target as HTMLAnchorElement).click()
             }}
           >
@@ -117,12 +116,12 @@ class ConfirmTransactionDialogClass extends Component<Props, {}> {
 }
 
 export default connect(
-  state => ({
+  (state) => ({
     sendAddress: state.sendAddress.fieldValue,
     summary: state.sendTransactionSummary,
     rawTransactionOpen: state.rawTransactionOpen,
     stakePools: state.shelleyDelegation.selectedPools,
-    txConfirmType: state.txConfirmType
+    txConfirmType: state.txConfirmType,
   }),
   actions
 )(ConfirmTransactionDialogClass)

--- a/app/frontend/components/pages/sendAda/confirmTransactionDialog.tsx
+++ b/app/frontend/components/pages/sendAda/confirmTransactionDialog.tsx
@@ -77,7 +77,8 @@ class ConfirmTransactionDialogClass extends Component<Props, {}> {
                 <div className="review-amount">{pool.ticker}</div>
                 <div className="review-label">Tax</div>
                 <div className="review-amount">
-                  {pool.rewards && roundNumber(pool.rewards.ratio[0] * 100) / pool.rewards.ratio[1]}%
+                  {pool.rewards && roundNumber(pool.rewards.ratio[0] * 100) / pool.rewards.ratio[1]}
+                  %
                 </div>
                 <div className="review-label">Homepage</div>
                 <div className="review-amount">{pool.homepage}</div>

--- a/app/frontend/components/pages/sendAda/sendAdaPage.tsx
+++ b/app/frontend/components/pages/sendAda/sendAdaPage.tsx
@@ -25,8 +25,8 @@ const SendFormErrorMessage = ({sendFormValidationError}) => (
   <span>{getTranslation(sendFormValidationError.code, sendFormValidationError.params)}</span>
 )
 
-const SendValidation = ({sendFormValidationError, showTxSuccess}) =>
-  showTxSuccess === 'send' ? (
+const SendValidation = ({sendFormValidationError, txSuccessTab}) =>
+  txSuccessTab === 'send' ? (
     <div className="validation-message transaction-success">Transaction successful!</div>
   ) : (
     sendFormValidationError && (
@@ -90,7 +90,7 @@ class SendAdaPage extends Component<Props> {
     conversionRates,
     sendTransactionSummary: summary,
     transactionFee,
-    showTxSuccess,
+    txSuccessTab,
   }) {
     const sendFormValidationError =
       sendAddressValidationError || sendAmountValidationError || donationAmountValidationError
@@ -192,7 +192,7 @@ class SendAdaPage extends Component<Props> {
           ) : (
             <SendValidation
               sendFormValidationError={sendFormValidationError}
-              showTxSuccess={showTxSuccess}
+              txSuccessTab={txSuccessTab}
             />
           )}
         </div>
@@ -234,7 +234,7 @@ export default connect(
     conversionRates: state.conversionRates && state.conversionRates.data,
     sendTransactionSummary: state.sendTransactionSummary,
     transactionFee: state.transactionFee,
-    showTxSuccess: state.showTxSuccess,
+    txSuccessTab: state.txSuccessTab,
   }),
   actions
 )(SendAdaPage)

--- a/app/frontend/components/pages/txHistory/transactionHistory.tsx
+++ b/app/frontend/components/pages/txHistory/transactionHistory.tsx
@@ -65,9 +65,6 @@ interface Props {
 }
 
 class TransactionHistory extends Component<Props> {
-  constructor(props) {
-    super(props)
-  }
   render({transactionHistory}) {
     return (
       <div className="transactions card">
@@ -90,33 +87,6 @@ class TransactionHistory extends Component<Props> {
     )
   }
 }
-
-// const TransactionHistory2 = ({transactionHistory}) => (
-//   <div className="transactions card">
-//     <h2 className="card-title">Transaction History</h2>
-//     {transactionHistory.length === 0 ? (
-//       <div className="transactions-empty">No transactions found</div>
-//     ) : (
-//       <ul className="transactions-content">
-//         {transactionHistory.map((transaction) => (
-//           <li key={transaction.ctbId} className="transaction-item">
-//             <div className="transaction-date">{formatDate(transaction.ctbTimeIssued)}</div>
-//             <FormattedAmount amount={transaction.effect} />
-//             <Transaction txid={transaction.ctbId} />
-//             <FormattedFee fee={transaction.fee} />
-//           </li>
-//         ))}
-//       </ul>
-//     )}
-//   </div>
-// )
-
-// export default connect(
-//   (state) => ({
-//     transactionHistory: state.transactionHistory,
-//   }),
-//   actions
-// )(TransactionHistory)
 
 export default connect(
   (state) => ({

--- a/app/frontend/helpers/roundNumber.ts
+++ b/app/frontend/helpers/roundNumber.ts
@@ -1,0 +1,6 @@
+const roundNumber = (number: number, decimals = 2) => {
+  const tenthPower = Math.pow(10, decimals)
+  return Math.round((number + Number.EPSILON) * tenthPower) / tenthPower
+}
+
+export default roundNumber

--- a/app/frontend/helpers/validators.ts
+++ b/app/frontend/helpers/validators.ts
@@ -88,6 +88,7 @@ const delegationFeeValidator = (fee, balance) => {
       params: {balance},
     }
   }
+  return null
 }
 
 const mnemonicValidator = (mnemonic) => {

--- a/app/frontend/helpers/validators.ts
+++ b/app/frontend/helpers/validators.ts
@@ -1,4 +1,5 @@
 import {isValidAddress as isValidByronAddress} from 'cardano-crypto.js'
+import {isShelleyAddress as isValidShelleyAddress} from '../wallet/shelley/helpers/addresses'
 import {ADALITE_CONFIG} from '../config'
 import {toCoins} from './adaConverters'
 import {validateMnemonic} from '../wallet/mnemonic'
@@ -6,9 +7,6 @@ import {Lovelace, Ada} from '../state'
 
 const {ADALITE_MIN_DONATION_VALUE} = ADALITE_CONFIG
 const parseToLovelace = (str): Lovelace => Math.trunc(toCoins(parseFloat(str) as Ada)) as Lovelace
-
-// TODO: real validation
-const isValidShelleyAddress = (addr) => addr.startsWith('addr1')
 
 const _sendAddressValidators = {
   byron: isValidByronAddress,

--- a/app/frontend/helpers/validators.ts
+++ b/app/frontend/helpers/validators.ts
@@ -110,7 +110,7 @@ const poolIdValidator = (poolIndex, poolId, selectedPools, validStakepools) => {
   const selectedPoolsIds = selectedPools.map((pool) => pool.pool_id)
   if (selectedPoolsIds.every((id, index) => poolId === id && index !== poolIndex)) {
     return {
-      code: 'RudundantStakePool',
+      code: 'RedundantStakePool',
     }
   }
   return null

--- a/app/frontend/state.ts
+++ b/app/frontend/state.ts
@@ -109,13 +109,14 @@ export interface State {
     stakePools?: any
   }
   delegationHistory?: any
-  validStakepools?: any
-  ticker2Id?: any
+  validStakepools?: any | null
+  ticker2Id?: any | null
   delegationValidationError?: any
   shelleyAccountInfo?: {
     delegation: any
     value: number
     counter: number
+    // eslint-disable-next-line camelcase
     last_rewards: {
       epoch: number
       reward: number

--- a/app/frontend/state.ts
+++ b/app/frontend/state.ts
@@ -10,7 +10,7 @@ export interface SendTransactionSummary {
   donation?: Lovelace
   fee: Lovelace
   plan: any
-  type?: any
+  tab?: any
 }
 
 export interface State {
@@ -122,7 +122,7 @@ export interface State {
     }
   }
   txConfirmType: string
-  showTxSuccess: string
+  txSuccessTab: string
 }
 
 const initialState: State = {
@@ -202,7 +202,7 @@ const initialState: State = {
     },
   },
   txConfirmType: '',
-  showTxSuccess: '',
+  txSuccessTab: '',
 }
 
 export {initialState}

--- a/app/frontend/translations.ts
+++ b/app/frontend/translations.ts
@@ -48,13 +48,12 @@ const translations = {
   TrezorError: ({message}) => `TrezorError: ${message}`,
   LedgerOperationError: ({message}) => `LedgerOperationError: ${message}`,
 
-  CoinAmountError: () => 'CoinAmounError: Unsupported amount of coins.',
+  CoinAmountError: () => 'CoinAmountError: Unsupported amount of coins.',
   CryptoProviderError: ({message}) => `CryptoProviderError: ${message}`,
-  NetworkError: ({message}) =>
-    `NetworkError: connection failed. Please check your network connection. ${message}`,
-  BackendDownError: () =>
-    'We are sorry. It seems that our backend is not working properly at the moment, try again in a few minutes.',
-
+  NetworkError: () =>
+    'NetworkError: Request to our servers has failed. Please check your network connection and if the problem persists, contact us.',
+  ServerError: () =>
+    'ServerError: Our servers are probably down. Please try again later and if the problem persists, contact us.',
   NodeOutOfSync: () => 'Service is temporarily unavailable, please try again in 1-2 minutes.',
 }
 

--- a/app/frontend/translations.ts
+++ b/app/frontend/translations.ts
@@ -20,7 +20,7 @@ const translations = {
   DonationInsufficientBalance: () => 'Insufficient balance for the donation.',
 
   InvalidStakepoolIdentifier: () => 'Stakepool id or ticker is invalid.',
-  RudundantStakePool: () => 'This stake pool is already chosen.',
+  RedundantStakePool: () => 'This stake pool is already chosen.',
   DelegationAccountBalanceError: () => 'Not enough funds to pay the delegation fee.',
   DelegationFeeError: () => 'Unsuccessful delegation fee calculation.',
   NonStakingConversionError: () =>

--- a/app/frontend/wallet/blockchain-explorer.ts
+++ b/app/frontend/wallet/blockchain-explorer.ts
@@ -137,7 +137,7 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
     )
     if (!response.Right) {
       debugLog(`Unexpected tx submission response: ${JSON.stringify(response)}`)
-      throw NamedError('NodeOutOfSync')
+      throw NamedError('ServerError')
     }
 
     return response.Right

--- a/app/frontend/wallet/blockchain-explorer.ts
+++ b/app/frontend/wallet/blockchain-explorer.ts
@@ -69,7 +69,8 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
         }
       }
       t.effect = effect
-      const fee = t.ctbInputSum.getCoin - t.ctbOutputSum.getCoin || parseInt(t.ctbInputSum.getCoin)
+      const fee =
+        t.ctbInputSum.getCoin - t.ctbOutputSum.getCoin || parseInt(t.ctbInputSum.getCoin, 10)
       t.fee = Math.max(fee, 0)
       // some txs from restored testnet wallets have no inputs thus fee would be negative
     }

--- a/app/frontend/wallet/byron-tx-planner.ts
+++ b/app/frontend/wallet/byron-tx-planner.ts
@@ -6,7 +6,6 @@ import {TxInputFromUtxo} from './byron/byron-transaction'
 import {ADA_DONATION_ADDRESS, TX_WITNESS_SIZE_BYTES} from './constants'
 import CborIndefiniteLengthArray from './byron/helpers/CborIndefiniteLengthArray'
 import NamedError from '../helpers/NamedError'
-import {roundWholeAdas} from '../helpers/adaConverters'
 import {Lovelace} from '../state'
 
 export function txFeeFunction(txSizeInBytes: number): Lovelace {

--- a/app/frontend/wallet/byron/byron-transaction.ts
+++ b/app/frontend/wallet/byron/byron-transaction.ts
@@ -25,7 +25,13 @@ function TxAux(inputs, outputs, attributes) {
   }
 }
 
-function TxWitness(extendedPublicKey, signature) {
+type PkWitness = {
+  extendedPublicKey: any
+  signature: any
+  encodeCBOR: any
+}
+
+function TxWitness(extendedPublicKey, signature): PkWitness {
   // default - PkWitness
   const type = 0
 
@@ -120,4 +126,12 @@ function SignedTransactionStructured(txAux, witnesses) {
   }
 }
 
-export {TxInput, TxInputFromUtxo, TxOutput, SignedTransactionStructured, TxAux, TxWitness}
+export {
+  TxInput,
+  TxInputFromUtxo,
+  TxOutput,
+  SignedTransactionStructured,
+  TxAux,
+  TxWitness,
+  PkWitness,
+}

--- a/app/frontend/wallet/byron/cardano-wallet-secret-crypto-provider.ts
+++ b/app/frontend/wallet/byron/cardano-wallet-secret-crypto-provider.ts
@@ -1,7 +1,7 @@
 import {encode} from 'borc'
 import {blake2b, sign as signMsg, derivePrivate, xpubToHdPassphrase} from 'cardano-crypto.js'
 
-import {TxWitness, SignedTransactionStructured} from './byron-transaction'
+import {TxWitness, PkWitness, SignedTransactionStructured} from './byron-transaction'
 
 import HdNode from '../helpers/hd-node'
 import {parseTxAux} from './helpers/cbor-parsers'
@@ -81,7 +81,7 @@ const CardanoWalletSecretCryptoProvider = ({
     }
   }
 
-  async function getWitness(txAuxHash, absPath) {
+  async function getWitness(txAuxHash, absPath): Promise<PkWitness> {
     const xpub = await deriveXpub(absPath)
 
     /*

--- a/app/frontend/wallet/byron/cardano-wallet-secret-crypto-provider.ts
+++ b/app/frontend/wallet/byron/cardano-wallet-secret-crypto-provider.ts
@@ -1,6 +1,7 @@
 import {encode} from 'borc'
 import {blake2b, sign as signMsg, derivePrivate, xpubToHdPassphrase} from 'cardano-crypto.js'
 
+// eslint-disable-next-line no-unused-vars
 import {TxWitness, PkWitness, SignedTransactionStructured} from './byron-transaction'
 
 import HdNode from '../helpers/hd-node'
@@ -8,6 +9,7 @@ import {parseTxAux} from './helpers/cbor-parsers'
 import NamedError from '../../helpers/NamedError'
 import CachedDeriveXpubFactory from '../helpers/CachedDeriveXpubFactory'
 
+// eslint-disable-next-line no-unused-vars
 import {DerivationScheme} from '../helpers/derivation-schemes'
 
 const CardanoWalletSecretCryptoProvider = ({

--- a/app/frontend/wallet/byron/cardano-wallet-secret-crypto-provider.ts
+++ b/app/frontend/wallet/byron/cardano-wallet-secret-crypto-provider.ts
@@ -8,7 +8,6 @@ import {parseTxAux} from './helpers/cbor-parsers'
 import NamedError from '../../helpers/NamedError'
 import CachedDeriveXpubFactory from '../helpers/CachedDeriveXpubFactory'
 
-// eslint-disable-next-line no-unused-vars
 import {DerivationScheme} from '../helpers/derivation-schemes'
 
 const CardanoWalletSecretCryptoProvider = ({

--- a/app/frontend/wallet/byron/cardano-wallet-secret-crypto-provider.ts
+++ b/app/frontend/wallet/byron/cardano-wallet-secret-crypto-provider.ts
@@ -8,6 +8,7 @@ import {parseTxAux} from './helpers/cbor-parsers'
 import NamedError from '../../helpers/NamedError'
 import CachedDeriveXpubFactory from '../helpers/CachedDeriveXpubFactory'
 
+// eslint-disable-next-line no-unused-vars
 import {DerivationScheme} from '../helpers/derivation-schemes'
 
 const CardanoWalletSecretCryptoProvider = ({
@@ -101,7 +102,7 @@ const CardanoWalletSecretCryptoProvider = ({
   async function signTxGetStructured(txAux, addressToAbsPathMapper) {
     const txHash = txAux.getId()
     const witnesses = await Promise.all(
-      txAux.inputs.map(async (input) => {
+      txAux.inputs.map((input) => {
         const absPath = addressToAbsPathMapper(input.utxo.address)
         return getWitness(txHash, absPath)
       })

--- a/app/frontend/wallet/cardano-wallet.ts
+++ b/app/frontend/wallet/cardano-wallet.ts
@@ -28,28 +28,6 @@ type UTxO = {
   outputIndex: number
 }
 
-// type AccountInput = {
-//   address: string
-//   coins: Lovelace
-//   counter: number
-//   type: string
-// }
-
-// export type Input = UTxO | any
-
-// export type Output = {
-//   address: string
-//   coins: Lovelace
-// }
-
-// export interface TxPlan {
-//   inputs: Array<Input>
-//   outputs: Array<Output>
-//   change: Output | null
-//   cert?: any
-//   fee: Lovelace
-// }
-
 interface NoTxPlan {
   estimatedFee: Lovelace
 }
@@ -158,12 +136,7 @@ const CardanoWallet = (options) => {
 
   async function submitTx(signedTx) {
     const {txBody, txHash} = signedTx
-    const response = await blockchainExplorer.submitTxRaw(txHash, txBody).catch((e) => {
-      debugLog(e)
-      throw e
-    })
-
-    return response
+    return await blockchainExplorer.submitTxRaw(txHash, txBody)
   }
 
   function getWalletSecretDef() {
@@ -262,12 +235,8 @@ const CardanoWallet = (options) => {
   }
 
   async function getUTxOs(): Promise<Array<UTxO>> {
-    try {
-      const addresses = await myAddresses.discoverAllAddresses()
-      return await blockchainExplorer.fetchUnspentTxOutputs(addresses)
-    } catch (e) {
-      throw NamedError('NetworkError')
-    }
+    const addresses = await myAddresses.discoverAllAddresses()
+    return await blockchainExplorer.fetchUnspentTxOutputs(addresses)
   }
 
   async function getVisibleAddresses() {

--- a/app/frontend/wallet/cardano-wallet.ts
+++ b/app/frontend/wallet/cardano-wallet.ts
@@ -131,9 +131,9 @@ const CardanoWallet = (options) => {
     return isHwWallet ? (cryptoProvider as any).getHwWalletName() : undefined
   }
 
-  async function submitTx(signedTx) {
+  function submitTx(signedTx): Promise<any> {
     const {txBody, txHash} = signedTx
-    return await blockchainExplorer.submitTxRaw(txHash, txBody)
+    return blockchainExplorer.submitTxRaw(txHash, txBody)
   }
 
   function getWalletSecretDef() {
@@ -202,10 +202,6 @@ const CardanoWallet = (options) => {
     return blockchainExplorer.getTxHistory(addresses)
   }
 
-  function getAccountInfo() {
-    return undefined
-  }
-
   function getValidStakepools() {
     return {validStakepools: null, ticker2Id: null}
   }
@@ -233,10 +229,10 @@ const CardanoWallet = (options) => {
 
   async function getUTxOs(): Promise<Array<UTxO>> {
     const addresses = await myAddresses.discoverAllAddresses()
-    return await blockchainExplorer.fetchUnspentTxOutputs(addresses)
+    return blockchainExplorer.fetchUnspentTxOutputs(addresses)
   }
 
-  function getVisibleAddresses() {
+  function getVisibleAddresses(): Promise<any> {
     return myAddresses.getVisibleAddresses()
   }
 
@@ -272,7 +268,6 @@ const CardanoWallet = (options) => {
     verifyAddress,
     fetchTxInfo,
     generateNewSeeds,
-    getAccountInfo,
     getValidStakepools,
     getWalletInfo,
     getMaxNonStakingAmount,

--- a/app/frontend/wallet/cardano-wallet.ts
+++ b/app/frontend/wallet/cardano-wallet.ts
@@ -10,7 +10,7 @@ import NamedError from '../helpers/NamedError'
 import {Lovelace} from '../state'
 import {computeRequiredTxFee, selectMinimalTxPlan, isUtxoProfitable} from './byron-tx-planner'
 import {MaxAmountCalculator} from './max-amount-calculator'
-// eslint-disable-next-line no-unused-vars
+
 import {TxPlan} from './shelley/build-transaction'
 
 const {
@@ -23,10 +23,6 @@ type UTxO = {
   address: string
   coins: Lovelace
   outputIndex: number
-}
-
-interface NoTxPlan {
-  estimatedFee: Lovelace
 }
 
 function prepareTxAux(plan: TxPlan) {

--- a/app/frontend/wallet/cardano-wallet.ts
+++ b/app/frontend/wallet/cardano-wallet.ts
@@ -10,7 +10,7 @@ import NamedError from '../helpers/NamedError'
 import {Lovelace} from '../state'
 import {computeRequiredTxFee, selectMinimalTxPlan, isUtxoProfitable} from './byron-tx-planner'
 import {MaxAmountCalculator} from './max-amount-calculator'
-
+// eslint-disable-next-line no-unused-vars
 import {TxPlan} from './shelley/build-transaction'
 
 const {
@@ -199,11 +199,11 @@ const CardanoWallet = (options) => {
   }
 
   function getValidStakepools() {
-    return {validStakepools: null, ticker2Id: null}
+    throw NamedError('UnsupportedOperationError', 'Incompatible operation with Byron wallet')
   }
 
   function getMaxNonStakingAmount(address) {
-    return undefined
+    throw NamedError('UnsupportedOperationError', 'Incompatible operation with Byron wallet')
   }
 
   async function fetchTxInfo(txHash) {

--- a/app/frontend/wallet/cardano-wallet.ts
+++ b/app/frontend/wallet/cardano-wallet.ts
@@ -1,7 +1,5 @@
 import debugLog from '../helpers/debugLog'
-
 import {TxInputFromUtxo, TxOutput, TxAux} from './byron/byron-transaction'
-
 import AddressManager from './address-manager'
 import {ByronAddressProvider} from './byron/byron-address-provider'
 import BlockchainExplorer from './blockchain-explorer'
@@ -10,10 +8,9 @@ import {MAX_INT32} from './constants'
 import shuffleArray from './helpers/shuffleArray'
 import NamedError from '../helpers/NamedError'
 import {Lovelace} from '../state'
-
 import {computeRequiredTxFee, selectMinimalTxPlan, isUtxoProfitable} from './byron-tx-planner'
-
 import {MaxAmountCalculator} from './max-amount-calculator'
+// eslint-disable-next-line no-unused-vars
 import {TxPlan} from './shelley/build-transaction'
 
 const {
@@ -205,12 +202,12 @@ const CardanoWallet = (options) => {
     return blockchainExplorer.getTxHistory(addresses)
   }
 
-  async function getAccountInfo() {
+  function getAccountInfo() {
     return undefined
   }
 
-  async function getValidStakepools() {
-    return undefined
+  function getValidStakepools() {
+    return {validStakepools: null, ticker2Id: null}
   }
 
   function getMaxNonStakingAmount(address) {
@@ -239,7 +236,7 @@ const CardanoWallet = (options) => {
     return await blockchainExplorer.fetchUnspentTxOutputs(addresses)
   }
 
-  async function getVisibleAddresses() {
+  function getVisibleAddresses() {
     return myAddresses.getVisibleAddresses()
   }
 

--- a/app/frontend/wallet/helpers/request.ts
+++ b/app/frontend/wallet/helpers/request.ts
@@ -19,7 +19,7 @@ const request = async function request(url, method = 'GET', body = null, headers
 
   if (response.status === 429) {
     await sleep(DELAY_AFTER_TOO_MANY_REQUESTS)
-    return await request(url, method, body, headers)
+    return request(url, method, body, headers)
   } else if (response.status === 503) {
     throw NamedError('NodeOutOfSync')
   } else if (response.status >= 500) {

--- a/app/frontend/wallet/helpers/request.ts
+++ b/app/frontend/wallet/helpers/request.ts
@@ -1,11 +1,6 @@
 import NamedError from '../../helpers/NamedError'
-import debugLog from '../../helpers/debugLog'
 import sleep from '../../helpers/sleep'
 import {DELAY_AFTER_TOO_MANY_REQUESTS} from '../constants'
-
-const errors = {
-  503: 'NodeOutOfSync',
-}
 
 const request = async function request(url, method = 'GET', body = null, headers = {}) {
   let requestParams = {
@@ -17,54 +12,32 @@ const request = async function request(url, method = 'GET', body = null, headers
   if (method.toUpperCase() !== 'GET') {
     requestParams = Object.assign({}, requestParams, {body})
   }
-  try {
-    const response = await fetch(url, requestParams as any).catch((e) => {
-      throw NamedError('NetworkError', `${method} ${url} returns error: ${e}`)
-    })
-    if (!response) throw NamedError('NetworkError')
-    if (response.status === 429) {
-      await sleep(DELAY_AFTER_TOO_MANY_REQUESTS)
-      return await request(url, method, body, headers)
-    } else if (response.status === 503) {
-      throw NamedError('NodeOutOfSync')
-    } else if (response.status >= 500) {
-      throw NamedError('BackendDownError')
-    } else if (response.status >= 400) {
-      throw NamedError(
-        'NetworkError',
-        `${method} ${url} returns error: ${response.status} on payload: ${JSON.stringify(
-          requestParams
-        )}`
-      )
-    }
-    return response.json()
-  } catch (e) {
-    debugLog(e)
-    throw e
-  }
+  const response = await fetch(url, requestParams).catch((e) => {
+    throw NamedError('NetworkError', `${method} ${url} has failed with the following error: ${e}`)
+  })
+  if (!response) throw NamedError('NetworkError', `No response from ${method} ${url}`)
 
-  // try {
-  //   const response = await fetch(url, requestParams as any) // TS does not like credentials
-  //   if (!response) throw NamedError('NetworkError')
-  //   if (response.status === 429) {
-  //     await sleep(DELAY_AFTER_TOO_MANY_REQUESTS)
-  //     return await request(url, method, body, headers)
-  //   } else if (response.status === 503) {
-  //     throw NamedError('NodeOutOfSync')
-  //   } else if (response.status >= 400) {
-  //     throw NamedError(
-  //       'NetworkError',
-  //       `${url} returns error: ${response.status} on payload: ${JSON.stringify(requestParams)}`
-  //     )
-  //   }
-  //   return response.json()
-  // } catch (e) {
-  //   debugLog(e)
-  //   throw NamedError(
-  //     e.name === 'NodeOutOfSync' ? e.name : 'NetworkError',
-  //     `${method} ${url} returns error: ${e}`
-  //   )
-  // }
+  if (response.status === 429) {
+    await sleep(DELAY_AFTER_TOO_MANY_REQUESTS)
+    return await request(url, method, body, headers)
+  } else if (response.status === 503) {
+    throw NamedError('NodeOutOfSync')
+  } else if (response.status >= 500) {
+    throw NamedError(
+      'ServerError',
+      `${method} ${url} returns error: ${response.status} on payload: ${JSON.stringify(
+        requestParams
+      )}`
+    )
+  } else if (response.status >= 400) {
+    throw NamedError(
+      'NetworkError',
+      `${method} ${url} returns error: ${response.status} on payload: ${JSON.stringify(
+        requestParams
+      )}`
+    )
+  }
+  return response.json()
 }
 
 export default request

--- a/app/frontend/wallet/shelley-wallet.ts
+++ b/app/frontend/wallet/shelley-wallet.ts
@@ -155,10 +155,11 @@ const ShelleyBlockchainExplorer = (config) => {
   // TODO: move to separate file
   const be = BlockchainExplorer(config)
 
-  const fixAddress = (address) => (isShelleyAddress(address) ? bechAddressToHex(address) : address)
-  const fix = (addresses: Array<string>): Array<string> => {
-    return addresses.map(fixAddress)
-  } // TODO: rename to better name than "fix"
+  const shelleyToHex = (address) =>
+    isShelleyAddress(address) ? bechAddressToHex(address) : address
+
+  const shelleyAddressesToHex = (addresses: Array<string>): Array<string> =>
+    addresses.map(shelleyToHex)
 
   async function getAccountInfo(accountPubkeyHex) {
     const url = `${ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL}/api/v2/account/info`
@@ -201,18 +202,15 @@ const ShelleyBlockchainExplorer = (config) => {
   }
 
   return {
-    getTxHistory: (addresses) => {
-      return be.getTxHistory(fix(addresses))
-    },
+    getTxHistory: (addresses) => be.getTxHistory(shelleyAddressesToHex(addresses)),
     fetchTxRaw: be.fetchTxRaw,
-    fetchUnspentTxOutputs: (addresses) => be.fetchUnspentTxOutputs(fix(addresses)),
-    isSomeAddressUsed: (addresses) => be.isSomeAddressUsed(fix(addresses)),
+    fetchUnspentTxOutputs: (addresses) =>
+      be.fetchUnspentTxOutputs(shelleyAddressesToHex(addresses)),
+    isSomeAddressUsed: (addresses) => be.isSomeAddressUsed(shelleyAddressesToHex(addresses)),
     submitTxRaw: be.submitTxRaw,
-    getBalance: (addresses) => {
-      return be.getBalance(fix(addresses))
-    },
+    getBalance: (addresses) => be.getBalance(shelleyAddressesToHex(addresses)),
     fetchTxInfo: be.fetchTxInfo,
-    filterUsedAddresses: (addresses) => be.filterUsedAddresses(fix(addresses)),
+    filterUsedAddresses: (addresses) => be.filterUsedAddresses(shelleyAddressesToHex(addresses)),
     getAccountInfo,
     getValidStakepools,
   }

--- a/app/frontend/wallet/shelley-wallet.ts
+++ b/app/frontend/wallet/shelley-wallet.ts
@@ -278,21 +278,21 @@ const ShelleyWallet = ({config, randomInputSeed, randomChangeSeed, cryptoProvide
 
   async function getMaxSendableAmount(address, hasDonation, donationAmount, donationType) {
     // TODO: why do we need hasDonation?
-    const utxos = (await getUTxOs()).filter(isUtxoProfitable)
+    const utxos = (await getUtxos()).filter(isUtxoProfitable)
     return _getMaxSendableAmount(utxos, address, hasDonation, donationAmount, donationType)
   }
 
   async function getMaxDonationAmount(address, sendAmount: Lovelace) {
-    const utxos = (await getUTxOs()).filter(isUtxoProfitable)
+    const utxos = (await getUtxos()).filter(isUtxoProfitable)
     return _getMaxDonationAmount(utxos, address, sendAmount)
   }
 
   async function getMaxNonStakingAmount(address) {
-    const utxos = (await getUTxOs()).filter(({address}) => !isGroup(address))
+    const utxos = (await getUtxos()).filter(({address}) => !isGroup(address))
     return _getMaxSendableAmount(utxos, address, false, 0, false)
   }
 
-  type utXoArgs = {
+  type utxoArgs = {
     address?: string
     donationAmount?: Lovelace
     coins?: Lovelace
@@ -300,10 +300,10 @@ const ShelleyWallet = ({config, randomInputSeed, randomChangeSeed, cryptoProvide
     txType?: string
   }
 
-  const uTxOTxPlanner = async (args: utXoArgs, accountAddress: string) => {
+  const utxoTxPlanner = async (args: utxoArgs, accountAddress: string) => {
     const {address, coins, donationAmount, pools, txType} = args
     const changeAddress = await getChangeAddress()
-    const availableUtxos = await getUTxOs()
+    const availableUtxos = await getUtxos()
     const nonStakingUtxos = availableUtxos.filter(({address}) => !isGroup(address))
     const groupAddressUtxos = availableUtxos.filter(({address}) => isGroup(address))
     const randomGenerator = PseudoRandom(seeds.randomInputSeed)
@@ -348,12 +348,12 @@ const ShelleyWallet = ({config, randomInputSeed, randomChangeSeed, cryptoProvide
     return plan
   }
 
-  async function getTxPlan(args: utXoArgs | accountArgs) {
+  async function getTxPlan(args: utxoArgs | accountArgs) {
     const accountAddress = await myAddresses.accountAddrManager._deriveAddress(accountIndex)
     const txPlanners = {
-      sendAda: uTxOTxPlanner,
-      convert: uTxOTxPlanner,
-      delegate: uTxOTxPlanner,
+      sendAda: utxoTxPlanner,
+      convert: utxoTxPlanner,
+      delegate: utxoTxPlanner,
       redeem: accountTxPlanner,
     }
     return await txPlanners[args.txType](args, accountAddress)
@@ -426,7 +426,7 @@ const ShelleyWallet = ({config, randomInputSeed, randomChangeSeed, cryptoProvide
     return myAddresses.getChangeAddress(seeds.randomChangeSeed)
   }
 
-  async function getUTxOs(): Promise<Array<any>> {
+  async function getUtxos(): Promise<Array<any>> {
     try {
       const {legacy, group, single} = await myAddresses.discoverAllAddresses()
       const groupUtxos = await blockchainExplorer.fetchUnspentTxOutputs(group)

--- a/app/frontend/wallet/shelley-wallet.ts
+++ b/app/frontend/wallet/shelley-wallet.ts
@@ -249,11 +249,7 @@ const ShelleyWallet = ({config, randomInputSeed, randomChangeSeed, cryptoProvide
 
   async function submitTx(signedTx) {
     const {transaction, fragmentId} = signedTx
-    const response = await blockchainExplorer.submitTxRaw(fragmentId, transaction).catch((e) => {
-      throw e
-    })
-
-    return response
+    return await blockchainExplorer.submitTxRaw(fragmentId, transaction)
   }
 
   function getWalletSecretDef() {

--- a/app/frontend/wallet/shelley-wallet.ts
+++ b/app/frontend/wallet/shelley-wallet.ts
@@ -305,6 +305,7 @@ const ShelleyWallet = ({config, randomInputSeed, randomChangeSeed, cryptoProvide
     const nonStakingUtxos = availableUtxos.filter(({address}) => !isGroup(address))
     const groupAddressUtxos = availableUtxos.filter(({address}) => isGroup(address))
     const randomGenerator = PseudoRandom(seeds.randomInputSeed)
+    // we shuffle non-staking utxos separately since we want them to be spend first
     const shuffledUtxos =
       txType === 'convert'
         ? shuffleArray(nonStakingUtxos, randomGenerator)

--- a/app/frontend/wallet/shelley-wallet.ts
+++ b/app/frontend/wallet/shelley-wallet.ts
@@ -249,9 +249,9 @@ const ShelleyWallet = ({config, randomInputSeed, randomChangeSeed, cryptoProvide
     return isHwWallet ? (cryptoProvider as any).getHwWalletName() : undefined
   }
 
-  async function submitTx(signedTx) {
+  function submitTx(signedTx): Promise<any> {
     const {transaction, fragmentId} = signedTx
-    return await blockchainExplorer.submitTxRaw(fragmentId, transaction)
+    return blockchainExplorer.submitTxRaw(fragmentId, transaction)
   }
 
   function getWalletSecretDef() {
@@ -389,7 +389,7 @@ const ShelleyWallet = ({config, randomInputSeed, randomChangeSeed, cryptoProvide
     }
   }
 
-  async function getHistory() {
+  async function getHistory(): Promise<any> {
     // TODO: refactor to getTxHistory? or add delegation history or rewards history
     const {legacy, group, single, account} = await myAddresses.discoverAllAddresses()
     return blockchainExplorer.getTxHistory([...single, ...group, ...legacy, account])
@@ -414,7 +414,7 @@ const ShelleyWallet = ({config, randomInputSeed, randomChangeSeed, cryptoProvide
     }
   }
 
-  function getValidStakepools() {
+  function getValidStakepools(): Promise<any> {
     return blockchainExplorer.getValidStakepools()
   }
 

--- a/app/frontend/wallet/shelley-wallet.ts
+++ b/app/frontend/wallet/shelley-wallet.ts
@@ -237,6 +237,8 @@ const ShelleyWallet = ({config, randomInputSeed, randomChangeSeed, cryptoProvide
 
   const blockchainExplorer = ShelleyBlockchainExplorer(config)
 
+  const accountIndex = 0
+
   const myAddresses = MyAddresses({
     accountIndex: 0,
     cryptoProvider,
@@ -299,56 +301,71 @@ const ShelleyWallet = ({config, randomInputSeed, randomChangeSeed, cryptoProvide
     return _getMaxSendableAmount(utxos, address, false, 0, false)
   }
 
-  const uTxOTxPlanner = async (args, txType) => {
-    const {address, coins, donationAmount, pools} = args
-    const utxoFilters = {
-      delegation: isShelleyUtxo,
-      nonStakingConversion: isUtxoNonStaking,
-      utxo: () => true,
-    }
-    const utxoFilter = utxoFilters[txType]
-    const accountAddress = await myAddresses.accountAddrManager._deriveAddress(0)
-    const availableUtxos = (await getUTxOs()).filter(utxoFilter)
+  type utXoArgs = {
+    address?: string
+    donationAmount?: Lovelace
+    coins?: Lovelace
+    pools?: any
+    txType?: string
+  }
+
+  const uTxOTxPlanner = async (args: utXoArgs, accountAddress: string) => {
+    const {address, coins, donationAmount, pools, txType} = args
     const changeAddress = await getChangeAddress()
-    // we do it pseudorandomly to guarantee fee computation stability
+    const availableUtxos = await getUTxOs()
+    const nonStakingUtxos = availableUtxos.filter(({address}) => !isGroup(address))
+    const groupAddressUtxos = availableUtxos.filter(({address}) => isGroup(address))
     const randomGenerator = PseudoRandom(seeds.randomInputSeed)
-    const shuffledUtxos = shuffleArray(availableUtxos, randomGenerator)
+    const shuffledUtxos =
+      txType === 'convert'
+        ? shuffleArray(nonStakingUtxos, randomGenerator)
+        : [
+          ...shuffleArray(nonStakingUtxos, randomGenerator),
+          ...shuffleArray(groupAddressUtxos, randomGenerator),
+        ]
     const plan = selectMinimalTxPlan(
       cryptoProvider.network.chainConfig,
       shuffledUtxos,
-      address,
-      donationAmount,
       changeAddress,
+      address,
       coins,
+      donationAmount,
       pools,
       accountAddress
     )
     return plan
   }
 
-  const accountTxPlanner = async (args, txType) => {
-    const srcAddress = await myAddresses.accountAddrManager._deriveAddress(0)
-    const {dstAddress, amount, pools, accountCounter, accountBalance} = args
+  type accountArgs = {
+    address: string
+    coins: Lovelace
+    accountBalance: Lovelace
+    counter: number
+    txType: string
+  }
+
+  const accountTxPlanner = async (args: accountArgs, accountAddress: string) => {
+    const {address, coins, accountBalance, counter} = args
     const plan = computeAccountTxPlan(
       cryptoProvider.network.chainConfig,
-      dstAddress,
-      amount,
-      srcAddress,
-      pools,
-      accountCounter,
+      coins,
+      address,
+      accountAddress,
+      counter,
       accountBalance
     )
     return plan
   }
 
-  async function getTxPlan(args, txType) {
-    const txPlaner = {
-      utxo: uTxOTxPlanner,
-      nonStakingConversion: uTxOTxPlanner,
-      delegation: uTxOTxPlanner,
-      account: accountTxPlanner,
+  async function getTxPlan(args: utXoArgs | accountArgs) {
+    const accountAddress = await myAddresses.accountAddrManager._deriveAddress(accountIndex)
+    const txPlanners = {
+      sendAda: uTxOTxPlanner,
+      convert: uTxOTxPlanner,
+      delegate: uTxOTxPlanner,
+      redeem: accountTxPlanner,
     }
-    const plan = txPlaner[txType](args, txType)
+    const plan = txPlanners[args.txType](args, accountAddress)
     return plan
   }
 

--- a/app/frontend/wallet/shelley-wallet.ts
+++ b/app/frontend/wallet/shelley-wallet.ts
@@ -17,7 +17,7 @@ import {selectMinimalTxPlan, computeAccountTxPlan} from './shelley/build-transac
 import shuffleArray from './helpers/shuffleArray'
 import {MaxAmountCalculator} from './max-amount-calculator'
 import {ByronAddressProvider} from './byron/byron-address-provider'
-import {isShelleyAddress, bechAddressToHex, isGroup, isSingle} from './shelley/helpers/addresses'
+import {isShelleyAddress, bechAddressToHex, isGroup} from './shelley/helpers/addresses'
 import request from './helpers/request'
 import {ADALITE_CONFIG} from '../config'
 
@@ -193,7 +193,9 @@ const ShelleyBlockchainExplorer = (config) => {
       throw NamedError('NetworkError', e.message)
     }
     const poolArray = JSON.parse(await response.text())
+    // eslint-disable-next-line no-sequences
     const validStakepools = poolArray.reduce((dict, el) => ((dict[el.pool_id] = {...el}), dict), {})
+    // eslint-disable-next-line no-sequences
     const ticker2Id = poolArray.reduce((dict, el) => ((dict[el.ticker] = el.pool_id), dict), {})
     return {validStakepools, ticker2Id}
   }
@@ -333,7 +335,7 @@ const ShelleyWallet = ({config, randomInputSeed, randomChangeSeed, cryptoProvide
     txType: string
   }
 
-  const accountTxPlanner = async (args: accountArgs, accountAddress: string) => {
+  const accountTxPlanner = (args: accountArgs, accountAddress: string) => {
     const {address, coins, accountBalance, counter} = args
     const plan = computeAccountTxPlan(
       cryptoProvider.network.chainConfig,
@@ -412,7 +414,7 @@ const ShelleyWallet = ({config, randomInputSeed, randomChangeSeed, cryptoProvide
     }
   }
 
-  async function getValidStakepools() {
+  function getValidStakepools() {
     return blockchainExplorer.getValidStakepools()
   }
 
@@ -420,7 +422,7 @@ const ShelleyWallet = ({config, randomInputSeed, randomChangeSeed, cryptoProvide
     return await blockchainExplorer.fetchTxInfo(txHash)
   }
 
-  async function getChangeAddress() {
+  function getChangeAddress() {
     return myAddresses.getChangeAddress(seeds.randomChangeSeed)
   }
 
@@ -444,10 +446,11 @@ const ShelleyWallet = ({config, randomInputSeed, randomChangeSeed, cryptoProvide
   async function getVisibleAddresses() {
     const single = await myAddresses.singleExtManager.discoverAddressesWithMeta()
     const group = await myAddresses.groupExtManager.discoverAddressesWithMeta()
-    return [...group, ...single] //filterUnusedEndAddresses(addresses, config.ADALITE_DEFAULT_ADDRESS_COUNT)
+    return [...group, ...single]
+    //filterUnusedEndAddresses(addresses, config.ADALITE_DEFAULT_ADDRESS_COUNT)
   }
 
-  async function verifyAddress(addr: string) {
+  function verifyAddress(addr: string) {
     throw NamedError('UnsupportedOperationError', 'unsupported operation: verifyAddress')
   }
 

--- a/app/frontend/wallet/shelley/build-transaction.ts
+++ b/app/frontend/wallet/shelley/build-transaction.ts
@@ -1,10 +1,7 @@
 import {computeRequiredTxFee} from './helpers/chainlib-wrapper'
-import _ from 'lodash'
-// import {Input, Output, TxPlan} from '../cardano-wallet'
+// import _ from 'lodash'
 import {Lovelace} from '../../state'
-
 import NamedError from '../../helpers/NamedError'
-
 import {ADA_DONATION_ADDRESS} from '../constants'
 
 type UTxOInput = {

--- a/app/frontend/wallet/shelley/build-transaction.ts
+++ b/app/frontend/wallet/shelley/build-transaction.ts
@@ -1,5 +1,4 @@
 import {computeRequiredTxFee} from './helpers/chainlib-wrapper'
-// import _ from 'lodash'
 import {Lovelace} from '../../state'
 import NamedError from '../../helpers/NamedError'
 import {ADA_DONATION_ADDRESS} from '../constants'
@@ -30,8 +29,9 @@ type Delegation = {
 }
 
 export type Cert = {
+  type: string
   pools: Array<Delegation>
-  address: string
+  accountAddress: string
 }
 
 export interface TxPlan {
@@ -49,7 +49,7 @@ export function computeTxPlan(
   inputs: Array<Input>,
   outputs: Array<Output>,
   possibleChange?: Output,
-  cert?: any // TODO: cert
+  cert?: Cert
 ): TxPlan | null {
   const totalInput = inputs.reduce((acc, input) => acc + input.coins, 0)
   const totalOutput = outputs.reduce((acc, output) => acc + output.coins, 0)
@@ -112,7 +112,7 @@ export function selectMinimalTxPlan(
     ? {
       type: 'certificate_stake_delegation',
       pools,
-      accountAddress, // TODO: address: accountAddress
+      accountAddress,
     }
     : null
   const outputs = coins ? [{address, coins}] : []

--- a/app/frontend/wallet/shelley/helpers/addresses.ts
+++ b/app/frontend/wallet/shelley/helpers/addresses.ts
@@ -67,10 +67,6 @@ export const groupAddressFromXpub = (spendXpub: Xpub, stakeXpub: Xpub, network: 
   return _addr.to_string('addr')
 }
 
-export const isShelleyAddress = (address: string): boolean => {
-  return address.startsWith('addr1')
-}
-
 const getAddressKind = (address: string) => {
   // separate get_kind method since chain-libs throw error with legacy
   // addresses TODO: refactor
@@ -82,6 +78,16 @@ const getAddressKind = (address: string) => {
   } catch (e) {
     return undefined
   }
+}
+
+export const isShelleyAddress = (address: string): boolean => {
+  if (!address.startsWith('addr1')) return false
+  const addressKind = getAddressKind(address)
+  return (
+    addressKind === AddressKind.Group ||
+    addressKind === AddressKind.Single ||
+    addressKind === AddressKind.Account
+  )
 }
 
 export const isGroup = (address: string): boolean => {

--- a/app/frontend/wallet/shelley/helpers/addresses.ts
+++ b/app/frontend/wallet/shelley/helpers/addresses.ts
@@ -1,5 +1,5 @@
 import * as lib from '@emurgo/js-chain-libs'
-import {isValidAddress as isValidByronAddress} from 'cardano-crypto.js'
+// import {isValidAddress as isValidByronAddress} from 'cardano-crypto.js'
 import bech32 from './bech32'
 const {Address, Account, AddressDiscrimination, PublicKey, AddressKind} = lib
 

--- a/app/frontend/wallet/shelley/helpers/addresses.ts
+++ b/app/frontend/wallet/shelley/helpers/addresses.ts
@@ -1,5 +1,4 @@
 import * as lib from '@emurgo/js-chain-libs'
-// import {isValidAddress as isValidByronAddress} from 'cardano-crypto.js'
 import bech32 from './bech32'
 const {Address, Account, AddressDiscrimination, PublicKey, AddressKind} = lib
 

--- a/app/frontend/wallet/shelley/helpers/chainlib-wrapper.ts
+++ b/app/frontend/wallet/shelley/helpers/chainlib-wrapper.ts
@@ -1,5 +1,4 @@
 import * as lib from '@emurgo/js-chain-libs'
-// import * as _ from 'lodash'
 import {Buffer} from 'buffer'
 
 // Note(ppershing): cannot be imported directly via destructuring :-(

--- a/app/frontend/wallet/shelley/helpers/chainlib-wrapper.ts
+++ b/app/frontend/wallet/shelley/helpers/chainlib-wrapper.ts
@@ -84,7 +84,9 @@ export const computeRequiredTxFee = (chainConfig: ChainConfig) => (
 
 const _buildIOs = (inputs, outputs, payload) => {
   const inputBuilders = {
-    account: ({address, value}) =>
+    account: (
+      {address, value}
+    ) =>
       Input.from_account(
         Account.from_address(Address.from_string(address)),
         Value.from_str(value.toString())

--- a/app/frontend/wallet/shelley/helpers/chainlib-wrapper.ts
+++ b/app/frontend/wallet/shelley/helpers/chainlib-wrapper.ts
@@ -1,5 +1,5 @@
 import * as lib from '@emurgo/js-chain-libs'
-import * as _ from 'lodash'
+// import * as _ from 'lodash'
 import {Buffer} from 'buffer'
 
 // Note(ppershing): cannot be imported directly via destructuring :-(
@@ -32,7 +32,6 @@ const {
   TransactionSignDataHash,
   UtxoPointer,
   FragmentId,
-  Bip32PrivateKey,
   LegacyDaedalusPrivateKey,
 } = lib
 
@@ -241,13 +240,13 @@ interface BuildTransactionParams {
   chainConfig: ChainConfig
 }
 
-export const verifyFee = ({inputs, outputs, cert, chainConfig}) => {
-  const amountIn = _.sumBy(inputs, (inp) => inp.value)
-  const amountOut = _.sumBy(outputs, (out) => out.value)
-  const fee = computeRequiredTxFee(chainConfig)(inputs, outputs, cert)
+// export const verifyFee = ({inputs, outputs, cert, chainConfig}) => {
+//   const amountIn = _.sumBy(inputs, (inp) => inp.value)
+//   const amountOut = _.sumBy(outputs, (out) => out.value)
+//   const fee = computeRequiredTxFee(chainConfig)(inputs, outputs, cert)
 
-  // if (amountIn !== amountOut + fee) throw new Error('Unbalanced tx')
-}
+//   if (amountIn !== amountOut + fee) throw new Error('Unbalanced tx')
+// }
 
 export const buildTransaction = ({inputs, outputs, cert, chainConfig}: BuildTransactionParams) => {
   const {certificate, payloadAuth} = _getCert(cert)
@@ -272,7 +271,7 @@ export const buildTransaction = ({inputs, outputs, cert, chainConfig}: BuildTran
 
   const message = Fragment.from_transaction(signedTx)
 
-  verifyFee({inputs, outputs, cert, chainConfig})
+  // verifyFee({inputs, outputs, cert, chainConfig})
 
   return {
     transaction: buf2hex(message.as_bytes()),

--- a/app/frontend/wallet/shelley/helpers/chainlib-wrapper.ts
+++ b/app/frontend/wallet/shelley/helpers/chainlib-wrapper.ts
@@ -84,9 +84,7 @@ export const computeRequiredTxFee = (chainConfig: ChainConfig) => (
 
 const _buildIOs = (inputs, outputs, payload) => {
   const inputBuilders = {
-    account: (
-      {address, value}
-    ) =>
+    account: ({address, value}) =>
       Input.from_account(
         Account.from_address(Address.from_string(address)),
         Value.from_str(value.toString())

--- a/app/frontend/wallet/shelley/shelley-address-provider.ts
+++ b/app/frontend/wallet/shelley/shelley-address-provider.ts
@@ -25,12 +25,6 @@ const shelleyStakeAccountPath = (account: number) => {
   ]
 }
 
-const _validateScheme = (cryptoProvider) => {
-  return
-  // const scheme = cryptoProvider.getDerivationScheme()
-  //if (scheme.type !== 'v2') throw new Error('Invalid mnemonic scheme')
-}
-
 export const stakeAccountPubkeyHex = async (cryptoProvider, accountIndex: number) => {
   const pathStake = shelleyStakeAccountPath(accountIndex)
   return await cryptoProvider
@@ -40,8 +34,6 @@ export const stakeAccountPubkeyHex = async (cryptoProvider, accountIndex: number
 }
 
 export const ShelleyStakingAccountProvider = (cryptoProvider, accountIndex) => async () => {
-  _validateScheme(cryptoProvider)
-
   const pathStake = shelleyStakeAccountPath(accountIndex)
   const stakeXpub = await cryptoProvider.deriveXpub(pathStake)
 
@@ -56,8 +48,6 @@ export const ShelleySingleAddressProvider = (
   accountIndex: number,
   isChange: boolean
 ) => async (i: number) => {
-  _validateScheme(cryptoProvider)
-
   const pathSpend = shelleyPath(accountIndex, isChange, i)
   const spendXpub = await cryptoProvider.deriveXpub(pathSpend)
 
@@ -72,8 +62,6 @@ export const ShelleyGroupAddressProvider = (
   accountIndex: number,
   isChange: boolean
 ) => async (i: number) => {
-  _validateScheme(cryptoProvider)
-
   const pathSpend = shelleyPath(accountIndex, isChange, i)
   const spendXpub = await cryptoProvider.deriveXpub(pathSpend)
 

--- a/app/frontend/wallet/shelley/shelley-address-provider.ts
+++ b/app/frontend/wallet/shelley/shelley-address-provider.ts
@@ -26,7 +26,8 @@ const shelleyStakeAccountPath = (account: number) => {
 }
 
 const _validateScheme = (cryptoProvider) => {
-  const scheme = cryptoProvider.getDerivationScheme()
+  return
+  // const scheme = cryptoProvider.getDerivationScheme()
   //if (scheme.type !== 'v2') throw new Error('Invalid mnemonic scheme')
 }
 

--- a/app/frontend/wallet/shelley/shelley-js-crypto-provider.ts
+++ b/app/frontend/wallet/shelley/shelley-js-crypto-provider.ts
@@ -35,6 +35,7 @@ const ShelleyJsCryptoProvider = ({walletSecretDef: {rootSecret, derivationScheme
     return signMsg(messageToSign, hdNode.toBuffer())
   }
 
+  // eslint-disable-next-line require-await
   async function signTx(txAux, addressToAbsPathMapper) {
     const prepareUtxoInput = (input, hdnode) => {
       return {

--- a/app/frontend/wallet/shelley/shelley-js-crypto-provider.ts
+++ b/app/frontend/wallet/shelley/shelley-js-crypto-provider.ts
@@ -85,7 +85,6 @@ const ShelleyJsCryptoProvider = ({walletSecretDef: {rootSecret, derivationScheme
       }
     }
 
-    // const inputs = txAux.inputs.map((input) => prepareInput(txAux.type, input))
     const inputs = txAux.inputs.map(prepareInput)
     const outpustAndChange = txAux.change ? [...txAux.outputs, txAux.change] : [...txAux.outputs]
     const outputs = outpustAndChange.length ? outpustAndChange.map(prepareOutput) : []

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -570,6 +570,12 @@ button[data-balloon] {
   white-space: pre-wrap;
 }
 
+[data-balloon="Copied to clipboard"]::after,
+[data-balloon="Insufficient funds"]::after {
+  min-width: unset;
+  white-space: pre;
+}
+
 [data-balloon]::before {
   width: 0;
   height: 0;
@@ -703,7 +709,7 @@ button[data-balloon] {
 .alert-content {
   text-align: left;
   max-height: 180px;
-  overflow: hidden;
+  overflow: auto;
 }
 
 .alert.sidebar {

--- a/app/tests/src/shelley.js
+++ b/app/tests/src/shelley.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import assert from 'assert'
 
 import ShelleyJsCryptoProvider from '../../frontend/wallet/shelley/shelley-js-crypto-provider'

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2917,7 +2917,7 @@ set-immediate-shim@^1.0.1:
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
   integrity sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=
 
-set-value@^2.0.0, set-value@^2.0.1:
+set-value@^0.4.3, set-value@^2.0.0, set-value@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
   integrity sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "prettier-eslint-cli": "^5.0.0",
     "release-it": "^13.6.2",
     "ts-loader": "^6.2.1",
-    "typescript": "^3.7.2"
+    "typescript": "3.9.2"
   },
   "resolutions": {
     "lodash": "4.17.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5103,22 +5103,20 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
+typescript@3.9.2:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.2.tgz#64e9c8e9be6ea583c54607677dd4680a1cf35db9"
+  integrity sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==
+
 typescript@^3.2.1:
   version "3.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
   integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
 
-typescript@^3.7.2:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
-  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
-
 unique-string@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-2.0.0.tgz#39c6451f81afb2749de2b233e3f7c5e8843bd89d"
   integrity sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==
-  dependencies:
-    crypto-random-string "^2.0.0"
 
 universal-analytics@^0.4.20:
   version "0.4.20"


### PR DESCRIPTION
Marked WIP due to some known issues that will be added to this description shortly.

**Commits:** 

- **rename handle error to setErrorState**
renames the handleError function to setErrorState since it makes more sense, the function isn't handling the error rather than setting just setting some states
- **reorder actions.ts file**
reorders the functions in this file to some logical sections, the file is too long anyway so its hard to navigate either way, but helps at least a bit
- **refactor tx plan building**
adds some types to build-transaction file, adds type attribute to tx plan, refactors account plan computing
in shelley-wallet file, refactors plan building functions so separates staking and non-staking utxos, shuffling them separately,
adds types to txPlan arguments
- **refactor fee calculation**
renames `showTxSuccess` to `txSuccessTab` (this variable determines, on which tab is the tx success shown
previously, if a user typed a number of coins he doesn't have, the fee calculation was triggered anyway, this commit fixes this behavior, adds a validation error to validators along with balance argument ( this replaces the hotfix in this PR #604 so it all works as expected)
refactors the fee calculating functions (for normal sending, delegations, delegation revoking and non-staking conversion), these have been unnecessarily long and inconsistent, so it removes unnecessary lines and make them logically follow the same pattern
creates separate functions for setting a transaction plan and preparing the plan, 
also, some values in `sendAdaPage` haven't been resetting properly ( f.e if user cleaned the form, or after tx) so this behavior is also fixed in this commit.
- **remove useless error caching in wallets and refactor**
as pointed by Rafo, previously the networks errors have been generalized in wallets, this commit removes the behavior 
- **add proper server error and fix translations**
refactors request helper the way it is on mainnet and fixes the error translations
- **show network errors in components and fix setErrorState function**
previously there was a bug in `setErrorState` function
all fee calculating function has been slightly redone, to handle the way a possible error in preparing tx plan is shown. Previously we were showing all these errors in `TransactionErrorModal` which doesn't make much sense, this way, if an error occurs during fee calculation, in case of normal tx, or change in donation amount and delegation fee calculation, the error is shown in the `sendAdaPage` or `delegationPage` components, and a modal is shown for converting funds or revoking delegation (since these doesn't have a proper place to show the error)
- **fix modal error overflow and hotfix tool tip width**
again an issue already solved in mainet branch and hot-fixes the min-width attribute for the data-balloon
- **reorder actions.ts file to fix eslint errors**
the file had to be reordered once again, and SEND ADA and DONATION sections merged since its impossible to have them separated and avoid 'used before defined' error

- next free commits should be squashed before merge,
just fixing all the other linting errors and audit errors, 

- **bump yargs-parser from 13.1.1 to 13.1.2 and bump acorn**
bumps

- add real Shelley validation
previously the addresses were validated very simply, this commit fixes this behavior validating them with js-chain-libs

**Issues**
- according to the specification of the Shelley era, there won't be functionality for delegation by ratio, thus no multiple pools, with different ratios. Currently, the codebase is prepared for this functionality making it unnecessary complex, in multiple places.
- throughout the codebase, we use `coins`, `amount` and `value` terms, they should be unified or their difference in meaning should be specified
- the tx success sign (the green one) seems to be not showing in some cases after the tx is submitted
- `updateStakepoolIndetiifer` function should probably be modified, quick typing and deleting seems to be causing bugs