### PR TITLE
Test for actions.ts

### DIFF
--- a/app/frontend/store.ts
+++ b/app/frontend/store.ts
@@ -2,7 +2,7 @@ import devtools from './libs/unistore/devtools'
 import {ADALITE_CONFIG} from './config'
 import {initialState} from './state'
 
-const createDefaultStore = require('unistore').default
+const createDefaultStore = require('./libs/unistore').default
 
 const createStore = () =>
   ADALITE_CONFIG.ADALITE_ENABLE_DEBUGGING === 'true'

--- a/app/tests/src/actions/actions.js
+++ b/app/tests/src/actions/actions.js
@@ -1,0 +1,39 @@
+import assert from 'assert'
+import loadWasmModule from '../loadWasmModule'
+import {initialState} from '../../../frontend/state'
+import {default as actions} from '../../../frontend/actions'
+
+window.wasm = null
+before(loadWasmModule)
+
+export const setStateFn = function(state, changes) {
+  for (const [key, val] of Object.entries(changes)) {
+    state[key] = val
+  }
+}
+
+export const getStateFn = function(state) {
+  return state
+}
+
+export function assertPropertiesEqual(state, expectedState) {
+  for (const [key, val] of Object.entries(expectedState)) {
+    assert.deepEqual(state[key], val, `${key} not matching`)
+  }
+}
+
+export function setupState() {
+  const cloneDeep = require('lodash/fp/cloneDeep')
+  const state = cloneDeep(initialState)
+
+  const getState = () => getStateFn(state)
+  const setState = (change) => setStateFn(state, change)
+  const action = actions({setState, getState})
+  return [state, action]
+}
+
+// eslint-disable-next-line prefer-arrow-callback
+describe('Test wallet actions', function() {
+  this.timeout(5000) // this doesn't work in Mocha with arrow functions
+  require('./wallet-actions')
+})

--- a/app/tests/src/actions/wallet-actions.js
+++ b/app/tests/src/actions/wallet-actions.js
@@ -1,0 +1,93 @@
+import mockNetwork from '../common/mock'
+import {ADALITE_CONFIG} from '../../../frontend/config'
+import {CRYPTO_PROVIDER_TYPES} from '../../../frontend/wallet/constants'
+import mnemonicToWalletSecretDef from '../../../frontend/wallet/helpers/mnemonicToWalletSecretDef'
+import assert from 'assert'
+import {assertPropertiesEqual, setupState} from './actions'
+
+let state, action
+
+beforeEach(() => {
+  ;[state, action] = setupState()
+})
+
+const expectedStateChanges = {
+  walletIsLoaded: true,
+  balance: 1500000,
+  loading: false,
+  mnemonicAuthForm: {
+    mnemonicInputValue: '',
+    mnemonicInputError: null,
+    formIsValid: false,
+  },
+  usingHwWallet: false,
+  hwWalletName: undefined,
+  isDemoWallet: false,
+  showDemoWalletWarningDialog: false,
+  showGenerateMnemonicDialog: false,
+  // send form
+  sendAmount: {fieldValue: '', coins: 0},
+  sendAddress: {fieldValue: ''},
+  donationAmount: {fieldValue: '', coins: 0},
+  sendResponse: '',
+}
+
+it('Load shelley wallet', async () => {
+  ADALITE_CONFIG.ADALITE_CARDANO_VERSION = 'shelley'
+
+  const mockNet = mockNetwork(ADALITE_CONFIG)
+  mockNet.mockBulkAddressSummaryEndpoint()
+  mockNet.mockGetAccountInfo()
+  mockNet.mockGetStakePools()
+  mockNet.mockGetConversionRates()
+
+  expectedStateChanges.validStakepools = {
+    d4b1243dfc0bec57f146a90d85b478cdd3e0e646c43801c2bebd6792580a7db2: {
+      pool_id: 'd4b1243dfc0bec57f146a90d85b478cdd3e0e646c43801c2bebd6792580a7db2',
+      owner: 'def7e265ec2c54e1cf00dae85ec407e823dd1374e6520cd59264df321513ffe5',
+      name: 'IOHK Stakepool',
+      description: null,
+      ticker: 'IOHK1',
+      homepage: 'https://staking.cardano.org',
+      rewards: {
+        fixed: 258251123,
+        limit: null,
+        ratio: [2, 25],
+      },
+    },
+  }
+  expectedStateChanges.ticker2Id = {
+    IOHK1: 'd4b1243dfc0bec57f146a90d85b478cdd3e0e646c43801c2bebd6792580a7db2',
+  }
+
+  await action.loadWallet(state, {
+    cryptoProviderType: CRYPTO_PROVIDER_TYPES.WALLET_SECRET,
+    walletSecretDef: await mnemonicToWalletSecretDef(
+      'blame matrix water coil diet seat nerve street movie turkey jump bundle'
+    ),
+  })
+  assertPropertiesEqual(state, expectedStateChanges)
+  assert.equal(state.visibleAddresses.length, 40)
+})
+
+it('Load byron wallet', async () => {
+  ADALITE_CONFIG.ADALITE_CARDANO_VERSION = 'byron'
+
+  const mockNet = mockNetwork(ADALITE_CONFIG)
+  mockNet.mockBulkAddressSummaryEndpoint()
+  mockNet.mockGetAccountInfo()
+  mockNet.mockGetStakePools()
+  mockNet.mockGetConversionRates()
+
+  expectedStateChanges.validStakepools = null
+  expectedStateChanges.ticker2Id = null
+
+  await action.loadWallet(state, {
+    cryptoProviderType: CRYPTO_PROVIDER_TYPES.WALLET_SECRET,
+    walletSecretDef: await mnemonicToWalletSecretDef(
+      'blame matrix water coil diet seat nerve street movie turkey jump bundle'
+    ),
+  })
+  assertPropertiesEqual(state, expectedStateChanges)
+  assert.equal(state.visibleAddresses.length, 10)
+})

