### PR TITLE
separate redis stats amounts also for non-ada values

### DIFF
--- a/server/statsPageRedis.js
+++ b/server/statsPageRedis.js
@@ -120,7 +120,7 @@ module.exports = function(app, env) {
                 ${
   isAdaAmountKey(period)
     ? Math.round(value / 1000000).toLocaleString('en')
-    : value.toLocaleString('en')
+    : parseInt(value, 10).toLocaleString('en')
 }
     </b>
             </td>


### PR DESCRIPTION
The previous PR on this matter seems to be separating number by thousands only for ADA values, this PR fixes this.