### PR TITLE
Log failed transactions

### DIFF
--- a/server/transactionSubmitter.js
+++ b/server/transactionSubmitter.js
@@ -35,10 +35,21 @@ module.exports = function(app, env) {
           Right: {txHash},
         })
       }
+
+      // eslint-disable-next-line no-console
+      console.error(
+        `Submission of tx ${txHash} failed with status ${
+          response.status
+        } and message ${await response.text()}`
+      )
+
       return res.json({
         Left: 'Transaction rejected by network',
       })
     } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(`Submission of tx ${txHash} failed with an unexpected error: ${err.stack}`)
+
       return res.json({
         Left: 'An unexpected error has occurred',
       })


### PR DESCRIPTION
Motivation: over the last few weeks we are seeing like a 10% fail rate of transaction submissions. As of now, we don't know anything beyond the amount of failed transactions, therefore in this PR I'm adding logging of the hashes of the failed txs as well as the exact error message returned by the backend

Testing: I tried submitting a garbled tx and successfully logged the error status as well as an error thrown within the try-catch block with the request to submit tx