### PR TITLE
Remove automatic export of byron public key

### DIFF
--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -153,6 +153,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
             config: ADALITE_CONFIG,
             cryptoProvider,
             isShelleyCompatible,
+            loadByronAddresses: state.loadByronAddresses,
           })
           break
         }
@@ -1247,6 +1248,9 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
     })
   }
 
+  const toggleLoadByronAddresses = (state) =>
+    setState({loadByronAddresses: !state.loadByronAddresses})
+
   return {
     loadingAction,
     stopLoadingAction,
@@ -1297,5 +1301,6 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
     redeemRewards,
     openInfoModal,
     closeInfoModal,
+    toggleLoadByronAddresses,
   }
 }

--- a/app/frontend/components/pages/login/hardwareAuth.tsx
+++ b/app/frontend/components/pages/login/hardwareAuth.tsx
@@ -3,12 +3,20 @@ import {CRYPTO_PROVIDER_TYPES} from '../../../wallet/constants'
 import {TrezorLogoWhite, LedgerLogoWhite} from '../../common/svg'
 import {ADALITE_CONFIG} from '../../../config'
 import tooltip from '../../common/tooltip'
+import {connect} from '../../../helpers/connect'
+import actions from '../../../actions'
 
 interface Props {
   loadWallet: any
+  loadByronAddresses: boolean
+  toggleLoadByronAddresses: () => void
 }
 
