### PR TITLE
Reintroduce tracking of sent amount in Byron mode

### DIFF
--- a/server/helpers/loadConfig.js
+++ b/server/helpers/loadConfig.js
@@ -151,6 +151,7 @@ const backendConfig = {
   ADALITE_IP_BLACKLIST: ADALITE_IP_BLACKLIST
     ? ADALITE_IP_BLACKLIST.replace(/ /g, '').split(',')
     : [],
+  ADALITE_CARDANO_VERSION,
 }
 
 module.exports = {


### PR DESCRIPTION
When we transitioned to the unified Shelley-Byron codebase, we forgot to turn back on sent amount tracking which was causing problems with shelley itn.

tested locally using testnet redis storage - it successfully tracked the sent out amount in byron mode

This PR reintroduces that logic based on https://github.com/vacuumlabs/adalite/blob/f8583baaeaea16fa961b1b581d1a664009940f0f/server/middlewares/statsRedis.js#L58