### PR TITLE
Ignore XDR encoding failure

### DIFF
--- a/app/frontend/walletApp.js
+++ b/app/frontend/walletApp.js
@@ -73,6 +73,11 @@ init({
       return tags ? event : null
     })
   },
+  ignoreErrors: [
+    // FF 83.0 specific error to be ignored
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1678243
+    'XDR encoding failure',
+  ],
 })
 
 const Wrapper = h(HooksStoreProvider, {value: store}, h(UnistoreStoreProvider, {store}, h(App)))


### PR DESCRIPTION
Motivation: "XDR encoding failure" is an error that started appearing since FF 83.0 without apparent side-effects and it results in triggering an error modal upon almost all page loads.

more info: https://bugzilla.mozilla.org/show_bug.cgi?id=1678243
and https://github.com/xwiki-labs/cryptpad/issues/636

Changes: This seems to be an error beyond our control. Fortunately, Adalite's functionality does not seem to be impacted by it as I was able to successfully use the wallet and submit a transaction even if the error appeared at page load. So to not spam the users, this PR is adding the error to a list of ignored errors for sentry, hence stopping the error modal triggering.

Testing: I was able to replicate the error modal locally and after applying the fix the error no longer triggered the modal, just the message was logged into the console.

Screenshot of what happens in adalite
![Adalite error](https://user-images.githubusercontent.com/4980147/99993337-d1611e00-2db7-11eb-86e0-6cb7e7c1fe74.png)
