### PR TITLE
Fix eslint to work with typescript types

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,22 +6,41 @@
     "mocha": true,
     "es6": true
   },
-  "plugins": ["react-hooks"],
+  "plugins": [
+    "react-hooks",
+    "@typescript-eslint"
+  ],
   "rules": {
     "no-bitwise": "off",
     "guard-for-in": "off",
     "react/react-in-jsx-scope": "off",
     "no-undef": "off",
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "error"
+    "react-hooks/exhaustive-deps": "error",
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        "args": "none"
+      }
+    ],
+    "no-unused-vars": "off"
   },
+  "overrides": [
+    {
+        "files": ["*.js"],
+        "rules": {
+            "@typescript-eslint/no-unused-vars": "off",
+            "no-unused-vars": "warn"
+        }
+    }
+  ],
   "settings": {
     "react": {
         "version": "16.8",
         "pragma": "h"
     }
   },
-  "parser": "@typescript-eslint/typescript-estree",
+  "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "jsx": true
   }

--- a/app/frontend/components/pages/delegations/stakingHistoryPage.tsx
+++ b/app/frontend/components/pages/delegations/stakingHistoryPage.tsx
@@ -1,4 +1,4 @@
-import {h, Component, Fragment} from 'preact'
+import {h, Component} from 'preact'
 import actions from '../../../actions'
 import {connect} from '../../../libs/unistore/preact'
 import {CopyPoolId} from './common'
