### PR TITLE
Fix https in dev mode and fix crypto-random-strings dependency

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -2,7 +2,7 @@ const bodyParser = require('body-parser')
 const express = require('express')
 const compression = require('compression')
 const fs = require('fs')
-const http = require('http')
+const https = require('https')
 const {frontendConfig, backendConfig} = require('./helpers/loadConfig')
 
 let app = express()
@@ -107,7 +107,7 @@ if (enableHttps) {
     cert: fs.readFileSync('server.cert'),
     key: fs.readFileSync('server.key'),
   }
-  app = http.createServer(options, app)
+  app = https.createServer(options, app)
 }
 
 app.listen(backendConfig.PORT, () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1279,6 +1279,11 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
+crypto-random-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
+  integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"


### PR DESCRIPTION
* Fixes SSL record too long when trying to run adalite locally on https://localhost:3000
* I also ran `yarn install` which probably due to some previous misconfiguration reintroduced the missing `crypto-random-string` dependency (a sub-dependency of release-i, if you run `yarn why`), so this fixes it