### PR TITLE
Set transaction ttl

### DIFF
--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -384,12 +384,12 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
     const newState = getState()
     try {
       if (newState.sendTransactionSummary.plan) {
-        txAux = wallet.prepareTxAux(newState.sendTransactionSummary.plan)
+        txAux = await wallet.prepareTxAux(newState.sendTransactionSummary.plan)
       } else {
         loadingAction(state, 'Preparing transaction plan...')
         await sleep(1000) // wait for plan to be set in case of unfortunate timing
         const retriedState = getState()
-        txAux = wallet.prepareTxAux(retriedState.sendTransactionSummary.plan)
+        txAux = await wallet.prepareTxAux(retriedState.sendTransactionSummary.plan)
         stopLoadingAction(state, {})
       }
     } catch (e) {
@@ -1109,7 +1109,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
     let txSubmitResult
     const txTab = state.sendTransactionSummary.tab
     try {
-      const txAux = wallet.prepareTxAux(state.sendTransactionSummary.plan)
+      const txAux = await wallet.prepareTxAux(state.sendTransactionSummary.plan)
       const signedTx = await wallet.signTxAux(txAux)
 
       if (state.usingHwWallet) {

--- a/app/frontend/wallet/constants.ts
+++ b/app/frontend/wallet/constants.ts
@@ -27,7 +27,8 @@ export const NETWORKS = {
       name: 'mainnet',
       networkId: 1,
       protocolMagic: 764824073,
-      ttl: 10000000,
+      maxTtl: 10000000,
+      ttl: 3600,
     },
     HASKELL_TESTNET: {
       name: 'htn',

--- a/app/frontend/wallet/constants.ts
+++ b/app/frontend/wallet/constants.ts
@@ -27,7 +27,8 @@ export const NETWORKS = {
       name: 'mainnet',
       networkId: 1,
       protocolMagic: 764824073,
-      maxTtl: 10000000,
+      eraStartSlot: 4492800, // 21600 slot x 208 epochs
+      eraStartDateTime: Date.parse('29 Jul 2020 21:44:51 UTC'),
       ttl: 3600,
     },
     HASKELL_TESTNET: {

--- a/app/frontend/wallet/shelley-wallet.ts
+++ b/app/frontend/wallet/shelley-wallet.ts
@@ -169,7 +169,7 @@ const ShelleyBlockchainExplorer = (config) => {
     return {validStakepools}
   }
 
-  async function getBestSlot() {
+  function getBestSlot() {
     return request(`${ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL}/api/v2/bestSlot`)
   }
 

--- a/app/frontend/wallet/shelley-wallet.ts
+++ b/app/frontend/wallet/shelley-wallet.ts
@@ -245,17 +245,13 @@ const ShelleyWallet = ({
   }
 
   async function calculateTtl() {
-    return (
-      cryptoProvider.network.ttl +
-      (await blockchainExplorer
-        .getBestSlot()
-        .then((res) => res.Right.bestSlot)
-        .catch(
-          () =>
-            cryptoProvider.network.eraStartSlot +
-            Math.floor((Date.now() - cryptoProvider.network.eraStartDateTime) / 1000)
-        ))
-    )
+    try {
+      const bestSlot = await blockchainExplorer.getBestSlot().then((res) => res.Right.bestSlot)
+      return bestSlot + cryptoProvider.network.ttl
+    } catch (e) {
+      const timePassed = Math.floor((Date.now() - cryptoProvider.network.eraStartDateTime) / 1000)
+      return cryptoProvider.network.eraStartSlot + timePassed + cryptoProvider.network.ttl
+    }
   }
 
   async function prepareTxAux(plan) {

--- a/app/frontend/wallet/shelley/shelley-ledger-crypto-provider.ts
+++ b/app/frontend/wallet/shelley/shelley-ledger-crypto-provider.ts
@@ -211,11 +211,12 @@ const ShelleyLedgerCryptoProvider = async ({network, config, isWebUSB}) => {
   }
 
   async function signTx(unsignedTx, rawInputTxs, addressToAbsPathMapper) {
+    console.log(unsignedTx)
     const inputs = unsignedTx.inputs.map((input, i) => _prepareInput(input, addressToAbsPathMapper))
     const outputs = unsignedTx.outputs.map((output) => _prepareOutput(output))
     const certificates = unsignedTx.certs.map((cert) => _prepareCert(cert, addressToAbsPathMapper))
     const feeStr = `${unsignedTx.fee.fee}`
-    const ttlStr = `${network.ttl}`
+    const ttlStr = `${unsignedTx.ttl.ttl}`
     const withdrawals = unsignedTx.withdrawals
       ? [_prepareWithdrawal(unsignedTx.withdrawals, addressToAbsPathMapper)]
       : []

--- a/app/frontend/wallet/shelley/shelley-ledger-crypto-provider.ts
+++ b/app/frontend/wallet/shelley/shelley-ledger-crypto-provider.ts
@@ -211,7 +211,6 @@ const ShelleyLedgerCryptoProvider = async ({network, config, isWebUSB}) => {
   }
 
   async function signTx(unsignedTx, rawInputTxs, addressToAbsPathMapper) {
-    console.log(unsignedTx)
     const inputs = unsignedTx.inputs.map((input, i) => _prepareInput(input, addressToAbsPathMapper))
     const outputs = unsignedTx.outputs.map((output) => _prepareOutput(output))
     const certificates = unsignedTx.certs.map((cert) => _prepareCert(cert, addressToAbsPathMapper))


### PR DESCRIPTION
Implements logic for dynamic fee calculation. At first, we try to get the latest slot from out backend and add 3600 slots to it (meaning the ttl for tx is 1 hour) and if the request for some reason fails, we calculate the ttl from the date.