### PR TITLE
Force WebUSB transport with Ledger when selected

### DIFF
--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -121,7 +121,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
 
   /* LOADING WALLET */
 
-  const loadWallet = async (state, {cryptoProviderType, walletSecretDef, isWebUSB}) => {
+  const loadWallet = async (state, {cryptoProviderType, walletSecretDef, forceWebUsb}) => {
     // loadingAction(state, `Waiting for ${state.hwWalletName}...`)
     loadingAction(state, 'Loading wallet data...', {
       walletLoadingError: undefined,
@@ -149,7 +149,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
               walletSecretDef,
               network: NETWORKS.SHELLEY[ADALITE_CONFIG.ADALITE_NETWORK],
               config: ADALITE_CONFIG,
-              isWebUSB,
+              forceWebUsb,
             }
           )
 

--- a/app/frontend/components/pages/login/hardwareAuth.tsx
+++ b/app/frontend/components/pages/login/hardwareAuth.tsx
@@ -75,10 +75,13 @@ const LoadByHardwareWalletSection = ({loadWallet}: Props) => {
             <LedgerLogoWhite />
           </div>
         </button>
+        <div className="authentication-paragraph small">
+          alternatively, if the above does not work:
+        </div>
         <button
           className="button secondary"
           onClick={() =>
-            loadWallet({cryptoProviderType: CRYPTO_PROVIDER_TYPES.LEDGER, isWebUSB: true})
+            loadWallet({cryptoProviderType: CRYPTO_PROVIDER_TYPES.LEDGER, forceWebUsb: true})
           }
         >
           Connect with WebUSB

--- a/app/frontend/translations.ts
+++ b/app/frontend/translations.ts
@@ -30,7 +30,14 @@ const translations = {
   InvalidMnemonic: () => 'Invalid mnemonic, check your mnemonic for typos and try again.',
   DaedalusMnemonic: () => '',
 
-  TransportOpenUserCancelled: ({message}) => `TransportCanceledByUser: ${message}`,
+  TransportOpenUserCancelled: ({message}) => {
+    const errors = {
+      'navigator.usb is undefined':
+        'Your browser does not support WebUSB, use e.g. Google Chrome instead.',
+    }
+
+    return `TransportCanceledByUser: ${message}. ${errors[message] || ''}`
+  },
   TransportError: ({message}) =>
     `TransportError: ${message}.If you are using a hardware wallet, please make sure you are using the latest version of the Cardano application.`,
   TransportStatusError: ({message}) => {
@@ -40,6 +47,13 @@ const translations = {
       'Ledger device: Device is locked': 'Please unlock your device.',
     }
     return `TransportStatusError: ${message}. ${errors[message] || ''}`
+  },
+  TransportInterfaceNotAvailable: ({message}) => {
+    const errors = {
+      'Unable to claim interface.':
+        'Please make sure that no other web page/app is interacting with your Ledger device at the same time.',
+    }
+    return `TransportInterfaceNotAvailable: ${message} ${errors[message] || ''}`
   },
 
   TransactionRejectedByNetwork: () =>

--- a/app/package.json
+++ b/app/package.json
@@ -26,9 +26,9 @@
   "dependencies": {
     "@cardano-foundation/ledgerjs-hw-app-cardano": "^2.1.0",
     "@emurgo/js-chain-libs": "https://github.com/SebastienGllmt/js-chain-libs-pkg",
-    "@ledgerhq/hw-transport": "^5.15.0",
-    "@ledgerhq/hw-transport-u2f": "^5.15.0",
-    "@ledgerhq/hw-transport-webusb": "^5.16.0",
+    "@ledgerhq/hw-transport": "^5.36.0",
+    "@ledgerhq/hw-transport-u2f": "^5.36.0-deprecated",
+    "@ledgerhq/hw-transport-webusb": "^5.36.0",
     "@sentry/browser": "5.22.3",
     "babel-regenerator-runtime": "^6.5.0",
     "bip39-light": "^1.0.7",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -34,32 +34,46 @@
     "@ledgerhq/logs" "^5.15.0"
     rxjs "^6.5.5"
 
+"@ledgerhq/devices@^5.36.0":
+  version "5.36.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-5.36.0.tgz#f4493bea44390325fcc7a2a0d03bba69fc1604ec"
+  integrity sha512-EwQwLZcz66a2V07Bad0J+Q67LR2afj2NJChJNcA6/gqvzXrtNtJ37u1co9eLU7S5GGll5JGi7KdBqAD9ZTHaaQ==
+  dependencies:
+    "@ledgerhq/errors" "^5.36.0"
+    "@ledgerhq/logs" "^5.36.0"
+    rxjs "^6.6.3"
+
 "@ledgerhq/errors@^5.15.0":
   version "5.15.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-5.15.0.tgz#e5d5b5ad48fc07f6308b78b065242e158bc044a2"
   integrity sha512-ZlLhR7qaChPgEbvcqOptRepWGm8VhhwOM6kC1gx3WErutbtaOjUX8lLA4ButWFU2f+xTl2rS/5c86wC7qGqGXQ==
 
-"@ledgerhq/hw-transport-u2f@^5.15.0":
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-5.15.0.tgz#8da4f9cf33e91c99cee560d47c1645d4f273f1e3"
-  integrity sha512-oJLznJjibDVxXReFGAXnRimopiz5xf2cv2l5RxVKhSbaiJRq4Pgurl0YKTORVEucvdyzAGGwwinjghEdJCh8Jg==
+"@ledgerhq/errors@^5.34.0", "@ledgerhq/errors@^5.36.0":
+  version "5.36.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-5.36.0.tgz#9d178b54116ae81b1fbdfa80afcd33981453be4c"
+  integrity sha512-VS6aFzn3IDUmSLaX2kAPg5sQOc5m7IwvswAGvoMc3FCi9/a1dXWwtiYn5rWd1QjDJlTKSfCwmSpvUMp8FKoY2Q==
+
+"@ledgerhq/hw-transport-u2f@^5.36.0-deprecated":
+  version "5.36.0-deprecated"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-5.36.0-deprecated.tgz#66e3ed399a117a1c0110871a055dd54f5fe707fd"
+  integrity sha512-T/+mGHIiUK/ZQATad6DMDmobCMZ1mVST952009jKzhaE1Et2Uy2secU+QhRkx3BfEAkvwa0zSRSYCL9d20Iqjg==
   dependencies:
-    "@ledgerhq/errors" "^5.15.0"
-    "@ledgerhq/hw-transport" "^5.15.0"
-    "@ledgerhq/logs" "^5.15.0"
+    "@ledgerhq/errors" "^5.34.0"
+    "@ledgerhq/hw-transport" "^5.34.0"
+    "@ledgerhq/logs" "^5.30.0"
     u2f-api "0.2.7"
 
-"@ledgerhq/hw-transport-webusb@^5.16.0":
-  version "5.16.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-webusb/-/hw-transport-webusb-5.16.0.tgz#c41863cc51f4835ec47f9be0f8a76035a8086ada"
-  integrity sha512-JK0VVb/u4eQVKe6SA6t/ddQ+5BcG4FAmXgN8+WCc4YHpHUYpZ4BCBbR0lTo+JacUk8Rz0/UWk/YETuRNLdhPJg==
+"@ledgerhq/hw-transport-webusb@^5.36.0":
+  version "5.36.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-webusb/-/hw-transport-webusb-5.36.0.tgz#2aeee2cb6eb38c5c6a82b5fd8aa89d5a99948332"
+  integrity sha512-NfDOP0Z1wiKzbVD4jh24MX0AqoyiqNxdkIBhhiB0kSuRoXFWZ13WwPGQAlIAVAdUwXgsEww/v7QGOzEZyN42mw==
   dependencies:
-    "@ledgerhq/devices" "^5.15.0"
-    "@ledgerhq/errors" "^5.15.0"
-    "@ledgerhq/hw-transport" "^5.15.0"
-    "@ledgerhq/logs" "^5.15.0"
+    "@ledgerhq/devices" "^5.36.0"
+    "@ledgerhq/errors" "^5.36.0"
+    "@ledgerhq/hw-transport" "^5.36.0"
+    "@ledgerhq/logs" "^5.36.0"
 
-"@ledgerhq/hw-transport@^5.12.0", "@ledgerhq/hw-transport@^5.15.0":
+"@ledgerhq/hw-transport@^5.12.0":
   version "5.15.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-5.15.0.tgz#01dc22adb156061728dbb937df2f310c761d06b9"
   integrity sha512-WIHqxEMGa1+MH5xTLLZcjPainFhCihzWVDw3zo1mzUqTzVEgYXFhnn2j6Lboov0Elpit+KiPOA1XuSofslajhg==
@@ -68,10 +82,24 @@
     "@ledgerhq/errors" "^5.15.0"
     events "^3.1.0"
 
+"@ledgerhq/hw-transport@^5.34.0", "@ledgerhq/hw-transport@^5.36.0":
+  version "5.36.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-5.36.0.tgz#b6e951c411182ece59c7b527f948240d1b0a8a51"
+  integrity sha512-rwLTBUsdGCC3Ka4G99sqGbbyVhkVxXd4eWWeOb8gnuKhrTydZGkkP3JdZSHgWSrVRYTAUmkE1AnUmchbfh361w==
+  dependencies:
+    "@ledgerhq/devices" "^5.36.0"
+    "@ledgerhq/errors" "^5.36.0"
+    events "^3.2.0"
+
 "@ledgerhq/logs@^5.15.0":
   version "5.15.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-5.15.0.tgz#870524ade408b50ce74971509aa170e9d85c0575"
   integrity sha512-QuAva3K3YFDtQidi8xAfOQcb+aExJus3p0GhPNscOE+r152klBdiZUHLp818zEeQZT7PRSm83gEknmeUYjGU9A==
+
+"@ledgerhq/logs@^5.30.0", "@ledgerhq/logs@^5.36.0":
+  version "5.36.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-5.36.0.tgz#78721347162fb834d90effa1123b363dc46e3a52"
+  integrity sha512-HnD/hByteUL1MsJu1lMinY9bNq8++5mWJ8qHCW9dLC9LbsvWIqwLwmZiGcW0D2tX9p0/C5ESuIpJ9B/d2dReuw==
 
 "@sentry/browser@5.22.3":
   version "5.22.3"
@@ -2990,6 +3018,13 @@ rxjs@^6.5.5:
   version "6.5.5"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
   integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.6.3:
+  version "6.6.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
+  integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
Motivation: Currently, when the user selects "Connect with WebUSB" this actually may not be true as the logic still falls back to U2F in case of any problem. This potentially makes for a very confusing debugging experience with users that report issues with the (notoriously unreliable) U2F transport, see: https://github.com/vacuumlabs/adalite/issues/775 And generally, it's really confusing to tell users they are connecting via WebUSB only to fall back to a different transport. If they want that "smart" behavior, they can always go through the highlighted default option.

So the aim of this PR is to make the behavior of "Connect with WebUSB" button more intuitive and actually force WebUSB and display whatever goes wrong with it which should naturally lead the users to set up webusb properly instead of "running in circles" with U2F issues, believing they are using WebUSB

Changes:
* refactor `isWebUSB` flag to `forceWebUsb` and adjust the logic that constructs the transport to actually force web USB without the U2F fallback
* added translations to match the errors I found while testing. Other errors should be captured by sentry so we get notified of them and act accordingly on it.
* add text above the "Connect with WebUSB" button guiding the users to use it if the default option does not work
* update ledger transport libraries to the latest versions

Testing:
* tested end-to-end on Windows
* tried connecting with WebUSB in Firefox - error explaining that browser does not support it shows
* tried connecting with WebUSB while other adalite tab is connected with WebUSB - error modal asking to make sure no other app using ledger is running appears

Note: this is a short-term fix, I also created an issue proposing a long term fix to this: https://github.com/vacuumlabs/adalite/issues/779