### PR TITLE
Add server error handler

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -5,6 +5,7 @@ const fs = require('fs')
 const https = require('https')
 const {frontendConfig, backendConfig} = require('./helpers/loadConfig')
 const ipfilter = require('express-ipfilter').IpFilter
+const errorHandler = require('./middlewares/errorHandler')
 
 let app = express()
 
@@ -35,7 +36,7 @@ if (backendConfig.ADALITE_IP_BLACKLIST.length > 0) {
     ipfilter(backendConfig.ADALITE_IP_BLACKLIST, {
       detectIp: (req) => req.headers['x-forwarded-for'] || req.connection.remoteAddress,
       mode: 'deny',
-      logLevel: 'deny',
+      logLevel: 'deny', // logs "Access denied to IP address: <ip>" for denied IPs
     })
   )
 }
@@ -103,6 +104,8 @@ app.get('*', (req, res) => {
       </html>
     `)
 })
+
+app.use(errorHandler)
 
 /*
  * To run server in secure mode, you need to set

--- a/server/middlewares/errorHandler.js
+++ b/server/middlewares/errorHandler.js
@@ -1,0 +1,11 @@
+const IpDeniedError = require('express-ipfilter').IpDeniedError
+
+module.exports = (err, req, res, next) => {
+  if (err instanceof IpDeniedError) {
+    res.status(401).send('Forbidden')
+  } else {
+    // eslint-disable-next-line no-console
+    console.error(err.stack)
+    res.status(500).send('Internal Server Error')
+  }
+}


### PR DESCRIPTION
Motivation: Our logs are getting polluted with exceptions related to IP denials due to a missing error handler

Solution: Add generic error handler that catches the IpDeniedError and translates it into a 401 response, omitting redundant logging and translates the rest of unhandled errors into an error 500 with "Internal Server Error" message, logging the error to the console for future debugging.

Testing: tested locally, behaves as expected both for IpDeniedError and for unhandled errors