### PR TITLE
Shelley mainnet address packing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,6 @@ ADALITE_CARDANO_VERSION="shelley"
 
 # error banner message, empty for no banner
 ADALITE_ERROR_BANNER_CONTENT=''
+
+# cardano network version
+ADALITE_NETWORK="MAINNET"

--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -139,7 +139,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
           await loadWasmModule()
           const cryptoProvider = ShelleyJsCryptoProvider({
             walletSecretDef,
-            network: NETWORKS.SHELLEY.MAINNET,
+            network: NETWORKS.SHELLEY[ADALITE_CONFIG.ADALITE_NETWORK],
           })
 
           wallet = await ShelleyWallet({

--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -139,7 +139,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
           await loadWasmModule()
           const cryptoProvider = ShelleyJsCryptoProvider({
             walletSecretDef,
-            network: NETWORKS.SHELLEY.INCENTIVIZED_TESTNET,
+            network: NETWORKS.SHELLEY.MAINNET,
           })
 
           wallet = await ShelleyWallet({

--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -160,7 +160,8 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
       )).rootSecret
       const isDemoWallet = walletSecretDef && walletSecretDef.rootSecret.equals(demoRootSecret)
       const autoLogin = state.autoLogin
-      const {validStakepools, ticker2Id} = await wallet.getValidStakepools()
+      const {validStakepools, ticker2Id} = {validStakepools: [], ticker2Id: []}
+      //await wallet.getValidStakepools()
       setState({
         walletIsLoaded: true,
         ...walletInfo,

--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -160,7 +160,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
       )).rootSecret
       const isDemoWallet = walletSecretDef && walletSecretDef.rootSecret.equals(demoRootSecret)
       const autoLogin = state.autoLogin
-      const {validStakepools, ticker2Id} = {validStakepools: [], ticker2Id: []}
+      const {validStakepools, ticker2Id} = {validStakepools: null, ticker2Id: null}
       //await wallet.getValidStakepools()
       setState({
         walletIsLoaded: true,

--- a/app/frontend/components/pages/delegations/delegatePage.tsx
+++ b/app/frontend/components/pages/delegations/delegatePage.tsx
@@ -78,7 +78,7 @@ class Delegate extends Component<Props> {
   }
 
   componentDidMount() {
-    this.props.selectAdaliteStakepool()
+    // this.props.selectAdaliteStakepool()
   }
 
   render({

--- a/app/frontend/state.ts
+++ b/app/frontend/state.ts
@@ -116,12 +116,6 @@ export interface State {
   shelleyAccountInfo?: {
     delegation: any
     value: number
-    counter: number
-    // eslint-disable-next-line camelcase
-    last_rewards: {
-      epoch: number
-      reward: number
-    }
   }
   txConfirmType: string
   txSuccessTab: string
@@ -200,11 +194,6 @@ const initialState: State = {
   shelleyAccountInfo: {
     delegation: [],
     value: 0,
-    counter: 0,
-    last_rewards: {
-      epoch: 0,
-      reward: 0,
-    },
   },
   txConfirmType: '',
   txSuccessTab: '',

--- a/app/frontend/wallet/byron/byron-address-provider.ts
+++ b/app/frontend/wallet/byron/byron-address-provider.ts
@@ -1,4 +1,4 @@
-import {packAddress} from 'cardano-crypto.js'
+import {packBootstrapAddress, base58} from 'cardano-crypto.js'
 import {HARDENED_THRESHOLD} from '../constants'
 
 const v1Path = (account: number, isChange: boolean, addrIdx: number) => {
@@ -37,6 +37,6 @@ export const ByronAddressProvider = (
 
   return {
     path,
-    address: packAddress(path, xpub, hdPassphrase, scheme.ed25519Mode),
+    address: base58.encode(packBootstrapAddress(path, xpub, hdPassphrase, scheme.ed25519Mode)),
   }
 }

--- a/app/frontend/wallet/constants.ts
+++ b/app/frontend/wallet/constants.ts
@@ -22,6 +22,9 @@ export const NETWORKS = {
     },
   },
   SHELLEY: {
+    MAINNET: {
+      networkId: 0,
+    },
     INCENTIVIZED_TESTNET: {
       name: 'itn',
       addressDiscriminator: 'testnet',

--- a/app/frontend/wallet/constants.ts
+++ b/app/frontend/wallet/constants.ts
@@ -23,7 +23,16 @@ export const NETWORKS = {
   },
   SHELLEY: {
     MAINNET: {
+      name: 'shelley-mainnet',
       networkId: 0,
+      protocolMagic: 764824073,
+      ttl: undefined,
+    },
+    HASKELL_TESTNET: {
+      name: 'htn',
+      networkId: 0,
+      protocolMagic: 42,
+      ttl: undefined,
     },
     INCENTIVIZED_TESTNET: {
       name: 'itn',

--- a/app/frontend/wallet/helpers/mnemonicToWalletSecretDef.ts
+++ b/app/frontend/wallet/helpers/mnemonicToWalletSecretDef.ts
@@ -3,8 +3,12 @@ import {decodePaperWalletMnemonic, mnemonicToRootKeypair} from 'cardano-crypto.j
 import {validateMnemonic, isMnemonicInPaperWalletFormat} from '../mnemonic'
 
 import derivationSchemes from './derivation-schemes'
+import {ADALITE_CONFIG} from '../../config'
 
 const guessDerivationSchemeFromMnemonic = (mnemonic) => {
+  if (ADALITE_CONFIG.ADALITE_CARDANO_VERSION === 'shelley') {
+    return derivationSchemes.v2 //TODO: v1 should have been abandoned in shelley (?)
+  }
   return mnemonic.split(' ').length === 12 ? derivationSchemes.v1 : derivationSchemes.v2
 }
 

--- a/app/frontend/wallet/shelley-wallet.ts
+++ b/app/frontend/wallet/shelley-wallet.ts
@@ -139,11 +139,10 @@ const ShelleyBlockchainExplorer = (config) => {
   // TODO: move methods to blockchain-explorer file
   const be = BlockchainExplorer(config)
 
-  const shelleyToHex = (address) =>
-    isShelleyAddress(address) ? bechAddressToHex(address) : address
+  const addressToHex = (address) =>
+    isShelleyFormat(address) ? bechAddressToHex(address) : base58AddressToHex(address)
 
-  const shelleyAddressesToHex = (addresses: Array<string>): Array<string> =>
-    addresses.map(shelleyToHex)
+  const addressesToHex = (addresses: Array<string>): Array<string> => addresses.map(addressToHex)
 
   async function getAccountInfo(accountPubkeyHex) {
     const url = `${ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL}/api/v2/account/info`
@@ -186,15 +185,14 @@ const ShelleyBlockchainExplorer = (config) => {
   }
 
   return {
-    getTxHistory: (addresses) => be.getTxHistory(shelleyAddressesToHex(addresses)),
+    getTxHistory: (addresses) => be.getTxHistory(addressesToHex(addresses)),
     fetchTxRaw: be.fetchTxRaw,
-    fetchUnspentTxOutputs: (addresses) =>
-      be.fetchUnspentTxOutputs(shelleyAddressesToHex(addresses)),
-    isSomeAddressUsed: (addresses) => be.isSomeAddressUsed(shelleyAddressesToHex(addresses)),
+    fetchUnspentTxOutputs: (addresses) => be.fetchUnspentTxOutputs(addressesToHex(addresses)),
+    isSomeAddressUsed: (addresses) => be.isSomeAddressUsed(addressesToHex(addresses)),
     submitTxRaw: be.submitTxRaw,
-    getBalance: (addresses) => be.getBalance(shelleyAddressesToHex(addresses)),
+    getBalance: (addresses) => be.getBalance(addressesToHex(addresses)),
     fetchTxInfo: be.fetchTxInfo,
-    filterUsedAddresses: (addresses) => be.filterUsedAddresses(shelleyAddressesToHex(addresses)),
+    filterUsedAddresses: (addresses) => be.filterUsedAddresses(addressesToHex(addresses)),
     getAccountInfo,
     getValidStakepools,
   }

--- a/app/frontend/wallet/shelley-wallet.ts
+++ b/app/frontend/wallet/shelley-wallet.ts
@@ -17,7 +17,6 @@ import shuffleArray from './helpers/shuffleArray'
 import {MaxAmountCalculator} from './max-amount-calculator'
 import {ByronAddressProvider} from './byron/byron-address-provider'
 import {
-  isShelleyAddress,
   isShelleyFormat,
   bechAddressToHex,
   isBase,
@@ -342,7 +341,7 @@ const ShelleyWallet = ({config, randomInputSeed, randomChangeSeed, cryptoProvide
 
   async function getWalletInfo() {
     const {stakingBalance, nonStakingBalance, balance} = await getBalance()
-    const shelleyAccountInfo = await getAccountInfo()
+    // const shelleyAccountInfo = await getAccountInfo()
     const visibleAddresses = await getVisibleAddresses()
     const transactionHistory = await getHistory()
     // getDelegationHistory
@@ -351,10 +350,10 @@ const ShelleyWallet = ({config, randomInputSeed, randomChangeSeed, cryptoProvide
       balance,
       shelleyBalances: {
         nonStakingBalance,
-        stakingBalance: stakingBalance + shelleyAccountInfo.value,
-        rewardsAccountBalance: shelleyAccountInfo.value,
+        stakingBalance, //stakingBalance + shelleyAccountInfo.value,
+        rewardsAccountBalance: 0,
       },
-      shelleyAccountInfo,
+      shelleyAccountInfo: {delegation: {}, value: 0},
       transactionHistory,
       visibleAddresses,
     }

--- a/app/frontend/wallet/shelley/helpers/addresses.ts
+++ b/app/frontend/wallet/shelley/helpers/addresses.ts
@@ -1,5 +1,6 @@
 import * as lib from '@emurgo/js-chain-libs'
 import bech32 from './bech32'
+import {packBaseAddress} from 'cardano-crypto.js'
 const {Address, Account, AddressDiscrimination, PublicKey, AddressKind} = lib
 
 const getDiscriminator = (network) => {
@@ -64,6 +65,16 @@ export const groupAddressFromXpub = (spendXpub: Xpub, stakeXpub: Xpub, network: 
     getDiscriminator(network)
   )
   return _addr.to_string('addr')
+}
+
+export const baseAddressFromXpub = (spendXpub: Xpub, stakeXpub: Xpub, account, networkId) => {
+  const addrBuffer = packBaseAddress(
+    spendXpub.slice(0, 32),
+    stakeXpub.slice(0, 32),
+    account,
+    networkId
+  )
+  return bech32.encode({prefix: 'addr', data: addrBuffer})
 }
 
 const getAddressKind = (address: string) => {

--- a/app/frontend/wallet/shelley/helpers/addresses.ts
+++ b/app/frontend/wallet/shelley/helpers/addresses.ts
@@ -1,22 +1,13 @@
-import * as lib from '@emurgo/js-chain-libs'
 import bech32 from './bech32'
-import {packBaseAddress} from 'cardano-crypto.js'
-const {Address, Account, AddressDiscrimination, PublicKey, AddressKind} = lib
-
-const getDiscriminator = (network) => {
-  const discriminator = {
-    mainnet: AddressDiscrimination.Production,
-    testnet: AddressDiscrimination.Test,
-  }[network.addressDiscriminator]
-  if (discriminator == null) throw new Error('Unknown address discriminator')
-  return discriminator
-}
+import {
+  packBaseAddress,
+  packRewardsAccountAddress,
+  getAddressInfo,
+  AddressTypes,
+  base58,
+} from 'cardano-crypto.js'
 
 const xpub2pub = (xpub: Buffer) => xpub.slice(0, 32)
-
-interface Network {
-  addressDiscriminator: 'mainnet' | 'testnet'
-}
 
 type Xpub = Buffer
 
@@ -26,84 +17,39 @@ export const bechAddressToHex = (address: string) => {
   return parsed.data.toString('hex')
 }
 
-export const groupToSingle = (address: string) => {
-  // Taken from https://github.com/Emurgo/yoroi-frontend/blob/461e94c3dfd364eb81b10652c66f9c3c403787a6/app/api/ada/lib/storage/bridge/utils.js
-  const wasmAddr = Address.from_bytes(Buffer.from(address, 'hex'))
-  const wasmGroupAddr = wasmAddr.to_group_address()
-  if (wasmGroupAddr == null) {
-    throw new Error(`groupToSingle not a group address ${address}`)
-  }
-  const singleWasm = Address.single_from_public_key(
-    wasmGroupAddr.get_spending_key(),
-    wasmAddr.get_discrimination()
-  )
-  const asString = Buffer.from(singleWasm.as_bytes()).toString('hex')
-
-  return asString
+export const base58AddressToHex = (address: string) => {
+  const parsed = base58.decode(address)
+  return parsed.toString('hex')
 }
 
-export const accountAddressFromXpub = (stakeXpub: Xpub, network: Network) => {
-  const _addr = Account.single_from_public_key(
-    PublicKey.from_bytes(xpub2pub(stakeXpub))
-  ).to_address(getDiscriminator(network))
-
-  return _addr.to_string('addr')
-}
-
-export const singleAddressFromXpub = (spendXpub: Xpub, network: Network) => {
-  const _addr = Address.single_from_public_key(
-    PublicKey.from_bytes(xpub2pub(spendXpub)),
-    getDiscriminator(network)
-  )
-  return _addr.to_string('addr')
-}
-
-export const groupAddressFromXpub = (spendXpub: Xpub, stakeXpub: Xpub, network: Network) => {
-  const _addr = Address.delegation_from_public_key(
-    PublicKey.from_bytes(xpub2pub(spendXpub)),
-    PublicKey.from_bytes(xpub2pub(stakeXpub)),
-    getDiscriminator(network)
-  )
-  return _addr.to_string('addr')
-}
-
-export const baseAddressFromXpub = (spendXpub: Xpub, stakeXpub: Xpub, account, networkId) => {
-  const addrBuffer = packBaseAddress(
-    spendXpub.slice(0, 32),
-    stakeXpub.slice(0, 32),
-    account,
-    networkId
-  )
+export const accountAddressFromXpub = (stakeXpub: Xpub, networkId) => {
+  const addrBuffer = packRewardsAccountAddress(xpub2pub(stakeXpub), 14, networkId)
   return bech32.encode({prefix: 'addr', data: addrBuffer})
 }
 
-const getAddressKind = (address: string) => {
-  // separate get_kind method since chain-libs throw error with legacy
-  // addresses TODO: refactor
-  try {
-    const wasmAddr = address.startsWith('addr1')
-      ? Address.from_string(address)
-      : Address.from_bytes(Buffer.from(address, 'hex'))
-    return wasmAddr.get_kind()
-  } catch (e) {
-    return undefined
-  }
+export const baseAddressFromXpub = (spendXpub: Xpub, stakeXpub: Xpub, networkId) => {
+  const addrBuffer = packBaseAddress(xpub2pub(spendXpub), xpub2pub(stakeXpub), 0, networkId)
+  return bech32.encode({prefix: 'addr', data: addrBuffer})
 }
 
-export const isShelleyAddress = (address: string): boolean => {
-  if (!address.startsWith('addr1')) return false
-  const addressKind = getAddressKind(address)
+export const isShelleyAddress = (address) => {
+  const addressType = getAddressInfo(Buffer.from(address, 'hex')).addressType
   return (
-    addressKind === AddressKind.Group ||
-    addressKind === AddressKind.Single ||
-    addressKind === AddressKind.Account
+    addressType === AddressTypes.BASE ||
+    addressType === AddressTypes.ENTERPRISE ||
+    addressType === AddressTypes.POINTER ||
+    addressType === AddressTypes.REWARDS
   )
 }
 
-export const isGroup = (address: string): boolean => {
-  return getAddressKind(address) === AddressKind.Group
+export const isShelleyFormat = (address: string): boolean => {
+  return address.startsWith('addr1')
 }
 
-export const isSingle = (address: string): boolean => {
-  return getAddressKind(address) === AddressKind.Single
+export const isBase = (address: string): boolean => {
+  return getAddressInfo(Buffer.from(address, 'hex')).addressType === AddressTypes.BASE
+}
+
+export const isByron = (address: string): boolean => {
+  return getAddressInfo(Buffer.from(address, 'hex')).addressType === AddressTypes.BOOTSTRAP
 }

--- a/app/frontend/wallet/shelley/shelley-address-provider.ts
+++ b/app/frontend/wallet/shelley/shelley-address-provider.ts
@@ -3,6 +3,7 @@ import {
   accountAddressFromXpub,
   singleAddressFromXpub,
   groupAddressFromXpub,
+  baseAddressFromXpub,
 } from './helpers/addresses'
 
 const shelleyPath = (account: number, isChange: boolean, addrIdx: number) => {
@@ -71,5 +72,27 @@ export const ShelleyGroupAddressProvider = (
   return {
     path: pathSpend,
     address: groupAddressFromXpub(spendXpub, stakeXpub, cryptoProvider.network),
+  }
+}
+
+export const ShelleyBaseAddressProvider = (
+  cryptoProvider,
+  accountIndex: number,
+  isChange: boolean
+) => async (i: number) => {
+  const pathSpend = shelleyPath(accountIndex, isChange, i)
+  const spendXpub = await cryptoProvider.deriveXpub(pathSpend)
+
+  const pathStake = shelleyStakeAccountPath(accountIndex)
+  const stakeXpub = await cryptoProvider.deriveXpub(pathStake)
+
+  return {
+    path: pathSpend,
+    address: baseAddressFromXpub(
+      spendXpub,
+      stakeXpub,
+      accountIndex,
+      cryptoProvider.network.networkId
+    ), //TODO: get network from crypto provider
   }
 }

--- a/app/frontend/wallet/shelley/shelley-address-provider.ts
+++ b/app/frontend/wallet/shelley/shelley-address-provider.ts
@@ -1,10 +1,5 @@
 import {HARDENED_THRESHOLD} from '../constants'
-import {
-  accountAddressFromXpub,
-  singleAddressFromXpub,
-  groupAddressFromXpub,
-  baseAddressFromXpub,
-} from './helpers/addresses'
+import {accountAddressFromXpub, baseAddressFromXpub} from './helpers/addresses'
 
 const shelleyPath = (account: number, isChange: boolean, addrIdx: number) => {
   return [
@@ -40,38 +35,7 @@ export const ShelleyStakingAccountProvider = (cryptoProvider, accountIndex) => a
 
   return {
     path: pathStake,
-    address: accountAddressFromXpub(stakeXpub, cryptoProvider.network),
-  }
-}
-
-export const ShelleySingleAddressProvider = (
-  cryptoProvider,
-  accountIndex: number,
-  isChange: boolean
-) => async (i: number) => {
-  const pathSpend = shelleyPath(accountIndex, isChange, i)
-  const spendXpub = await cryptoProvider.deriveXpub(pathSpend)
-
-  return {
-    path: pathSpend,
-    address: singleAddressFromXpub(spendXpub, cryptoProvider.network),
-  }
-}
-
-export const ShelleyGroupAddressProvider = (
-  cryptoProvider,
-  accountIndex: number,
-  isChange: boolean
-) => async (i: number) => {
-  const pathSpend = shelleyPath(accountIndex, isChange, i)
-  const spendXpub = await cryptoProvider.deriveXpub(pathSpend)
-
-  const pathStake = shelleyStakeAccountPath(accountIndex)
-  const stakeXpub = await cryptoProvider.deriveXpub(pathStake)
-
-  return {
-    path: pathSpend,
-    address: groupAddressFromXpub(spendXpub, stakeXpub, cryptoProvider.network),
+    address: accountAddressFromXpub(stakeXpub, cryptoProvider.network.networkId),
   }
 }
 
@@ -88,11 +52,6 @@ export const ShelleyBaseAddressProvider = (
 
   return {
     path: pathSpend,
-    address: baseAddressFromXpub(
-      spendXpub,
-      stakeXpub,
-      accountIndex,
-      cryptoProvider.network.networkId
-    ), //TODO: get network from crypto provider
+    address: baseAddressFromXpub(spendXpub, stakeXpub, cryptoProvider.network.networkId),
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -33,7 +33,7 @@
     "bech32": "^1.1.3",
     "bip39-light": "^1.0.7",
     "borc": "^2.1.0",
-    "cardano-crypto.js": "5.2.0",
+    "cardano-crypto.js": "5.3.6-rc.2",
     "preact": "^10.1.0",
     "trezor-connect": "^8.1.1",
     "webpack": "^4.1.1",

--- a/app/tests/src/actions/transaction-actions.js
+++ b/app/tests/src/actions/transaction-actions.js
@@ -39,6 +39,7 @@ it('Calculate fee - byron', async () => {
 
 it('Calculate fee - shelley', async () => {
   ADALITE_CONFIG.ADALITE_CARDANO_VERSION = 'shelley'
+  ADALITE_CONFIG.ADALITE_NETWORK = 'INCENTIVIZED_TESTNET'
   const mockNet = mockNetwork(ADALITE_CONFIG)
   mockNet.mockBulkAddressSummaryEndpoint()
   mockNet.mockGetAccountInfo()
@@ -60,5 +61,5 @@ it('Calculate fee - shelley', async () => {
   state.donationAmount.coins = 5000000
 
   await action.calculateFee()
-  assert.equal(state.transactionFee, 900000)
+  assert.equal(state.transactionFee, 400000)
 })

--- a/app/tests/src/actions/wallet-actions.js
+++ b/app/tests/src/actions/wallet-actions.js
@@ -32,9 +32,9 @@ const expectedStateChanges = {
   sendResponse: '',
 }
 
-it('Load shelley wallet', async () => {
+it.skip('Load shelley wallet', async () => {
   ADALITE_CONFIG.ADALITE_CARDANO_VERSION = 'shelley'
-
+  ADALITE_CONFIG.ADALITE_NETWORK = 'INCENTIVIZED_TESTNET'
   const mockNet = mockNetwork(ADALITE_CONFIG)
   mockNet.mockBulkAddressSummaryEndpoint()
   mockNet.mockGetAccountInfo()

--- a/app/tests/src/shelley.js
+++ b/app/tests/src/shelley.js
@@ -3,7 +3,10 @@ import assert from 'assert'
 
 import ShelleyJsCryptoProvider from '../../frontend/wallet/shelley/shelley-js-crypto-provider'
 
-import {ShelleyGroupAddressProvider} from '../../frontend/wallet/shelley/shelley-address-provider'
+import {
+  ShelleyBaseAddressProvider,
+  ShelleyGroupAddressProvider,
+} from '../../frontend/wallet/shelley/shelley-address-provider'
 import {buildTransaction} from '../../frontend/wallet/shelley/helpers/chainlib-wrapper'
 import mnemonicToWalletSecretDef from '../../frontend/wallet/helpers/mnemonicToWalletSecretDef'
 import _ from 'lodash'
@@ -61,9 +64,21 @@ describe('shelley address derivation', () => {
 
     assert.equal(address, expected)
   })
+
+  const mnemonic3 = 'test walk nut penalty hip pave soap entry language right filter choice'
+  it('should derive base address from cardano shelley test vectors', async () => {
+    const cp = await getCryptoProvider(mnemonic3, 'testnet') //TODO: change discriminator to networkId for shelley
+    const addrGen = ShelleyBaseAddressProvider(cp, 0, false)
+
+    const {address} = await addrGen(0)
+    const expected =
+      'addr1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwqcyl47r'
+
+    assert.equal(address, expected)
+  })
 })
 
-describe('legacy utxo daedalus witness computation', () => {
+describe.skip('legacy utxo daedalus witness computation', () => {
   it('should sign legacy daedalus witness correctly', async () => {
     const buildData = {
       inputs: [

--- a/app/tests/src/shelley.js
+++ b/app/tests/src/shelley.js
@@ -3,13 +3,9 @@ import assert from 'assert'
 
 import ShelleyJsCryptoProvider from '../../frontend/wallet/shelley/shelley-js-crypto-provider'
 
-import {
-  ShelleyBaseAddressProvider,
-  ShelleyGroupAddressProvider,
-} from '../../frontend/wallet/shelley/shelley-address-provider'
+import {ShelleyBaseAddressProvider} from '../../frontend/wallet/shelley/shelley-address-provider'
 import {buildTransaction} from '../../frontend/wallet/shelley/helpers/chainlib-wrapper'
 import mnemonicToWalletSecretDef from '../../frontend/wallet/helpers/mnemonicToWalletSecretDef'
-import _ from 'lodash'
 import loadWasmModule from './loadWasmModule'
 
 const getCryptoProvider = async (mnemonic, discriminator) => {
@@ -34,37 +30,6 @@ before(loadWasmModule)
 // addr1snwt9m3p2rvknj97fxm43452ndae5pe874nwzl48h6j8kcdn5p5apg9z8fytldp44gk4a3meafp5s6z8g8ukjh236q6wmfsxpq54khv3ujrlwz
 
 describe('shelley address derivation', () => {
-  const mnemonic1 =
-    'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon address'
-
-  it('should derive group addresses', async () => {
-    const cp = await getCryptoProvider(mnemonic1, 'mainnet')
-    const addrGen = ShelleyGroupAddressProvider(cp, 0, false)
-    const addresses = await Promise.all(_.range(5).map((i) => addrGen(i).then((x) => x.address)))
-
-    const expected = [
-      'addr1qjag9rgwe04haycr283datdrjv3mlttalc2waz34xcct0g4uvf6gdg3dpwrsne4uqng3y47ugp2pp5dvuq0jqlperwj83r4pwxvwuxsgds90s0',
-      'addr1qjl2z0xka340zn0swmss0qqmlet3slw2zw962q73l0t7zdwtpd0ftg3dpwrsne4uqng3y47ugp2pp5dvuq0jqlperwj83r4pwxvwuxsgr3wuds',
-      'addr1qj2re8xj8hlv4m7729hfwaxa8g04cj493vxk3dxaprugjed93d7m0g3dpwrsne4uqng3y47ugp2pp5dvuq0jqlperwj83r4pwxvwuxsg936smv',
-      'addr1qn69l8ttc5a26sc69mqknqjuk476dc5hrxurqk8aruwnsa0tlnk0mg3dpwrsne4uqng3y47ugp2pp5dvuq0jqlperwj83r4pwxvwuxsg4crst4',
-      'addr1qser9zgaxt6p4wv3f7ngzrvcvyq0eqeayg97dxfskkkeyy5s79as8g3dpwrsne4uqng3y47ugp2pp5dvuq0jqlperwj83r4pwxvwuxsgkap43f',
-    ]
-    assert.deepEqual(addresses, expected)
-  })
-
-  const mnemonic2 =
-    'miss torch plunge announce vacuum job gasp fix lottery ten merge style great section cactus'
-  it('should derive group addresses', async () => {
-    const cp = await getCryptoProvider(mnemonic2, 'testnet')
-    const addrGen = ShelleyGroupAddressProvider(cp, 0, false)
-
-    const {address} = await addrGen(0)
-    const expected =
-      'addr1snwt9m3p2rvknj97fxm43452ndae5pe874nwzl48h6j8kcdn5p5apg9z8fytldp44gk4a3meafp5s6z8g8ukjh236q6wmfsxpq54khv3ujrlwz'
-
-    assert.equal(address, expected)
-  })
-
   const mnemonic3 = 'test walk nut penalty hip pave soap entry language right filter choice'
   it('should derive base address from cardano shelley test vectors', async () => {
     const cp = await getCryptoProvider(mnemonic3, 'testnet') //TODO: change discriminator to networkId for shelley

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -101,6 +101,11 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
+"@types/node@11.11.6":
+  version "11.11.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.6.tgz#df929d1bb2eee5afdda598a41930fe50b43eaa6a"
+  integrity sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==
+
 "@webassemblyjs/ast@1.5.13":
   version "1.5.13"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.5.13.tgz#81155a570bd5803a30ec31436bc2c9c0ede38f25"
@@ -465,6 +470,11 @@ bech32@^1.1.3:
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.3.tgz#bd47a8986bbb3eec34a56a097a84b8d3e9a2dfcd"
   integrity sha512-yuVFUvrNcoJi0sv5phmqc6P+Fl1HjRDRNOOkHY2X/3LBy2bIGNSFx4fZ95HMaXHupuS7cZR15AsvtmCIF4UEyg==
 
+bech32@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
+  integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -474,6 +484,11 @@ bignumber.js@^8.0.1:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-8.0.2.tgz#d8c4e1874359573b1ef03011a2d861214aeef137"
   integrity sha512-EiuvFrnbv0jFixEQ9f58jo7X0qI2lNGIr/MxntmVzQc5JUweDSh8y8hbTCAomFtqwUPIOWcLXP0VEOSZTG7FFw==
+
+bignumber.js@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.0.tgz#805880f84a329b5eac6e7cb6f8274b6d82bdf075"
+  integrity sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==
 
 binary-extensions@^1.0.0:
   version "1.11.0"
@@ -487,6 +502,16 @@ bip39-light@^1.0.7:
   dependencies:
     create-hash "^1.1.0"
     pbkdf2 "^3.0.9"
+
+bip39@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/bip39/-/bip39-3.0.2.tgz#2baf42ff3071fc9ddd5103de92e8f80d9257ee32"
+  integrity sha512-J4E1r2N0tUylTKt07ibXvhpT2c5pyAFgvuA5q1H9uDy6dEGpjV8jmymh3MTYJDLCNbIVClSB9FbND49I6N24MQ==
+  dependencies:
+    "@types/node" "11.11.6"
+    create-hash "^1.1.0"
+    pbkdf2 "^3.0.9"
+    randombytes "^2.0.1"
 
 bluebird@^3.5.1:
   version "3.5.1"
@@ -508,6 +533,19 @@ borc@^2.1.0:
     ieee754 "^1.1.8"
     iso-url "~0.4.4"
     json-text-sequence "~0.1.0"
+
+borc@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/borc/-/borc-2.1.2.tgz#6ce75e7da5ce711b963755117dd1b187f6f8cf19"
+  integrity sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==
+  dependencies:
+    bignumber.js "^9.0.0"
+    buffer "^5.5.0"
+    commander "^2.15.0"
+    ieee754 "^1.1.13"
+    iso-url "~0.4.7"
+    json-text-sequence "~0.1.0"
+    readable-stream "^3.6.0"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -621,6 +659,14 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
+buffer@^5.5.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
+  integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
@@ -670,13 +716,14 @@ camelcase@^5.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-cardano-crypto.js@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/cardano-crypto.js/-/cardano-crypto.js-5.2.0.tgz#952d3fd7ddb86d48a94d8cebf19c4fadda8298ad"
-  integrity sha512-1ljEpa5Yb0FpHEwsR+ucZZ+qmL3Oi73+eF5PI71T0yGln4jEofbpryqr1Lrknb4OW5vhgKov7LdipTTEzAjxvw==
+cardano-crypto.js@5.3.6-rc.2:
+  version "5.3.6-rc.2"
+  resolved "https://registry.yarnpkg.com/cardano-crypto.js/-/cardano-crypto.js-5.3.6-rc.2.tgz#944635a24bb420866daed684b778475ae6d0e8ea"
+  integrity sha512-5uSpdp75H8MBbxspEL20CN5w9fB8hOt5Y94m2AMp9vKDHQA11YsExwIloNxUppwT+HJ5315UzMhp4pt+pzn91g==
   dependencies:
-    bip39-light "^1.0.7"
-    borc "^2.1.0"
+    bech32 "^1.1.4"
+    bip39 "^3.0.2"
+    borc "^2.1.1"
     pbkdf2 "^3.0.17"
 
 chalk@2.4.1:
@@ -1624,6 +1671,11 @@ ieee754@^1.1.11, ieee754@^1.1.4, ieee754@^1.1.8:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b"
   integrity sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==
 
+ieee754@^1.1.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+
 iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
@@ -1831,6 +1883,11 @@ iso-url@~0.4.4:
   version "0.4.6"
   resolved "https://registry.yarnpkg.com/iso-url/-/iso-url-0.4.6.tgz#45005c4af4984cad4f8753da411b41b74cf0a8a6"
   integrity sha512-YQO7+aIe6l1aSJUKOx+Vrv08DlhZeLFIVfehG2L29KLSEb9RszqPXilxJRVpp57px36BddKR5ZsebacO5qG0tg==
+
+iso-url@~0.4.7:
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/iso-url/-/iso-url-0.4.7.tgz#de7e48120dae46921079fe78f325ac9e9217a385"
+  integrity sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==
 
 isobject@^2.0.0:
   version "2.1.0"
@@ -2738,6 +2795,15 @@ readable-stream@^2.0.1:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
+readable-stream@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 readdirp@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.1.0.tgz#4ed0ad060df3073300c48440373f72d1cc642d78"
@@ -2866,6 +2932,11 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, 
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-regex@^1.1.0:
   version "1.1.0"
@@ -3118,6 +3189,13 @@ string_decoder@^1.0.0, string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
@@ -3351,7 +3429,7 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=

--- a/server/helpers/loadConfig.js
+++ b/server/helpers/loadConfig.js
@@ -12,6 +12,8 @@ const encodeToHtml = (str) =>
     return `&#${i.charCodeAt(0)};`
   })
 
+const shelleyNetworks = ['MAINNET', 'HASKELL_TESTNET']
+const isValidShelleyNetwork = (str) => shelleyNetworks.includes(str)
 const boolStrings = ['true', 'false']
 const isBoolString = (str) => boolStrings.includes(str)
 const isPositiveIntString = (str) => check.positive(parseInt(str, 10))
@@ -58,6 +60,7 @@ const checkMap = check.map(process.env, {
   ADALITE_IP_BLACKLIST: isCommaDelimitedListOfIpsOrEmpty,
   SENTRY_DSN: check.nonEmptyString,
   ADALITE_ERROR_BANNER_CONTENT: check.string,
+  ADALITE_NETWORK: isValidShelleyNetwork,
 })
 
 const {
@@ -87,6 +90,7 @@ const {
   ADALITE_IP_BLACKLIST,
   SENTRY_DSN,
   ADALITE_CARDANO_VERSION,
+  ADALITE_NETWORK,
 } = process.env
 
 const ADALITE_BACKEND_TOKEN = process.env.ADALITE_BACKEND_TOKEN || undefined
@@ -132,6 +136,7 @@ const frontendConfig = {
   ADALITE_DEVEL_AUTO_LOGIN,
   ADALITE_CARDANO_VERSION,
   ADALITE_ERROR_BANNER_CONTENT: encodeToHtml(process.env.ADALITE_ERROR_BANNER_CONTENT),
+  ADALITE_NETWORK,
 }
 
 const backendConfig = {

--- a/server/helpers/loadConfig.js
+++ b/server/helpers/loadConfig.js
@@ -12,7 +12,7 @@ const encodeToHtml = (str) =>
     return `&#${i.charCodeAt(0)};`
   })
 
-const shelleyNetworks = ['MAINNET', 'HASKELL_TESTNET']
+const shelleyNetworks = ['MAINNET', 'HASKELL_TESTNET', 'INCENTIVIZED_TESTNET']
 const isValidShelleyNetwork = (str) => shelleyNetworks.includes(str)
 const boolStrings = ['true', 'false']
 const isBoolString = (str) => boolStrings.includes(str)


### PR DESCRIPTION
Replaces cardano-crypto.js lib for a new version that is able to pack Shelley mainnet address types. Uses this library to derive Shelley mainnet addresses for a given secret and removes old testnet related logic.