### PR TITLE
Fix account discovery if max account is used, set max account to 20 for Trezor

### DIFF
--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -171,6 +171,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
 
       const conversionRatesPromise = getConversionRates(state)
       const usingHwWallet = wallet.isHwWallet()
+      const maxAccountIndex = wallet.getMaxAccountIndex()
       const hwWalletName = usingHwWallet ? wallet.getWalletName() : undefined
       const shouldNumberAccountsFromOne = hwWalletName === 'Trezor'
       if (usingHwWallet) loadingAction(state, `Waiting for ${hwWalletName}...`)
@@ -186,6 +187,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
       setState({
         validStakepools,
         accountsInfo,
+        maxAccountIndex,
         totalWalletBalance,
         totalRewardsBalance,
         shouldShowSaturatedBanner,

--- a/app/frontend/components/pages/accounts/accountsDashboard.tsx
+++ b/app/frontend/components/pages/accounts/accountsDashboard.tsx
@@ -14,6 +14,7 @@ import Conversions from '../../common/conversions'
 
 type DashboardProps = {
   accountsInfo: Array<AccountInfo>
+  maxAccountIndex: number
   reloadWalletInfo: any
   shouldShowSendTransactionModal: boolean
   shouldShowDelegationModal: boolean
@@ -25,6 +26,7 @@ type DashboardProps = {
 
 const AccountsDashboard = ({
   accountsInfo,
+  maxAccountIndex,
   reloadWalletInfo,
   shouldShowSendTransactionModal,
   shouldShowDelegationModal,
@@ -149,7 +151,8 @@ const AccountsDashboard = ({
                   shouldShowAccountInfo
                 />
               ))}
-              {accountsInfo[accountsInfo.length - 1].isUsed && (
+              {accountsInfo[accountsInfo.length - 1].isUsed &&
+                accountsInfo.length - 1 < maxAccountIndex && (
                 <AccountTile
                   accountIndex={accountsInfo.length}
                   ticker={null}
@@ -173,6 +176,7 @@ const AccountsDashboard = ({
 export default connect(
   (state: State) => ({
     accountsInfo: state.accountsInfo,
+    maxAccountIndex: state.maxAccountIndex,
     shouldShowSendTransactionModal: state.shouldShowSendTransactionModal,
     shouldShowDelegationModal: state.shouldShowDelegationModal,
     activeAccountIndex: state.activeAccountIndex,

--- a/app/frontend/state.ts
+++ b/app/frontend/state.ts
@@ -122,6 +122,7 @@ export interface State {
   shouldShowSaturatedBanner?: boolean
   isBigDelegator: boolean
   accountsInfo: Array<AccountInfo>
+  maxAccountIndex: number
   shouldNumberAccountsFromOne: boolean
   sourceAccountIndex: number
   activeAccountIndex: number
@@ -251,6 +252,7 @@ const initialState: State = {
       accountIndex: 0,
     },
   ],
+  maxAccountIndex: 0,
   shouldNumberAccountsFromOne: false,
   sourceAccountIndex: 0,
   activeAccountIndex: 0,

--- a/app/frontend/wallet/account-manager.ts
+++ b/app/frontend/wallet/account-manager.ts
@@ -1,8 +1,8 @@
 import NamedError from '../helpers/NamedError'
 import {Account} from './account'
-import {CryptoProviderFeatures, MAX_ACCOUNT_INDEX} from './constants'
+import {CryptoProviderFeatures} from './constants'
 
-const AccountManager = ({config, cryptoProvider, blockchainExplorer}) => {
+const AccountManager = ({config, cryptoProvider, blockchainExplorer, maxAccountIndex}) => {
   const accounts: Array<ReturnType<typeof Account>> = []
 
   function getAccount(accountIndex: number) {
@@ -25,7 +25,7 @@ const AccountManager = ({config, cryptoProvider, blockchainExplorer}) => {
     if (
       account.accountIndex !== accounts.length ||
       !isLastAccountUsed ||
-      account.accountIndex > MAX_ACCOUNT_INDEX
+      account.accountIndex > maxAccountIndex
     ) {
       throw NamedError('AccountExplorationError')
     }
@@ -43,7 +43,12 @@ const AccountManager = ({config, cryptoProvider, blockchainExplorer}) => {
       const isAccountUsed = await newAccount.isAccountUsed()
       if (accountIndex === accounts.length) await addNextAccount(newAccount)
 
-      return shouldExplore && isAccountUsed && (await _discoverNextAccount(accountIndex + 1))
+      return (
+        shouldExplore &&
+        isAccountUsed &&
+        accountIndex < maxAccountIndex &&
+        (await _discoverNextAccount(accountIndex + 1))
+      )
     }
     await _discoverNextAccount(Math.max(0, accounts.length - 1))
     return accounts

--- a/app/frontend/wallet/shelley-wallet.ts
+++ b/app/frontend/wallet/shelley-wallet.ts
@@ -1,12 +1,23 @@
 import BlockchainExplorer from './blockchain-explorer'
 import {AccountManager} from './account-manager'
 import {AccountInfo} from '../types'
-import {CryptoProviderFeatures} from './constants'
+import {CryptoProviderFeatures, MAX_ACCOUNT_INDEX} from './constants'
 
 const ShelleyWallet = ({config, cryptoProvider}) => {
   const blockchainExplorer = BlockchainExplorer(config)
 
-  const accountManager = AccountManager({config, cryptoProvider, blockchainExplorer})
+  let maxAccountIndex = MAX_ACCOUNT_INDEX
+  if (cryptoProvider.getWalletName() === 'Trezor') {
+    // hotfix because of https://github.com/vacuumlabs/trezor-firmware/issues/43
+    maxAccountIndex = 20
+  }
+
+  const accountManager = AccountManager({
+    config,
+    cryptoProvider,
+    blockchainExplorer,
+    maxAccountIndex,
+  })
 
   function isHwWallet() {
     return cryptoProvider.isHwWallet()
@@ -50,6 +61,10 @@ const ShelleyWallet = ({config, cryptoProvider}) => {
     return Promise.all(accounts.map((account) => account.getAccountInfo(validStakepools)))
   }
 
+  function getMaxAccountIndex() {
+    return maxAccountIndex
+  }
+
   function getValidStakepools(): Promise<any> {
     return blockchainExplorer.getValidStakepools()
   }
@@ -65,6 +80,7 @@ const ShelleyWallet = ({config, cryptoProvider}) => {
     getValidStakepools,
     getAccount: accountManager.getAccount,
     exploreNextAccount: accountManager.exploreNextAccount,
+    getMaxAccountIndex,
   }
 }
 

--- a/app/tests/src/common/account-manager-settings.js
+++ b/app/tests/src/common/account-manager-settings.js
@@ -6,23 +6,27 @@ export const accountManagerSettings = [
     description: 'with multiple used accounts',
     shouldExportPubKeyBulk: true,
     numberOfDiscoveredAccounts: 4,
+    maxAccountIndex: 30,
   },
   {
     ...walletSettings[0],
     description: 'with disabled bulk export',
     shouldExportPubKeyBulk: false,
     numberOfDiscoveredAccounts: 1,
+    maxAccountIndex: 30,
   },
   {
     ...walletSettings[1],
     description: 'with shelley incompatible wallet',
     shouldExportPubKeyBulk: true,
     numberOfDiscoveredAccounts: 1,
+    maxAccountIndex: 30,
   },
   {
     ...walletSettings[2],
     description: 'with shelley unused wallet',
     shouldExportPubKeyBulk: true,
     numberOfDiscoveredAccounts: 1,
+    maxAccountIndex: 30,
   },
 ]

--- a/app/tests/src/wallet/account-manager.js
+++ b/app/tests/src/wallet/account-manager.js
@@ -23,6 +23,7 @@ const initAccountManager = async (settings, i) => {
     network,
     shouldExportPubKeyBulk,
     isShelleyCompatible,
+    maxAccountIndex,
   } = settings
   const config = {...ADALITE_CONFIG, isShelleyCompatible, shouldExportPubKeyBulk}
   // console.log(JSON.stringify(settings))
@@ -44,7 +45,9 @@ const initAccountManager = async (settings, i) => {
     config,
   })
 
-  accountManagers.push(AccountManager({config, cryptoProvider, blockchainExplorer}))
+  accountManagers.push(
+    AccountManager({config, cryptoProvider, blockchainExplorer, maxAccountIndex})
+  )
 }
 
 before(async () => {


### PR DESCRIPTION
Motivation: Originally when account discovery hit the limit of accounts (30), it failed with AccountExplorationError. This PR fixes this and stops the exploration before hitting the limit.

Changes:
* modify discoverAccounts to stop exploring when maxAccountIndex is hit
* remove the "Explore" tile should the last discovered account be at the limit
* Finally, there is a bug in Trezor that prevents transactions on accounts over 20' from working properly (https://github.com/vacuumlabs/trezor-firmware/issues/43), so there is a hotfix that overrides that limit for Trezor and sets maxAccountIndex to 20

Testing:
* tested manually with Ledger by setting the maxAccountIndex to a lower value to reproduce the situation when the condition triggers, exploration stops as expected
* tested manually with Trezor, verifying that the maxAccountIndex is overriden

closes #787 