-const LoadByHardwareWalletSection = ({loadWallet}: Props) => {
+const LoadByHardwareWalletSection = ({
+  loadWallet,
+  loadByronAddresses,
+  toggleLoadByronAddresses,
+}: Props) => {
   const TrezorAffiliateLink = (title) => (
     <a href="https://shop.trezor.io/?offer_id=10&aff_id=1071" target="blank">
       {title}
@@ -23,69 +31,87 @@ const LoadByHardwareWalletSection = ({loadWallet}: Props) => {
 
   return (
     <div className="authentication-content hardware">
-      <div className="authentication-wallet">
-        <div className="authentication-image-container">
-          <img className="authentication-image" src="assets/trezor.jpg" alt="Trezor model T" />
-        </div>
-        <div className="authentication-paragraph">Trezor model T</div>
-        <div className="authentication-paragraph small">
-          {TrezorAffiliateLink('Support us by buying one')}
-        </div>
-        <div
-          className="authentication-paragraph small"
-          dangerouslySetInnerHTML={{__html: '&nbsp;'}}
-        />
-        <button
-          disabled={!ADALITE_CONFIG.ADALITE_ENABLE_TREZOR}
-          {...tooltip(
-            'Support for Trezor is temporarily disabled',
-            !ADALITE_CONFIG.ADALITE_ENABLE_TREZOR
-          )}
-          className="button primary trezor thin-data-balloon"
-          onClick={() => loadWallet({cryptoProviderType: CRYPTO_PROVIDER_TYPES.TREZOR})}
-        >
-          Unlock with<div className="trezor-logo-container">
-            <TrezorLogoWhite />
+      <div className="authentication-wallet-row">
+        <div className="authentication-wallet">
+          <div className="authentication-image-container">
+            <img className="authentication-image" src="assets/trezor.jpg" alt="Trezor model T" />
           </div>
-        </button>
-      </div>
-      <div className="authentication-wallet">
-        <div className="authentication-image-container">
-          <img
-            className="authentication-image"
-            src="assets/ledger_nano_s_x.jpg"
-            alt="Ledger Nano S/X"
+          <div className="authentication-paragraph">Trezor model T</div>
+          <div className="authentication-paragraph small">
+            {TrezorAffiliateLink('Support us by buying one')}
+          </div>
+          <div
+            className="authentication-paragraph small"
+            dangerouslySetInnerHTML={{__html: '&nbsp;'}}
           />
+          <button
+            disabled={!ADALITE_CONFIG.ADALITE_ENABLE_TREZOR}
+            {...tooltip(
+              'Support for Trezor is temporarily disabled',
+              !ADALITE_CONFIG.ADALITE_ENABLE_TREZOR
+            )}
+            className="button primary trezor thin-data-balloon"
+            onClick={() => loadWallet({cryptoProviderType: CRYPTO_PROVIDER_TYPES.TREZOR})}
+          >
+            Unlock with<div className="trezor-logo-container">
+              <TrezorLogoWhite />
+            </div>
+          </button>
         </div>
-        <div className="authentication-paragraph">Ledger Nano S/X</div>
-        <div className="authentication-paragraph small">also with Android device</div>
-        <div className="authentication-paragraph small">
-          {LedgerAffiliateLink('Support us by buying one')}
-        </div>
-        <button
-          {...tooltip(
-            'Support for Ledger is temporarily disabled',
-            !ADALITE_CONFIG.ADALITE_ENABLE_LEDGER
-          )}
-          disabled={!ADALITE_CONFIG.ADALITE_ENABLE_LEDGER}
-          className="button primary ledger thin-data-balloon"
-          onClick={() => loadWallet({cryptoProviderType: CRYPTO_PROVIDER_TYPES.LEDGER})}
-        >
-          Unlock with<div className="ledger-logo-container">
-            <LedgerLogoWhite />
+        <div className="authentication-wallet">
+          <div className="authentication-image-container">
+            <img
+              className="authentication-image"
+              src="assets/ledger_nano_s_x.jpg"
+              alt="Ledger Nano S/X"
+            />
           </div>
-        </button>
-        <button
-          className="button secondary"
-          onClick={() =>
-            loadWallet({cryptoProviderType: CRYPTO_PROVIDER_TYPES.LEDGER, isWebUSB: true})
-          }
-        >
-          Connect with WebUSB
-        </button>
+          <div className="authentication-paragraph">Ledger Nano S/X</div>
+          <div className="authentication-paragraph small">also with Android device</div>
+          <div className="authentication-paragraph small">
+            {LedgerAffiliateLink('Support us by buying one')}
+          </div>
+          <button
+            {...tooltip(
+              'Support for Ledger is temporarily disabled',
+              !ADALITE_CONFIG.ADALITE_ENABLE_LEDGER
+            )}
+            disabled={!ADALITE_CONFIG.ADALITE_ENABLE_LEDGER}
+            className="button primary ledger thin-data-balloon"
+            onClick={() => loadWallet({cryptoProviderType: CRYPTO_PROVIDER_TYPES.LEDGER})}
+          >
+            Unlock with<div className="ledger-logo-container">
+              <LedgerLogoWhite />
+            </div>
+          </button>
+          <button
+            className="button secondary"
+            onClick={() =>
+              loadWallet({cryptoProviderType: CRYPTO_PROVIDER_TYPES.LEDGER, isWebUSB: true})
+            }
+          >
+            Connect with WebUSB
+          </button>
+        </div>
+      </div>
+      <div className="authentication-hw-byron-public-export">
+        <label className="checkbox">
+          <input
+            type="checkbox"
+            checked={loadByronAddresses}
+            onChange={toggleLoadByronAddresses}
+            className="checkbox-input"
+          />
+          <span className="checkbox-indicator" />Load legacy Byron wallet balance
+        </label>
       </div>
     </div>
   )
 }
 
-export default LoadByHardwareWalletSection
+export default connect(
+  (state) => ({
+    loadByronAddresses: state.loadByronAddresses,
+  }),
+  actions
+)(LoadByHardwareWalletSection)

--- a/app/frontend/components/pages/login/loginPage.tsx
+++ b/app/frontend/components/pages/login/loginPage.tsx
@@ -30,7 +30,6 @@ const getAuthMethodName = (authMethod) => AUTH_METHOD_NAMES[authMethod]
 
 interface Props {
   closeStakingBanner: () => void
-  loadWallet: any
   loadDemoWallet: any
   walletLoadingError: any
   authMethod: '' | 'mnemonic' | 'hw-wallet' | 'file'
@@ -73,7 +72,6 @@ class LoginPage extends Component<Props, {isDropdownOpen: boolean}> {
 
   render(
     {
-      loadWallet,
       loadDemoWallet,
       walletLoadingError,
       authMethod,
@@ -163,7 +161,7 @@ class LoginPage extends Component<Props, {isDropdownOpen: boolean}> {
           </ul>
         </div>
         {authMethod === 'mnemonic' && <MnemonicAuth />}
-        {authMethod === 'hw-wallet' && <HardwareAuth loadWallet={loadWallet} />}
+        {authMethod === 'hw-wallet' && <HardwareAuth />}
         {authMethod === 'file' && <KeyFileAuth />}
       </div>
     )

--- a/app/frontend/state.ts
+++ b/app/frontend/state.ts
@@ -126,6 +126,7 @@ export interface State {
   }
   txConfirmType: string
   txSuccessTab: string
+  loadByronAddresses: boolean
 }
 
 const initialState: State = {
@@ -213,6 +214,7 @@ const initialState: State = {
   txConfirmType: '',
   txSuccessTab: '',
   keepConfirmationDialogOpen: false,
+  loadByronAddresses: true,
 }
 
 export {initialState}

--- a/app/frontend/wallet/shelley/dummy-address-manager.ts
+++ b/app/frontend/wallet/shelley/dummy-address-manager.ts
@@ -1,0 +1,9 @@
+const DummyAddressManager = () => {
+  return {
+    discoverAddresses: () => [],
+    discoverAddressesWithMeta: () => [],
+    getAddressToAbsPathMapping: () => ({}),
+  }
+}
+
+export default DummyAddressManager

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -1386,6 +1386,7 @@ li.main-tab input + label.selected:after {
 
 .authentication-content.hardware {
   display: flex;
+  flex-direction: column;
   padding: 0;
 }
 
@@ -1421,13 +1422,18 @@ li.main-tab input + label.selected:after {
   margin-top: 24px;
 }
 
+.authentication-wallet-row {
+  display: flex;
+  flex-direction: row;
+}
+
 .authentication-wallet {
   position: relative;
   flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 56px 48px;
+  padding: 56px 48px 20px 48px;
 }
 
 .authentication-wallet:first-child::after {
@@ -1466,8 +1472,14 @@ li.main-tab input + label.selected:after {
 .authentication-wallet .authentication-image {
   margin-bottom: 24px;
 }
+
 .authentication-buttons {
   display: none;
+}
+
+.authentication-hw-byron-public-export {
+  padding-bottom: 24px;
+  margin: auto;
 }
 
 /* AUTHENTICATION TABS */


### PR DESCRIPTION
Related issue: https://github.com/vacuumlabs/adalite/issues/670

New:
- Checkbox under "Unlock with trezor/ledger" to load legacy Byron wallet balance, true by default

Changes:
- When checkbox is disabled, we won't load legacy address managers