@@ -119,10 +119,11 @@ export interface StakingKeyRegistration extends StakingHistoryObject {
 const formatStakingKey = (str: string, n: number) =>
   `${str.substring(0, n)}...${str.substring(str.length - n)}`
 
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 const StakingKeyRegistrationItem = ({
   stakingKeyRegistration,
 }: {
-stakingKeyRegistration: StakingKeyRegistration
+  stakingKeyRegistration: StakingKeyRegistration
 }) => {
   return (
     <li className="staking-history-item">

--- a/app/frontend/wallet/blockchain-explorer.ts
+++ b/app/frontend/wallet/blockchain-explorer.ts
@@ -197,7 +197,9 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
     const delegationsUrl = `${
       ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL
     }/api/account/delegationHistory/${accountPubkeyHex}`
-    // const rewardsUrl = `${ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL}/api/account/rewardHistory/${accountPubkeyHex}`
+    // const rewardsUrl = `${
+    //   ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL
+    // }/api/account/rewardHistory/${accountPubkeyHex}`
     const withdrawalsUrl = `${
       ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL
     }/api/account/withdrawalHistory/${accountPubkeyHex}`

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test-chrome-headless": "cd app && yarn install && yarn test-chrome-headless",
     "mocha": "cd app && mocha-chrome --help",
     "eslint": "eslint . --max-warnings=0 --ext .ts,.tsx,.js,.jsx",
-    "fix": "prettier-eslint --write \"{app/frontend,app/tests/src,server}/**/*.{ts,tsx,js,jsx,json,css}\"",
+    "fix": "prettier-eslint --write \"{{app/frontend,app/tests/src,server}/**/*.{ts,tsx,js,jsx,json,css},,package.json}\"",
     "heroku-postbuild": "cd app && yarn install && yarn build",
     "generate-cert": "test -e server.cert && echo \"certificate already exists\" || openssl req -nodes -new -x509 -keyout server.key -out server.cert -subj \"/C=US\""
   },
@@ -39,7 +39,7 @@
     }
   },
   "lint-staged": {
-    "{{app/frontend,app/tests,server}/**/*.{ts,tsx,js,jsx,json,css},package.json}": [
+    "{{app/frontend,app/tests/src,server}/**/*.{ts,tsx,js,jsx,json,css},package.json}": [
       "prettier-eslint --write",
       "git add"
     ]
@@ -64,6 +64,8 @@
     "universal-analytics": "^0.4.20"
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "2",
+    "@typescript-eslint/parser": "2",
     "babel-eslint": "^8.2.2",
     "eslint": "^6.0.1",
     "eslint-config-vacuumlabs": "^1.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -404,6 +404,16 @@
   dependencies:
     "@types/node" "*"
 
+"@typescript-eslint/eslint-plugin@2":
+  version "2.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz#6f8ce8a46c7dea4a6f1d171d2bb8fbae6dac2be9"
+  integrity sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "2.34.0"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^3.0.0"
+    tsutils "^3.17.1"
+
 "@typescript-eslint/experimental-utils@1.13.0":
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz#b08c60d780c0067de2fb44b04b432f540138301e"
@@ -412,6 +422,26 @@
     "@types/json-schema" "^7.0.3"
     "@typescript-eslint/typescript-estree" "1.13.0"
     eslint-scope "^4.0.0"
+
+"@typescript-eslint/experimental-utils@2.34.0":
+  version "2.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz#d3524b644cdb40eebceca67f8cf3e4cc9c8f980f"
+  integrity sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.34.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
+"@typescript-eslint/parser@2":
+  version "2.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.34.0.tgz#50252630ca319685420e9a39ca05fe185a256bc8"
+  integrity sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==
+  dependencies:
+    "@types/eslint-visitor-keys" "^1.0.0"
+    "@typescript-eslint/experimental-utils" "2.34.0"
+    "@typescript-eslint/typescript-estree" "2.34.0"
+    eslint-visitor-keys "^1.1.0"
 
 "@typescript-eslint/parser@^1.10.2":
   version "1.13.0"
@@ -430,6 +460,19 @@
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.5.0"
+
+"@typescript-eslint/typescript-estree@2.34.0":
+  version "2.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz#14aeb6353b39ef0732cc7f1b8285294937cf37d5"
+  integrity sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==
+  dependencies:
+    debug "^4.1.1"
+    eslint-visitor-keys "^1.1.0"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
 
 accepts@~1.3.5:
   version "1.3.5"
@@ -1759,10 +1802,25 @@ eslint-scope@^4.0.0, eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-scope@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.0.tgz#d0f971dfe59c69e0cada684b23d49dbf82600ce5"
+  integrity sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
 eslint-utils@^1.3.1:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
   integrity sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
+eslint-utils@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
+  integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
@@ -2320,7 +2378,7 @@ glob@^7.0.0, glob@^7.0.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -4408,6 +4466,11 @@ regexpp@^2.0.1:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
 
+regexpp@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
+  integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
+
 registry-auth-token@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.4.0.tgz#d7446815433f5d5ed6431cd5dca21048f66b397e"
@@ -4651,7 +4714,7 @@ semver@5.5.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
   integrity sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==
 
-semver@7.3.2:
+semver@7.3.2, semver@^7.3.2:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
@@ -5090,7 +5153,7 @@ ts-loader@^6.2.1:
     micromatch "^4.0.0"
     semver "^6.0.0"
 
-tslib@^1.9.0:
+tslib@^1.8.1, tslib@^1.9.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
@@ -5099,6 +5162,13 @@ tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
+tsutils@^3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
+  integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+  dependencies:
+    tslib "^1.8.1"
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
Motivation: `yarn eslint` command was not working properly with TypeScript definitions imported from other files as it was classifying them as unused vars.

Changes:
* I updated `.eslintrc` with typescript-specific rules to deal with unused vars, retaining the standard `unused-vars` rule for `.js` files.
* Along the way I was forced to switched from `@typescript-eslint/typescript-estree` parser to `@typescript-eslint/parser` as the issue with redundant unused vars warning was otherwise persisting - I'm not sure about the root cause, but the `typescript-estree` parser was also showing a warning thatt the current typescript version is not officially supported, so it may have something to do ith it. Never the less, the current parser seems to behave properly, not throwing redundant errors
* fixed minor unrelated eslint errors

Testing:
* I ran `yarn fix` and `yarn eslint` without issues
* sanity-checked `yarn eslint` by adding removing dangling commas in arrays and it displayed appropriate warnings, so the code-style checks have not been disabled by accident by these changes, same for `eslint-fix`

Gotchas:
* I had to use an older version of `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` as they are not supported by Node 11 (the current nodejs engine we are using). I tried migrating to node 12 (LTS and the current default for Heroku AFAIK), but `yarn fix` started failing apparently diue to the inability to fill filenames into the wildcards to match files to inspect and fix. Therefore I decided not to update node version for now. We may consider dropping prettier-eslint-cli completely 