### PR TITLE
Fix passing of network params to displayAddressForPath for hw wallets

### DIFF
--- a/app/frontend/wallet/shelley/shelley-ledger-crypto-provider.ts
+++ b/app/frontend/wallet/shelley/shelley-ledger-crypto-provider.ts
@@ -1,6 +1,6 @@
 import LedgerTransportU2F from '@ledgerhq/hw-transport-u2f'
 import LedgerTransportWebusb from '@ledgerhq/hw-transport-webusb'
-import Ledger from '@cardano-foundation/ledgerjs-hw-app-cardano'
+import Ledger, {AddressTypeNibbles} from '@cardano-foundation/ledgerjs-hw-app-cardano'
 import {encode} from 'borc'
 import CachedDeriveXpubFactory from '../helpers/CachedDeriveXpubFactory'
 import debugLog from '../../helpers/debugLog'
@@ -85,7 +85,12 @@ const ShelleyLedgerCryptoProvider = async ({network, config, isWebUSB}) => {
 
   async function displayAddressForPath(absDerivationPath, stakingPath?) {
     try {
-      await ledger.showAddress(0, 1, absDerivationPath, stakingPath)
+      await ledger.showAddress(
+        AddressTypeNibbles.BASE,
+        network.networkId,
+        absDerivationPath,
+        stakingPath
+      )
     } catch (err) {
       throw NamedError('LedgerOperationError', {message: `${err.name}: ${err.message}`})
     }

--- a/app/frontend/wallet/shelley/shelley-trezor-crypto-provider.ts
+++ b/app/frontend/wallet/shelley/shelley-trezor-crypto-provider.ts
@@ -53,7 +53,8 @@ const CardanoTrezorCryptoProvider = ({network, config}) => {
     }
     const response = await TrezorConnect.cardanoGetAddress({
       addressParameters,
-      networkId: 1,
+      networkId: network.networkId,
+      protocolMagic: network.protocolMagic,
       showOnTrezor: true,
     })
 


### PR DESCRIPTION
Problem: Trezor was not passing protocolMagic to the cardanoGetAddress call, resulting in it being None. This was not an issue until now because it negated itself with a bug in trezor-connect resolved here:

Changes:
* add passing of protocolMagic to the cardanoGetAddress call for trezor crypto provider
* refactor the displayAddressForPath call to pass the proper network parameters for both Ledger and Trezor (the nework id was hardcoded to `0` until now even though the crypto provider received the parameter from outside)

Testing/validation: tested address verification in Adalite on localhost for both Ledger and Trezor and works as expected