### PR TITLE
Fix ledger webusb button margin

### DIFF
--- a/app/frontend/components/pages/login/hardwareAuth.tsx
+++ b/app/frontend/components/pages/login/hardwareAuth.tsx
@@ -75,11 +75,11 @@ const LoadByHardwareWalletSection = ({loadWallet}: Props) => {
             <LedgerLogoWhite />
           </div>
         </button>
-        <div className="authentication-paragraph small">
+        <div className="authentication-paragraph small ledger-webusb">
           alternatively, if the above does not work:
         </div>
         <button
-          className="button secondary"
+          className="button secondary ledger-webusb"
           onClick={() =>
             loadWallet({cryptoProviderType: CRYPTO_PROVIDER_TYPES.LEDGER, forceWebUsb: true})
           }

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -422,6 +422,14 @@ p.hey {
   background-image: url('../assets/logout_symbol_active.svg');
 }
 
+.button.secondary.ledger-webusb {
+  margin-top: 0px;
+}
+
+.authentication-paragraph.small.ledger-webusb {
+  margin-top: 8px;
+}
+
 .button.trezor {
   position: relative;
   padding-right: 119px;


### PR DESCRIPTION
Motivation: Fix ledger "connect with WebUSB" button and title relative position so it is more naturally spaced respective to the main button above

Before:
![image (1)](https://user-images.githubusercontent.com/4980147/104104683-e7646880-52a9-11eb-953e-540724d568a2.png)


After:
![Untitled](https://user-images.githubusercontent.com/4980147/104104886-fe578a80-52aa-11eb-8156-abe54fd3b67f.png)

