### PR TITLE
Switch cardanoexplorer for adascan

### DIFF
--- a/app/frontend/components/common/footer.tsx
+++ b/app/frontend/components/common/footer.tsx
@@ -83,7 +83,7 @@ const Footer = () => {
             </a>
             <a
               className="donations-item ada"
-              href={`https://seiza.com/blockchain/address/${getDonationAddress()}`}
+              href={`https://adascan.net/address/${getDonationAddress()}`}
               target="_blank"
               title="Donate via Adalite"
               rel="noopener"

--- a/app/frontend/components/pages/receiveAda/addressItem.tsx
+++ b/app/frontend/components/pages/receiveAda/addressItem.tsx
@@ -68,11 +68,11 @@ class AddressItem extends Component<Props, {onSmallDevice: boolean}> {
                 <span> | </span>
                 <a
                   className="address-link"
-                  href={`https://explorer.cardano.org/en/address/?address=${address}`}
+                  href={`https://adascan.net/address/${address}`}
                   target="_blank"
                   rel="noopener"
                 >
-                  CardanoExplorer
+                  AdaScan
                 </a>
               </span>
             )}

--- a/app/frontend/components/pages/txHistory/transactionHistory.tsx
+++ b/app/frontend/components/pages/txHistory/transactionHistory.tsx
@@ -37,11 +37,11 @@ const Transaction = ({txid}) => (
         <span> | </span>
         <a
           className="transaction-address"
-          href={`https://explorer.cardano.org/en/transaction/?id=${txid}`}
+          href={`https://adascan.net/transaction/${txid}`}
           target="_blank"
           rel="noopener"
         >
-          CardanoExplorer
+          AdaScan
         </a>
       </span>
     )}


### PR DESCRIPTION
Seiza is down and Cardanoexplorer has apparently some routing issues and you cannot go to an address/txid via the url (try e.g. https://explorer.cardano.org/en/transaction/?id=17eaffc77d431d30b60b5630c69cdc02692d6eac93692072975f0dcfad6cb909), you need to type it into the search bar. This is especially awkard for txids as we do not show them in the interface. Meanwhile, adascan is working again so we can switch back to it.
