### PR TITLE
Fix Byron tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ app/tests/dist/
 app/dist/
 server.cert
 server.key
+app/tests/.chrome/*
+app/tests/*.module.wasm

--- a/app/frontend/helpers/wasmLoader.js
+++ b/app/frontend/helpers/wasmLoader.js
@@ -1,4 +1,3 @@
-import {Buffer} from 'buffer'
 // interface extendedWindow extends Window {
 //   wasm?: any;
 // }
@@ -6,5 +5,4 @@ import {Buffer} from 'buffer'
 export default async function loadWasmModule() {
   // (window as extendedWindow).wasm = await import('@emurgo/js-chain-libs/js_chain_libs_bg.wasm')
   window.wasm = await import('@emurgo/js-chain-libs/js_chain_libs_bg.wasm')
-  window.Buffer = Buffer
 }

--- a/app/tests/src/cardano-wallet.js
+++ b/app/tests/src/cardano-wallet.js
@@ -184,7 +184,10 @@ describe('successful transaction fee computation', () => {
     mockNet.mockBulkAddressSummaryEndpoint()
     mockNet.mockUtxoEndpoint()
 
-    assert.equal((await wallets.used.getTxPlan(myAddress, 47, 0)).fee, 179288)
+    assert.equal(
+      (await wallets.used.getTxPlan({address: myAddress, coins: 47, donationAmount: 0})).fee,
+      179288
+    )
     mockNet.clean()
   })
 
@@ -192,7 +195,10 @@ describe('successful transaction fee computation', () => {
     const mockNet = mockNetwork(mockConfig2)
     mockNet.mockUtxoEndpoint()
 
-    assert.equal((await wallets.used.getTxPlan(shortAddress, 47, 0)).fee, 177838)
+    assert.equal(
+      (await wallets.used.getTxPlan({address: shortAddress, coins: 47, donationAmount: 0})).fee,
+      177838
+    )
     mockNet.clean()
   })
 })
@@ -214,7 +220,7 @@ describe('transaction serialization', () => {
   it('should properly serialize transaction before signing', async () => {
     const mockNet = mockNetwork(mockConfig2)
     mockNet.mockUtxoEndpoint()
-    const plan = await wallets.used.getTxPlan(myAddress, 47, false)
+    const plan = await wallets.used.getTxPlan({address: myAddress, coins: 47, donationAmount: 0})
     const txAux = wallets.used.prepareTxAux(plan)
 
     // transaction serialization before providing witnesses
@@ -231,7 +237,11 @@ describe('transaction serialization', () => {
     mockNet.mockUtxoEndpoint()
     mockNet.mockBulkAddressSummaryEndpoint()
 
-    const plan = await wallets.smallUtxos.getTxPlan(myAddress, 1000000, false)
+    const plan = await wallets.smallUtxos.getTxPlan({
+      address: myAddress,
+      coins: 1000000,
+      donationAmount: 0,
+    })
     const txAux = wallets.smallUtxos.prepareTxAux(plan)
 
     assert.equal(txAux.inputs.length, 2)
@@ -242,7 +252,7 @@ describe('transaction serialization', () => {
     const mockNet = mockNetwork(mockConfig2)
     mockNet.mockUtxoEndpoint()
 
-    const plan = await wallets.used.getTxPlan(myAddress, 47, false)
+    const plan = await wallets.used.getTxPlan({address: myAddress, coins: 47, donationAmount: 0})
     const txAux = await wallets.used.prepareTxAux(plan)
 
     const expectedTxHash = '5e3c57744fb9b134589cb006db3d6536cd6471a2bde542149326dd92859f0a93'
@@ -260,7 +270,7 @@ describe('transaction serialization', () => {
     const wallet = wallets.used
 
     const tx = await wallet
-      .getTxPlan(myAddress, 47, false)
+      .getTxPlan({address: myAddress, coins: 47, donationAmount: 0})
       .then(wallet.prepareTxAux)
       .then(wallet.signTxAux)
 
@@ -281,7 +291,7 @@ describe('test transaction submission', () => {
 
     const wallet = wallets.used
     const tx = await wallet
-      .getTxPlan(myAddress, 47, false)
+      .getTxPlan({address: myAddress, coins: 47, donationAmount: 0})
       .then(wallet.prepareTxAux)
       .then(wallet.signTxAux)
 

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2917,7 +2917,7 @@ set-immediate-shim@^1.0.1:
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
   integrity sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=
 
-set-value@^0.4.3, set-value@^2.0.0, set-value@^2.0.1:
+set-value@^2.0.0, set-value@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
   integrity sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1279,11 +1279,6 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
-crypto-random-string@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
-  integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
-
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -5117,6 +5112,8 @@ unique-string@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-2.0.0.tgz#39c6451f81afb2749de2b233e3f7c5e8843bd89d"
   integrity sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==
+  dependencies:
+    crypto-random-string "^2.0.0"
 
 universal-analytics@^0.4.20:
   version "0.4.20"


### PR DESCRIPTION
1. for tests failing on getTxPlan:
getTxPlan expects just one argument, containing the values for address, coins and donationAmount. The original test code thus didn't provide any of these values and plan generation failed

2. Shelley testnet tests were failing on global leak detection - it seems the global Buffer causing the leaks is not needed (anymore)

3. Wallet import tests seem to be working fine

closes #623 