--- a/app/tests/src/common/mock.js
+++ b/app/tests/src/common/mock.js
@@ -44,6 +44,73 @@ const mock = (ADALITE_CONFIG) => {
     })
   }
 
+  function mockGetAccountInfo() {
+    fetchMock.config.overwriteRoutes = true
+    const acctInfoMock = {
+      delegation: [],
+      value: 0,
+      counter: 0,
+      last_rewards: {
+        epoch: 0,
+        reward: 0,
+      },
+    }
+
+    fetchMock.mock({
+      matcher: `${ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL}/api/v2/account/info`,
+      response: {
+        status: 200,
+        body: acctInfoMock,
+        sendAsJson: true,
+      },
+    })
+  }
+
+  function mockGetStakePools() {
+    fetchMock.config.overwriteRoutes = true
+
+    const stakePoolsMock = [
+      {
+        pool_id: 'd4b1243dfc0bec57f146a90d85b478cdd3e0e646c43801c2bebd6792580a7db2',
+        owner: 'def7e265ec2c54e1cf00dae85ec407e823dd1374e6520cd59264df321513ffe5',
+        name: 'IOHK Stakepool',
+        description: null,
+        ticker: 'IOHK1',
+        homepage: 'https://staking.cardano.org',
+        rewards: {
+          fixed: 258251123,
+          ratio: [2, 25],
+          limit: null,
+        },
+      },
+    ]
+
+    fetchMock.mock({
+      matcher: `${ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL}/api/v2/stakePools`,
+      response: {
+        status: 200,
+        body: stakePoolsMock,
+        sendAsJson: true,
+      },
+    })
+  }
+
+  function mockGetConversionRates() {
+    fetchMock.config.overwriteRoutes = true
+
+    fetchMock.mock({
+      matcher: 'https://min-api.cryptocompare.com/data/price?fsym=ADA&tsyms=USD,EUR',
+      response: {
+        status: 200,
+        body: {
+          USD: '0.08245',
+          EUR: '0.07364',
+        },
+        sendAsJson: true,
+      },
+    })
+  }
+
   function mockRawTxEndpoint() {
     fetchMock.config.overwriteRoutes = true
 
@@ -128,6 +195,9 @@ const mock = (ADALITE_CONFIG) => {
 
   return {
     mockBulkAddressSummaryEndpoint,
+    mockGetAccountInfo,
+    mockGetStakePools,
+    mockGetConversionRates,
     mockTransactionSubmitter,
     mockUtxoEndpoint,
     mockRawTxEndpoint,

--- a/app/tests/src/common/setup-test-config.js
+++ b/app/tests/src/common/setup-test-config.js
@@ -1,0 +1,20 @@
+const config = `{
+  "ADALITE_SERVER_URL": "https://localhost:3000",
+  "ADALITE_BLOCKCHAIN_EXPLORER_URL": "https://test-test.adalite.io",
+  "ADALITE_DEFAULT_ADDRESS_COUNT": 10,
+  "ADALITE_GAP_LIMIT": 20,
+  "ADALITE_DEMO_WALLET_MNEMONIC": "quit gloom sell coil mosquito capital silk climb around fabric drink hood patient more whip",
+  "ADALITE_ENABLE_DEBUGGING": false,
+  "ADALITE_APP_VERSION": "3.7.0",
+  "ADALITE_LOGOUT_AFTER": "900",
+  "ADALITE_TREZOR_CONNECT_URL": "",
+  "ADALITE_SUPPORT_EMAIL": "support@test.test",
+  "ADALITE_FIXED_DONATION_VALUE": "40",
+  "ADALITE_MIN_DONATION_VALUE": "1",
+  "ADALITE_STAKE_POOL_ID": "f61c42cbf7c8c53af3f520508212ad3e72f674f957fe23ff0acb49733c37b8f6",
+  "ADALITE_ENV": "local",
+  "ADALITE_DEVEL_AUTO_LOGIN": "false",
+  "ADALITE_CARDANO_VERSION": "byron"
+}`
+
+document.body.setAttribute('data-config', config)

--- a/app/tests/src/index.js
+++ b/app/tests/src/index.js
@@ -1,4 +1,6 @@
 describe('AdaLite Test Suite', () => {
+  require('./common/setup-test-config')
+
   describe('CBOR', () => {
     require('./cbor')
   })
@@ -16,6 +18,9 @@ describe('AdaLite Test Suite', () => {
   })
   describe('Import/Export Wallet as JSON', () => {
     require('./keypass-json')
+  })
+  describe('Actions', () => {
+    require('./actions/actions')
   })
   describe('Shelley testnet', () => {
     require('./shelley')


### PR DESCRIPTION
The purpose was to provide a way to test actions.ts (those that contain more logic than setting 1 state field).
In this PR this is only done for loadWallet, other actions will be covered in subsequent PRs.

I had some problems with initializing config, which is needed for both getting initial state and also used across the codebase directly - for that I set up some dummy config on tests startup (as other than actions tests try to load it, though other tests are OK with it remaining null).