### PR TITLE
Update ledgerjs library to latest version (2.1.0)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -24,7 +24,7 @@
     "postinstall": "node ./helpers/removeChainLibsWasmImport"
   },
   "dependencies": {
-    "@cardano-foundation/ledgerjs-hw-app-cardano": "^2.0.0",
+    "@cardano-foundation/ledgerjs-hw-app-cardano": "^2.1.0",
     "@emurgo/js-chain-libs": "https://github.com/SebastienGllmt/js-chain-libs-pkg",
     "@ledgerhq/hw-transport": "^5.15.0",
     "@ledgerhq/hw-transport-u2f": "^5.15.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -9,10 +9,10 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@cardano-foundation/ledgerjs-hw-app-cardano@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@cardano-foundation/ledgerjs-hw-app-cardano/-/ledgerjs-hw-app-cardano-2.0.0.tgz#7bad95e79ba585864c69f364fbaad8449b5328d9"
-  integrity sha512-YP9Uuc8Fc690xVbGzExRi/WpqIO4CLQNW6NOZkmUImo5sw7dlHH3FKbdSit1848zEvmSiGazJWRHT/ykH2oPrg==
+"@cardano-foundation/ledgerjs-hw-app-cardano@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@cardano-foundation/ledgerjs-hw-app-cardano/-/ledgerjs-hw-app-cardano-2.1.0.tgz#e2e4b1a0d5b672f8dbe7c46dc514c27d6603082f"
+  integrity sha512-44rezv9eGE/AvFeEqQ80V7xZgTvsRPnxlb1aSZnMDSVZhgxWBV9LHNPtT5kjWsrKzalsX7k+xrDybp7+ay/2HQ==
   dependencies:
     "@ledgerhq/hw-transport" "^5.12.0"
     babel-polyfill "^6.26.0"


### PR DESCRIPTION
Motivation: This update is needed in order for the Ledger Cardano app version 2.1.0 to work properly with Adalite, otherwise, as there were breaking changes in internal calls of the signTransaction call, signing of transactions would fail with a validation error on Ledger app's side.

More info on what changed in the latest ledgerjs version here: https://github.com/cardano-foundation/ledgerjs-hw-app-cardano/releases/tag/v2.1.0

Changes:
* bump `@cardano-foundation/ledgerjs-hw-app-cardano` from version 2.0.0 to 2.1.0

Testing: tested manually end-to-end adalite with Ledger app 2.1.0 and 2.0.4 and logging-in/sending txs works as expected