### PR TITLE
Optimize redis stats - change redis scan bulk size from 10 to 1024

### DIFF
--- a/server/statsPageRedis.js
+++ b/server/statsPageRedis.js
@@ -49,6 +49,7 @@ const getStats = async () => {
   await new Promise((resolve, reject) => {
     redisScan({
       redis: client,
+      count_amt: 1024,
       each_callback(type, key, subkey, length, value, next) {
         response.push([key, value])
         next()


### PR DESCRIPTION
Motivation: adalite usage stats page takes a lot of time to load, intermittently timing out. This is most likely due to the amount of entries in Redis (several thousands) and the sequential scan we do on them. Based on this article: https://dzone.com/articles/the-effects-of-redis-scan-on-performance-and-how-k it seems that increasing the batch size from 10 to something bigger should significantly improve the speed of the scan, offsetting the need to migrate to a different solution in the foreseeable future.

Change: force batch size in the sequential scan of redis in the page that renders the usage stats to be 1024 instead of the default value 10.

Testing: I was not able to test the performance conclusively in my local environment as the requests from localhost to redis seem to be significantly slower than from Heroku. But I confirmed that the change does not break the interface/data in any way by comparing the usage_stats rendered locally vs the usage stats in https://testnet.adalite.io/usage_stats . To see if it makes an impact on the performance in prod we will need to deploy it