### PR TITLE
Change staking screen descriptions and make UI design more consistent

### DIFF
--- a/app/frontend/components/common/accordion.tsx
+++ b/app/frontend/components/common/accordion.tsx
@@ -1,0 +1,33 @@
+import {Fragment, h} from 'preact'
+import {useState, useCallback} from 'preact/hooks'
+import {DropdownCaret} from './svg'
+
+interface Props {
+  initialVisibility: Boolean
+  header: h.JSX.Element
+  body: h.JSX.Element
+}
+
+const Accordion = ({initialVisibility, header, body}: Props) => {
+  const [visible, setVisible] = useState(initialVisibility)
+  const toggleVisibility = useCallback(
+    () => {
+      setVisible(!visible)
+    },
+    [visible]
+  )
+
+  return (
+    <Fragment>
+      <div className="accordion space-between" onClick={toggleVisibility}>
+        <div>{header}</div>
+        <div className={`accordion-icon ${visible ? 'shown' : 'hidden'}`}>
+          <DropdownCaret />
+        </div>
+      </div>
+      <div className={`accordion-panel ${visible ? 'shown' : 'hidden'}`}>{body}</div>
+    </Fragment>
+  )
+}
+
+export default Accordion

--- a/app/frontend/components/common/balance.tsx
+++ b/app/frontend/components/common/balance.tsx
@@ -20,7 +20,7 @@ const Balance = ({balance, reloadWalletInfo, conversionRates}: Props) => (
         {isNaN(Number(balance)) ? balance : `${printAda(balance)}`}
         <AdaIcon />
       </div>
-      <button className="button refresh" onClick={reloadWalletInfo}>
+      <button className="button secondary refresh" onClick={reloadWalletInfo}>
         Refresh Balance
       </button>
     </div>

--- a/app/frontend/components/common/balance.tsx
+++ b/app/frontend/components/common/balance.tsx
@@ -14,14 +14,14 @@ interface Props {
 
 const Balance = ({balance, reloadWalletInfo, conversionRates}: Props) => (
   <div className="balance card">
-    <h2 className="card-title balance-title">Balance</h2>
+    <h2 className="card-title balance-title">Available balance</h2>
     <div className="balance-row">
       <div className="balance-amount">
         {isNaN(Number(balance)) ? balance : `${printAda(balance)}`}
         <AdaIcon />
       </div>
       <button className="button secondary refresh" onClick={reloadWalletInfo}>
-        Refresh Balance
+        Refresh
       </button>
     </div>
     {conversionRates && <Conversions balance={balance} conversionRates={conversionRates} />}

--- a/app/frontend/components/common/balance.tsx
+++ b/app/frontend/components/common/balance.tsx
@@ -20,7 +20,7 @@ const Balance = ({balance, reloadWalletInfo, conversionRates}: Props) => (
         {isNaN(Number(balance)) ? balance : `${printAda(balance)}`}
         <AdaIcon />
       </div>
-      <button className="button secondary refresh" onClick={reloadWalletInfo}>
+      <button className="button secondary balance refresh" onClick={reloadWalletInfo}>
         Refresh
       </button>
     </div>

--- a/app/frontend/components/common/navbar/navbarAuth.tsx
+++ b/app/frontend/components/common/navbar/navbarAuth.tsx
@@ -99,7 +99,7 @@ class NavbarAuth extends Component<Props, {}> {
               Help
             </a>
           </div>
-          <button className="button logout" onClick={() => setTimeout(logout, 100)}>
+          <button className="button secondary logout" onClick={() => setTimeout(logout, 100)}>
             Logout
           </button>
         </div>

--- a/app/frontend/components/common/svg.tsx
+++ b/app/frontend/components/common/svg.tsx
@@ -270,6 +270,31 @@ const DownloadIcon = () => (
   </svg>
 )
 
+const DropdownCaret = () => (
+  <svg width="24px" height="12px" viewBox="0 0 12 6" version="1.1">
+    <g
+      id="Symbols"
+      stroke="none"
+      strokeWidth="1"
+      fill="none"
+      fillRule="evenodd"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <g
+        id="select"
+        transform="translate(-348.000000, -31.000000)"
+        stroke="#20323F"
+        strokeWidth="1.3"
+      >
+        <g id="Group-4">
+          <polyline id="Path-7" points="349 32 354 36 359 32" />
+        </g>
+      </g>
+    </g>
+  </svg>
+)
+
 export {
   LedgerLogoWhite,
   TrezorLogoWhite,
@@ -284,4 +309,5 @@ export {
   ExitIcon,
   RefreshIcon,
   DownloadIcon,
+  DropdownCaret,
 }

--- a/app/frontend/components/pages/delegations/delegatePage.tsx
+++ b/app/frontend/components/pages/delegations/delegatePage.tsx
@@ -146,7 +146,7 @@ class Delegate extends Component<Props> {
         </div>
         <div className="validation-row">
           <button
-            className="button primary staking"
+            className="button primary"
             disabled={
               !isShelleyCompatible ||
               validationError ||

--- a/app/frontend/components/pages/delegations/delegatePage.tsx
+++ b/app/frontend/components/pages/delegations/delegatePage.tsx
@@ -1,4 +1,4 @@
-import {h, Component} from 'preact'
+import {h, Component, Fragment} from 'preact'
 import {connect} from '../../../libs/unistore/preact'
 import actions from '../../../actions'
 import tooltip from '../../common/tooltip'
@@ -10,6 +10,7 @@ import {errorHasHelp} from '../../../helpers/errorsWithHelp'
 import ConfirmTransactionDialog from '../../pages/sendAda/confirmTransactionDialog'
 import {Lovelace} from '../../../state'
 import {ADALITE_CONFIG} from '../../../config'
+import Accordion from '../../common/accordion'
 
 const CalculatingFee = () => <div className="validation-message send">Calculating fee...</div>
 
@@ -84,6 +85,7 @@ interface Props {
   shouldShowConfirmTransactionDialog: any
   txSuccessTab: any
   gettingPoolInfo: boolean
+  pool: any
 }
 
 class Delegate extends Component<Props> {
@@ -110,79 +112,88 @@ class Delegate extends Component<Props> {
     shouldShowConfirmTransactionDialog,
     txSuccessTab,
     gettingPoolInfo,
+    pool,
   }) {
     const delegationHandler = async () => {
       await confirmTransaction('delegate')
     }
     const validationError =
       delegationValidationError || stakePool.validationError || stakePool.poolHash === ''
+
     return (
       <div className="delegate card">
-        <h2 className="card-title">Delegate Stake</h2>
-        <div className="stakepools">
-          <ul className="stake-pool-list">
-            <li className="stake-pool-item">
-              <input
-                type="text"
-                className="input stake-pool-id"
-                name={'pool'}
-                placeholder="Stake Pool ID"
-                value={stakePool.poolHash}
-                onInput={updateStakePoolIdentifier}
-                autoComplete="off"
-              />
-              <StakePoolInfo pool={stakePool} gettingPoolInfo={gettingPoolInfo} />
-              <div />
-            </li>
-          </ul>
-        </div>
+        <Accordion
+          initialVisibility={!Object.keys(pool).length}
+          header={<h2 className="card-title no-margin">Delegate Stake</h2>}
+          body={
+            <Fragment>
+              <div className="stake-pool">
+                <ul className="stake-pool-list">
+                  <li className="stake-pool-item">
+                    <input
+                      type="text"
+                      className="input stake-pool-id"
+                      name={'pool'}
+                      placeholder="Stake Pool ID"
+                      value={stakePool.poolHash}
+                      onInput={updateStakePoolIdentifier}
+                      autoComplete="off"
+                    />
+                    <StakePoolInfo pool={stakePool} gettingPoolInfo={gettingPoolInfo} />
+                    <div />
+                  </li>
+                </ul>
+              </div>
 
-        <div className="add-stake-pool-wrapper" />
-        <div className="delegation-info-row">
-          <label className="fee-label">
-            Fee<AdaIcon />
-          </label>
-          <div className="delegation-fee">{printAda(delegationFee)}</div>
-        </div>
-        <div className="validation-row">
-          <button
-            className="button primary"
-            disabled={
-              !isShelleyCompatible ||
-              validationError ||
-              calculatingDelegationFee ||
-              stakePool.poolHash === ''
-            }
-            onClick={delegationHandler}
-            {...tooltip(
-              'You are using Shelley incompatible wallet. To delegate your ADA, follow the instructions to convert you wallet.',
-              !isShelleyCompatible
-            )}
-          >
-            Delegate
-          </button>
-          {[
-            calculatingDelegationFee ? (
-              <CalculatingFee />
-            ) : (
-              <DelegationValidation
-                delegationValidationError={delegationValidationError}
-                txSuccessTab={txSuccessTab}
-              />
-            ),
-          ]}
-        </div>
-        {shouldShowTransactionErrorModal && (
-          <TransactionErrorModal
-            onRequestClose={closeTransactionErrorModal}
-            errorMessage={getTranslation(
-              transactionSubmissionError.code,
-              transactionSubmissionError.params
-            )}
-            showHelp={errorHasHelp(transactionSubmissionError.code)}
-          />
-        )}
-        {shouldShowConfirmTransactionDialog && <ConfirmTransactionDialog isDelegation />}
+              <div className="add-stake-pool-wrapper" />
+              <div className="delegation-info-row">
+                <label className="fee-label">
+                  Fee<AdaIcon />
+                </label>
+                <div className="delegation-fee">{printAda(delegationFee)}</div>
+              </div>
+              <div className="validation-row">
+                <button
+                  className="button primary"
+                  disabled={
+                    !isShelleyCompatible ||
+                    validationError ||
+                    calculatingDelegationFee ||
+                    stakePool.poolHash === ''
+                  }
+                  onClick={delegationHandler}
+                  {...tooltip(
+                    'You are using Shelley incompatible wallet. To delegate your ADA, follow the instructions to convert you wallet.',
+                    !isShelleyCompatible
+                  )}
+                >
+                  Delegate
+                </button>
+                {[
+                  calculatingDelegationFee ? (
+                    <CalculatingFee />
+                  ) : (
+                    <DelegationValidation
+                      delegationValidationError={delegationValidationError}
+                      txSuccessTab={txSuccessTab}
+                    />
+                  ),
+                ]}
+              </div>
+              {shouldShowTransactionErrorModal && (
+                <TransactionErrorModal
+                  onRequestClose={closeTransactionErrorModal}
+                  errorMessage={getTranslation(
+                    transactionSubmissionError.code,
+                    transactionSubmissionError.params
+                  )}
+                  showHelp={errorHasHelp(transactionSubmissionError.code)}
+                />
+              )}
+              {shouldShowConfirmTransactionDialog && <ConfirmTransactionDialog isDelegation />}
+            </Fragment>
+          }
+        />
       </div>
     )
   }
@@ -200,6 +211,7 @@ export default connect(
     txSuccessTab: state.txSuccessTab,
     gettingPoolInfo: state.gettingPoolInfo,
     isShelleyCompatible: state.isShelleyCompatible,
+    pool: state.shelleyAccountInfo.delegation,
   }),
   actions
 )(Delegate)

--- a/app/frontend/components/pages/delegations/shelleyBalances.tsx
+++ b/app/frontend/components/pages/delegations/shelleyBalances.tsx
@@ -109,7 +109,7 @@ const shelleyBalances = ({
           {isNaN(Number(balance)) ? balance : `${printAda(balance)}`}
           <AdaIcon />
         </div>
-        <button className="button refresh" onClick={reloadWalletInfo}>
+        <button className="button secondary refresh" onClick={reloadWalletInfo}>
           Refresh
         </button>
       </div>

--- a/app/frontend/components/pages/delegations/shelleyBalances.tsx
+++ b/app/frontend/components/pages/delegations/shelleyBalances.tsx
@@ -23,7 +23,7 @@ const shelleyBalances = ({
       <a
         className="wide-data-balloon"
         {...tooltip(
-          "Staking balance represents the funds that are on your staking addresses. Once you delegate to a pool, all these funds are staked. Stake delegation doesn't lock the funds and they are free to move. All funds that you receive to your addresses displayed on My Addresses tab on Send screen are automatically added to this balance (and therefore automatically staked)",
+          "Staking Balance represents the funds that are on your staking addresses. Once you delegate to a pool, all these funds are staked. Stake delegation doesn't lock the funds and they are free to move. All funds that you receive to your addresses displayed on My Addresses tab on Send screen are automatically added to this balance (and therefore automatically staked). Also all staking rewards that are added to your Rewards Balance at the end of each epoch are included in your Staking Balance.",
           true
         )}
       >
@@ -66,8 +66,9 @@ const shelleyBalances = ({
     <h2 className="card-title staking-balances-title">
       Rewards account balance
       <a
+        className="wide-data-balloon"
         {...tooltip(
-          'This value represents balance on your rewards account. It contains all received rewards from delegation.',
+          'This value represents balance on your rewards account. It contains all rewards received from delegation that were not transferred yet to your Available balance. This rewards are automatically staked. You need to Withdraw Rewards only when you want to spend them. Withdraw Rewards button will appear only once you have some rewards in your Rewards Balance.',
           true
         )}
       >
@@ -87,7 +88,7 @@ const shelleyBalances = ({
           className="button stake-pool"
           onClick={redeemRewards}
         >
-          Redeem
+          Withdraw Rewards
         </button>
       )}
     </div>
@@ -96,7 +97,7 @@ const shelleyBalances = ({
         Available balance
         <a
           {...tooltip(
-            'Balance on your payment addresses available to be used in transactions. In order to add your Rewards Balance to Available Balance, you need to redeem your rewards',
+            'Balance on your payment addresses available to be used in transactions. In order to add your Rewards Balance to Available Balance, you need to withdraw them.',
             true
           )}
         >

--- a/app/frontend/components/pages/delegations/shelleyBalances.tsx
+++ b/app/frontend/components/pages/delegations/shelleyBalances.tsx
@@ -56,7 +56,7 @@ const shelleyBalances = ({
         !!nonStakingBalance && (
         <button
           disabled={calculatingDelegationFee}
-          className="button stake-pool"
+          className="button secondary"
           onClick={convertNonStakingUtxos}
         >
             Convert to stakable
@@ -85,7 +85,7 @@ const shelleyBalances = ({
       {!!rewardsAccountBalance && (
         <button
           disabled={calculatingDelegationFee}
-          className="button stake-pool"
+          className="button secondary"
           onClick={redeemRewards}
         >
           Withdraw Rewards

--- a/app/frontend/components/pages/delegations/shelleyBalances.tsx
+++ b/app/frontend/components/pages/delegations/shelleyBalances.tsx
@@ -1,4 +1,4 @@
-import {h} from 'preact'
+import {Fragment, h} from 'preact'
 import printAda from '../../../helpers/printAda'
 import {AdaIcon} from '../../common/svg'
 import actions from '../../../actions'
@@ -19,11 +19,10 @@ const shelleyBalances = ({
 }) => (
   <div className="rewards card">
     <h2 className="card-title staking-balances-title">
-      Staking balance
+      Available balance
       <a
-        className="wide-data-balloon"
         {...tooltip(
-          "Staking Balance represents the funds that are on your staking addresses. Once you delegate to a pool, all these funds are staked. Stake delegation doesn't lock the funds and they are free to move. All funds that you receive to your addresses displayed on My Addresses tab on Send screen are automatically added to this balance (and therefore automatically staked). Also all staking rewards that are added to your Rewards Balance at the end of each epoch are included in your Staking Balance.",
+          'Balance on your payment addresses available to be used in transactions. In order to add your Rewards Balance to Available Balance, you need to withdraw them.',
           true
         )}
       >
@@ -32,37 +31,14 @@ const shelleyBalances = ({
     </h2>
     <div className="staking-balances-row">
       <div className="staking-balances-amount">
-        {isNaN(Number(stakingBalance)) ? stakingBalance : `${printAda(stakingBalance)}`}
+        {isNaN(Number(balance)) ? balance : `${printAda(balance)}`}
         <AdaIcon />
       </div>
+      <button className="button secondary refresh" onClick={reloadWalletInfo}>
+        Refresh
+      </button>
     </div>
-    <h2 className="card-title staking-balances-title">
-      Non-staking balance
-      <a
-        {...tooltip(
-          'These are funds located on legacy or non-staking addresses and can be automatically transferred to your first staking address by clicking on the "Convert to stakeable" button. (minimum is 1.5 ADA)',
-          true
-        )}
-      >
-        <span className="show-info">{''}</span>
-      </a>
-    </h2>
-    <div className="staking-balances-row">
-      <div className="staking-balances-amount">
-        {isNaN(Number(nonStakingBalance)) ? nonStakingBalance : `${printAda(nonStakingBalance)}`}
-        <AdaIcon />
-      </div>
-      {isShelleyCompatible &&
-        !!nonStakingBalance && (
-        <button
-          disabled={calculatingDelegationFee}
-          className="button secondary"
-          onClick={convertNonStakingUtxos}
-        >
-            Convert to stakable
-        </button>
-      )}
-    </div>
+
     <h2 className="card-title staking-balances-title">
       Rewards account balance
       <a
@@ -85,19 +61,21 @@ const shelleyBalances = ({
       {!!rewardsAccountBalance && (
         <button
           disabled={calculatingDelegationFee}
-          className="button secondary"
+          className="button secondary withdraw"
           onClick={redeemRewards}
         >
-          Withdraw Rewards
+          Withdraw
         </button>
       )}
     </div>
+
     <div className="total-balance-wrapper">
       <h2 className="card-title staking-balances-title">
-        Available balance
+        Staking balance
         <a
+          className="wide-data-balloon"
           {...tooltip(
-            'Balance on your payment addresses available to be used in transactions. In order to add your Rewards Balance to Available Balance, you need to withdraw them.',
+            "Staking Balance represents the funds that are on your staking addresses. Once you delegate to a pool, all these funds are staked. Stake delegation doesn't lock the funds and they are free to move. All funds that you receive to your addresses displayed on My Addresses tab on Send screen are automatically added to this balance (and therefore automatically staked). Also all staking rewards that are added to your Rewards Balance at the end of each epoch are included in your Staking Balance.",
             true
           )}
         >
@@ -106,13 +84,42 @@ const shelleyBalances = ({
       </h2>
       <div className="balance-row">
         <div className="balance-amount-staking">
-          {isNaN(Number(balance)) ? balance : `${printAda(balance)}`}
+          {isNaN(Number(stakingBalance)) ? stakingBalance : `${printAda(stakingBalance)}`}
           <AdaIcon />
         </div>
-        <button className="button secondary refresh" onClick={reloadWalletInfo}>
-          Refresh
-        </button>
       </div>
+
+      {isShelleyCompatible &&
+        !!nonStakingBalance && (
+        <Fragment>
+          <h2 className="card-title staking-balances-title">
+              Non-staking balance
+            <a
+              {...tooltip(
+                'These are funds located on legacy or non-staking addresses and can be automatically transferred to your first staking address by clicking on the "Convert to stakeable" button. (minimum is 1.5 ADA)',
+                true
+              )}
+            >
+              <span className="show-info">{''}</span>
+            </a>
+          </h2>
+          <div className="balance-row">
+            <div className="balance-amount-staking">
+              {isNaN(Number(nonStakingBalance))
+                ? nonStakingBalance
+                : `${printAda(nonStakingBalance)}`}
+              <AdaIcon />
+            </div>
+            <button
+              disabled={calculatingDelegationFee}
+              className="button secondary"
+              onClick={convertNonStakingUtxos}
+            >
+                Convert to stakable
+            </button>
+          </div>
+        </Fragment>
+      )}
     </div>
   </div>
 )

--- a/app/frontend/components/pages/delegations/shelleyBalances.tsx
+++ b/app/frontend/components/pages/delegations/shelleyBalances.tsx
@@ -112,11 +112,9 @@ const shelleyBalances = ({
             </div>
             <button
               disabled={calculatingDelegationFee}
-              className="button secondary"
+              className="button secondary convert"
               onClick={convertNonStakingUtxos}
-            >
-                Convert to stakable
-            </button>
+            />
           </div>
         </Fragment>
       )}

--- a/app/frontend/components/pages/delegations/shelleyBalances.tsx
+++ b/app/frontend/components/pages/delegations/shelleyBalances.tsx
@@ -34,7 +34,7 @@ const shelleyBalances = ({
         {isNaN(Number(balance)) ? balance : `${printAda(balance)}`}
         <AdaIcon />
       </div>
-      <button className="button secondary refresh" onClick={reloadWalletInfo}>
+      <button className="button secondary balance refresh" onClick={reloadWalletInfo}>
         Refresh
       </button>
     </div>
@@ -61,7 +61,7 @@ const shelleyBalances = ({
       {!!rewardsAccountBalance && (
         <button
           disabled={calculatingDelegationFee}
-          className="button secondary withdraw"
+          className="button secondary balance withdraw"
           onClick={redeemRewards}
         >
           Withdraw

--- a/app/public/assets/cash-stack.svg
+++ b/app/public/assets/cash-stack.svg
@@ -1,0 +1,5 @@
+<svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-cash-stack" fill="#606A71" xmlns="http://www.w3.org/2000/svg">
+  <path d="M14 3H1a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1h-1z"/>
+  <path fill-rule="evenodd" d="M15 5H1v8h14V5zM1 4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1H1z"/>
+  <path d="M13 5a2 2 0 0 0 2 2V5h-2zM3 5a2 2 0 0 1-2 2V5h2zm10 8a2 2 0 0 1 2-2v2h-2zM3 13a2 2 0 0 0-2-2v2h2zm7-4a2 2 0 1 1-4 0 2 2 0 0 1 4 0z"/>
+</svg>

--- a/app/public/assets/cash-stack_active.svg
+++ b/app/public/assets/cash-stack_active.svg
@@ -1,0 +1,5 @@
+<svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-cash-stack" fill="#E72076" xmlns="http://www.w3.org/2000/svg">
+  <path d="M14 3H1a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1h-1z"/>
+  <path fill-rule="evenodd" d="M15 5H1v8h14V5zM1 4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1H1z"/>
+  <path d="M13 5a2 2 0 0 0 2 2V5h-2zM3 5a2 2 0 0 1-2 2V5h2zm10 8a2 2 0 0 1 2-2v2h-2zM3 13a2 2 0 0 0-2-2v2h2zm7-4a2 2 0 1 1-4 0 2 2 0 0 1 4 0z"/>
+</svg>

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -3682,6 +3682,20 @@ input:checked + .slider:before {
     width: unset;
   }
 
+  /* ACCORDIONS */
+
+  .accordion {
+    cursor: unset;
+  }
+  
+  .accordion-panel.hidden, .accordion-panel.shown {
+    max-height: unset;
+  }
+  
+  .accordion-icon {
+    display: none;
+  }
+
   /* NAVBAR */
 
   .navbar {
@@ -4470,6 +4484,20 @@ input:checked + .slider:before {
 
   .button.navbar {
     margin-left: 0;
+  }
+
+  /* ACCORDIONS */
+
+  .accordion {
+    cursor: unset;
+  }
+  
+  .accordion-panel.hidden, .accordion-panel.shown {
+    max-height: unset;
+  }
+  
+  .accordion-icon {
+    display: none;
   }
 
   /* MODALS */

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -1987,7 +1987,7 @@ li.main-tab input + label.selected:after {
   margin-left: 16px;
   font-size: 20px;
   line-height: 48px;
-  color: var(--color-staking);
+  color: var(--color-brand);
   padding-right: 20px;
   position: relative;
 }
@@ -1998,13 +1998,13 @@ li.main-tab input + label.selected:after {
 } 
 
 .staking-balances-amount svg path {
-  fill: var(--color-staking);
+  fill: var(--color-brand);
 }
 
 .balance-amount-staking {
   font-size: 32px;
   line-height: 48px;
-  color: var(--color-staking);
+  color: var(--color-brand);
   padding-right: 34px;
   position: relative;
 }
@@ -2015,7 +2015,7 @@ li.main-tab input + label.selected:after {
 } 
 
 .balance-amount-staking svg path {
-  fill: var(--color-staking);
+  fill: var(--color-brand);
 }
 
 .total-balance-wrapper {

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -117,6 +117,11 @@ p.hey {
   margin-left: 8px;
 }
 
+.space-between {
+  display: flex;
+  justify-content: space-between;
+}
+
 /* SELECTABILITY */
 
 .one-click-select {
@@ -515,6 +520,38 @@ p.hey {
   border: none;
   background-color: transparent;
   padding: 0;
+}
+
+/* ACCORDIONS */
+
+.accordion {
+  cursor: pointer;
+}
+
+.accordion-panel {
+  overflow: hidden;
+  transition: max-height 0.5s ease-out;
+}
+
+.accordion-panel.hidden {
+  max-height: 0;
+}
+
+.accordion-panel.shown {
+  max-height: 600px;
+}
+
+.accordion-icon {
+  transform-origin: 50% 30%;
+  transition: transform 0.5s ease-out;
+}
+
+.accordion-icon.hidden {
+  transform: rotate(0deg);
+}
+
+.accordion-icon.shown {
+  transform: rotate(180deg);
 }
 
 /* FORM GLOBAL */
@@ -1296,6 +1333,10 @@ li.main-tab input + label.selected:after {
   font-size: 16px;
   line-height: 32px;
   font-weight: bold;
+}
+
+.card-title.no-margin {
+  margin-bottom: unset;
 }
 
 /* AUTHENTICATION */
@@ -2312,11 +2353,6 @@ li.main-tab input + label.selected:after {
   margin-top: 12px;
 }
 
-.staking-history-item .space-between {
-  display: flex;
-  justify-content: space-between;
-}
-
 .staking-history-item .label {
   font-size: 16px;
   font-weight: bold;
@@ -2759,6 +2795,10 @@ input:checked + .slider:before {
   /* grid-template-columns: 76% 24%; */
   padding: 24px 0px 24px 0;
   color: var(--color-grey);
+}
+
+.stake-pool {
+  margin-top: 24px;
 }
 
 .add-stake-pool-wrapper {

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -263,19 +263,6 @@ p.hey {
   color: white;
 }
 
-.button.primary.staking {
-  background-color: var(--color-staking);
-}
-
-.button.primary.staking:hover {
-  background-color: var(--color-staking-dark);
-}
-
-.button.primary.staking:disabled {
-  background-color: var(--color-staking-light);
-  color: white;
-}
-
 .button.secondary {
   padding: 10px 24px;
   color: var(--color-grey);
@@ -2380,7 +2367,6 @@ li.main-tab input + label.selected:after {
   position: relative;
   padding-left: 21px;
   color: rgba(96, 106, 113, 0.64);
-
 }
 
 .download-transactions-text::before {
@@ -2738,51 +2724,6 @@ input:checked + .slider:before {
 
 .input.stake-pool-id {
   margin-bottom: 12px;
-}
-
-.button.add-stake-pool {
-  float: right;
-  border: 1px solid var(--color-staking);
-  margin-right: 16px;
-  font-size: 14px;
-  font-weight: 400;
-  background-color: transparent;
-  padding: 6px 10px;
-  color: var(--color-staking);
-  white-space: nowrap;
-}
-
-.button.add-stake-pool svg path {
-  fill: var(--color-staking);
-}
-
-.button.add-stake-pool.active,
-.button.add-stake-pool:hover {
-  background-color: var(--color-staking);
-  color: #fff;
-}
-
-.button.add-stake-pool.active svg path,
-.button.add-stake-pool:hover svg path {
-  fill: #fff;
-}
-
-.button.add-stake-pool:disabled {
-  border-color: var(--color-border);
-  color: var(--color-placeholder);
-}
-
-.button.add-stake-pool:disabled svg path {
-  fill: var(--color-placeholder);
-}
-
-.button.add-stake-pool:disabled:hover {
-  background-color: var(--color-staking-light);
-  color: #fff;
-}
-
-.button.add-stake-pool:disabled:hover svg path {
-  fill: #fff;
 }
 
 .button.revoke-delegation {

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -306,18 +306,13 @@ p.hey {
   width: 206px;
 }
 
-.button.refresh {
-  padding-left: 60px;
+.button.secondary.refresh {
+  padding: 12px 24px 12px 60px;
   position: relative;
-  background-color: white;
-  border: 2px solid var(--color-border);
-  color: var(--color-grey);
-  font-weight: normal;
-  font-size: 14px;
   line-height: 24px;
 }
 
-.button.refresh::before {
+.button.secondary.refresh::before {
   content: '';
   background-position: center;
   background-repeat: no-repeat;
@@ -332,12 +327,8 @@ p.hey {
   background-image: url('../assets/refresh_button_symbol.svg');
 }
 
-.button.refresh:hover::before {
+.button.secondary.refresh:hover::before {
   background-image: url('../assets/refresh_button_symbol_active.svg');
-}
-
-.button.refresh:hover {
-  color: var(--color-brand);
 }
 
 .button.logout {
@@ -3484,12 +3475,12 @@ input:checked + .slider:before {
 }
 
 @media screen and (min-width: 1024px) and (max-width: 1112px) {
-  .button.refresh {
+  .button.secondary.refresh {
     text-indent: -9999em;
     padding-left: 24px;
   }
 
-  .button.refresh::before {
+  .button.secondary.refresh::before {
     left: 0;
     right: 0;
   }
@@ -3576,12 +3567,12 @@ input:checked + .slider:before {
     font-size: 14px;
   }
 
-  .button.refresh {
+  .button.secondary.refresh {
     text-indent: -9999em;
     padding-left: 24px;
   }
 
-  .button.refresh::before {
+  .button.secondary.refresh::before {
     left: 0;
     right: 0;
   }

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -331,18 +331,13 @@ p.hey {
   background-image: url('../assets/refresh_button_symbol_active.svg');
 }
 
-.button.logout {
+.button.secondary.logout {
   margin-left: 16px;
   padding: 7px 24px 8px 56px;
   position: relative;
-  color: var(--color-grey);
-  border: 2px solid var(--color-border);
-  font-weight: normal;
-  background-color: white;
-  font-size: 14px;
 }
 
-.button.logout::before {
+.button.secondary.logout::before {
   content: '';
   position: absolute;
   top: 0;
@@ -357,11 +352,7 @@ p.hey {
   background-image: url('../assets/logout_symbol.svg');
 }
 
-.button.logout:hover {
-  color: var(--color-brand);
-}
-
-.button.logout:hover::before {
+.button.secondary.logout:hover::before {
   background-image: url('../assets/logout_symbol_active.svg');
 }
 

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -554,7 +554,8 @@ p.hey {
 }
 
 .accordion-icon {
-  transform-origin: 50% 30%;
+  margin-top: 6px;
+  transform-origin: 50% 37%;
   transition: transform 0.5s ease-out;
 }
 

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -312,6 +312,10 @@ p.hey {
   width: 206px;
 }
 
+.button.secondary.balance {
+  width: 154px;
+}
+
 .button.secondary.refresh {
   padding: 10px 24px 10px 58px;
   position: relative;
@@ -3551,6 +3555,10 @@ input:checked + .slider:before {
     left: 0;
     right: 0;
   }
+
+  .button.secondary.balance {
+    width: unset;
+  }
 }
 
 /* MOBILE MEDIA QUERIES */
@@ -3652,6 +3660,10 @@ input:checked + .slider:before {
   .button.secondary.withdraw::before {
     left: 0;
     right: 0;
+  }
+
+  .button.secondary.balance {
+    width: unset;
   }
 
   /* NAVBAR */

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -308,7 +308,7 @@ p.hey {
 }
 
 .button.secondary.refresh {
-  padding: 12px 24px 12px 60px;
+  padding: 10px 24px 10px 58px;
   position: relative;
   line-height: 24px;
 }
@@ -330,6 +330,31 @@ p.hey {
 
 .button.secondary.refresh:hover::before {
   background-image: url('../assets/refresh_button_symbol_active.svg');
+}
+
+.button.secondary.withdraw {
+  padding: 10px 24px 10px 58px;
+  position: relative;
+  line-height: 24px;
+}
+
+.button.secondary.withdraw::before {
+  content: '';
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
+  position: absolute;
+  left: 24px;
+  top: 0;
+  bottom: 0;
+  margin: auto;
+  width: 20px;
+  height: 20px;
+  background-image: url('../assets/cash-stack.svg');
+}
+
+.button.secondary.withdraw:hover::before {
+  background-image: url('../assets/cash-stack_active.svg');
 }
 
 .button.secondary.logout {
@@ -3476,6 +3501,16 @@ input:checked + .slider:before {
     left: 0;
     right: 0;
   }
+
+  .button.secondary.withdraw {
+    text-indent: -9999em;
+    padding-left: 24px;
+  }
+
+  .button.secondary.withdraw::before {
+    left: 0;
+    right: 0;
+  }
 }
 
 /* MOBILE MEDIA QUERIES */
@@ -3565,6 +3600,16 @@ input:checked + .slider:before {
   }
 
   .button.secondary.refresh::before {
+    left: 0;
+    right: 0;
+  }
+
+  .button.secondary.withdraw {
+    text-indent: -9999em;
+    padding-left: 24px;
+  }
+
+  .button.secondary.withdraw::before {
     left: 0;
     right: 0;
   }

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -276,7 +276,6 @@ p.hey {
   color: white;
 }
 
-
 .button.secondary {
   padding: 10px 24px;
   color: var(--color-grey);
@@ -284,6 +283,10 @@ p.hey {
   font-weight: normal;
   background-color: white;
   font-size: 14px;
+}
+
+.button.secondary:hover {
+  color: var(--color-brand);
 }
 
 .button.outline {
@@ -2735,21 +2738,6 @@ input:checked + .slider:before {
 
 .input.stake-pool-id {
   margin-bottom: 12px;
-}
-
-.button.stake-pool {
-  padding: 0;
-  background: none;
-  font-size: 14px;
-  color: var(--color-staking);
-  text-decoration: none;
-  margin-left: 16px;
-  font-weight: normal;
-  text-decoration: underline;
-}
-
-.button.stake-pool svg path {
-  fill: var(--color-staking);
 }
 
 .button.add-stake-pool {

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -314,12 +314,12 @@ p.hey {
 
 .button.secondary.balance {
   width: 154px;
+  line-height: 24px;
 }
 
 .button.secondary.refresh {
   padding: 10px 24px 10px 58px;
   position: relative;
-  line-height: 24px;
 }
 
 .button.secondary.refresh::before {
@@ -344,7 +344,6 @@ p.hey {
 .button.secondary.withdraw {
   padding: 10px 24px 10px 58px;
   position: relative;
-  line-height: 24px;
 }
 
 .button.secondary.withdraw::before {
@@ -364,6 +363,15 @@ p.hey {
 
 .button.secondary.withdraw:hover::before {
   background-image: url('../assets/cash-stack_active.svg');
+}
+
+.button.secondary.convert {
+  padding: 10px 20px;
+  line-height: 24px;
+}
+
+.button.secondary.convert::before {
+  content: 'Convert to stakable'
 }
 
 .button.secondary.logout {
@@ -3556,6 +3564,10 @@ input:checked + .slider:before {
     right: 0;
   }
 
+  .button.secondary.convert::before {
+    content: 'Convert'
+  }
+
   .button.secondary.balance {
     width: unset;
   }
@@ -3660,6 +3672,10 @@ input:checked + .slider:before {
   .button.secondary.withdraw::before {
     left: 0;
     right: 0;
+  }
+
+  .button.secondary.convert::before {
+    content: 'Convert'
   }
 
   .button.secondary.balance {

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -242,6 +242,7 @@ p.hey {
   border: none;
   display: inline-block;
   text-decoration: none;
+  outline:none;
 }
 
 .button:hover {


### PR DESCRIPTION
Changes:
- updated balloon description on Staking Balance, Available Balance
- changed colors on staking page from blue to pink, so it's consistent with the rest of the app
- changed order of balances on staking page
  - available balance and rewards are above the line
  - staking balance and nonstaking balance are bellow the line (nonstaking balance is hidden if equals to 0)
  - this way it also makes sense mathematically
- similarly looking white buttons with grey text/icons are now using `button secondary` class
- withdraw button has an icon now
- refresh button and withdraw buttons are same width
- updated styles to fix black borders around buttons on chrome browser
- renamed some of existing elements to be consistent across pages (like Balance -> Available Balance)

New:
- added `Accordion` element
- changed "delegate stake card" to use `Accordion` element
  - when user has already delegated, this element is by default contracted
  - if he hasn't delegated yet, it's expanded by default
  - this is added only to pc user, not mobile/tablet users