### PR TITLE
Fix address explorer link margin

### DIFF
--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -2110,7 +2110,6 @@ li.main-tab input + label.selected:after {
 
 .address-link {
   color: var(--color-grey);
-  margin-right: 24px;
 }
 
 .address-link:last-child {


### PR DESCRIPTION
After promoting develop to master I noticed the following UI bug:

![Untitled](https://user-images.githubusercontent.com/4980147/85731388-c61ba080-b6fa-11ea-8a91-9a91b5f243fc.png)

I removed the apparently redundant right margin for explorer link - tested both in Shelley and Byron mode