### PR TITLE
Refactor login page and its sidebar

### DIFF
--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -104,7 +104,8 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
   const setAuthMethod = (state: State, option: AuthMethodEnum): void => {
     setState({
       authMethod: option,
-      shouldShowExportOption: option === 'mnemonic' || option === 'file',
+      shouldShowExportOption:
+        option === AuthMethodEnum.Mnemonic || option === AuthMethodEnum.KeyFile,
     })
   }
 
@@ -273,7 +274,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
       },
       walletLoadingError: undefined,
       shouldShowWalletLoadingErrorModal: false,
-      authMethod: 'mnemonic',
+      authMethod: AuthMethodEnum.Mnemonic,
       shouldShowExportOption: true,
     })
   }
@@ -326,7 +327,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
         formIsValid: false,
       },
       shouldShowGenerateMnemonicDialog: true,
-      authMethod: 'mnemonic',
+      authMethod: AuthMethodEnum.Mnemonic,
       shouldShowMnemonicInfoAlert: true,
     })
   }

--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -37,7 +37,7 @@ import {parseUnsignedTx} from './helpers/cliParser/parser'
 import {TxPlan, unsignedPoolTxToTxPlan} from './wallet/shelley/shelley-transaction-planner'
 import getDonationAddress from './helpers/getDonationAddress'
 import {localStorageVars} from './localStorage'
-import {AccountInfo, Ada, Lovelace, CryptoProviderFeature, _Address, TxType} from './types'
+import {AccountInfo, Ada, Lovelace, CryptoProviderFeature, _Address, TxType, AuthMethodType} from './types'
 import {MainTabs} from './constants'
 
 let wallet: ReturnType<typeof ShelleyWallet>
@@ -101,11 +101,11 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
     }
   }
 
-  const setAuthMethod = (state: State, option: AuthMethodEnum): void => {
+  const setAuthMethod = (state: State, option: AuthMethodType): void => {
     setState({
       authMethod: option,
       shouldShowExportOption:
-        option === AuthMethodEnum.Mnemonic || option === AuthMethodEnum.KeyFile,
+        option === AuthMethodType.MNEMONIC || option === AuthMethodType.KEY_FILE,
     })
   }
 
@@ -274,7 +274,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
       },
       walletLoadingError: undefined,
       shouldShowWalletLoadingErrorModal: false,
-      authMethod: AuthMethodEnum.Mnemonic,
+      authMethod: AuthMethodType.MNEMONIC,
       shouldShowExportOption: true,
     })
   }
@@ -327,7 +327,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
         formIsValid: false,
       },
       shouldShowGenerateMnemonicDialog: true,
-      authMethod: AuthMethodEnum.Mnemonic,
+      authMethod: AuthMethodType.MNEMONIC,
       shouldShowMnemonicInfoAlert: true,
     })
   }

--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -101,7 +101,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
     }
   }
 
-  const setAuthMethod = (state, option) => {
+  const setAuthMethod = (state: State, option: AuthMethodEnum): void => {
     setState({
       authMethod: option,
       shouldShowExportOption: option === 'mnemonic' || option === 'file',

--- a/app/frontend/components/common/viewPort.tsx
+++ b/app/frontend/components/common/viewPort.tsx
@@ -1,0 +1,38 @@
+import {ScreenType} from '../../types'
+import {useState, useEffect} from 'preact/hooks'
+
+// we could export this and use it in other places, in that case
+// we should optimalize it with context
+// https://blog.logrocket.com/developing-responsive-layouts-with-react-hooks/
+const useViewport = (): ScreenType => {
+  const [screenType, setScreenType] = useState<ScreenType>(undefined)
+
+  const handleScreenResize = () => {
+    if (window.innerWidth < 768) {
+      setScreenType(ScreenType.MOBILE)
+    } else if (window.innerWidth <= 1024) {
+      setScreenType(ScreenType.TABLET)
+    } else {
+      setScreenType(ScreenType.DESKTOP)
+    }
+  }
+
+  useEffect(() => {
+    handleScreenResize()
+    window.addEventListener('resize', handleScreenResize)
+
+    return () => window.removeEventListener('resize', handleScreenResize)
+  }, [])
+
+  return screenType
+}
+
+const isSmallerThanDesktop = (screenType: ScreenType): boolean => {
+  return [ScreenType.MOBILE, ScreenType.TABLET].includes(screenType)
+}
+
+const isBiggerThanMobile = (screenType: ScreenType): boolean => {
+  return [ScreenType.TABLET, ScreenType.DESKTOP].includes(screenType)
+}
+
+export {useViewport, isSmallerThanDesktop, isBiggerThanMobile}

--- a/app/frontend/components/pages/dashboard/dashboardPage.tsx
+++ b/app/frontend/components/pages/dashboard/dashboardPage.tsx
@@ -21,35 +21,18 @@ import AccountsDashboard from '../accounts/accountsDashboard'
 import {State} from '../../../state'
 import PoolOwner from '../advanced/poolOwner'
 import ErrorModals from './errorModals'
-import {useEffect, useState} from 'preact/hooks'
+import {useState} from 'preact/hooks'
 import {SubTabs, MainTabs} from '../../../constants'
+import {useViewport, isSmallerThanDesktop} from '../../common/viewPort'
+import {ScreenType} from '../../../types'
 
-// we could export this and use it in other places, in that case
-// we should optimalize it with context
-// https://blog.logrocket.com/developing-responsive-layouts-with-react-hooks/
-const useViewport = () => {
-  const [isViewportSmall, setIsViewportSmall] = useState(false)
-
-  const handleScreenResize = () => {
-    setIsViewportSmall(window.innerWidth <= 1024)
-  }
-  useEffect(() => {
-    handleScreenResize()
-    window.addEventListener('resize', handleScreenResize)
-
-    return () => window.removeEventListener('resize', handleScreenResize)
-  }, [])
-
-  return isViewportSmall
-}
-
-const StakingPage = ({isViewportSmall}: {isViewportSmall: boolean}) => {
+const StakingPage = ({screenType}: {screenType: ScreenType}) => {
   const subTabs = [SubTabs.DELEGATE_ADA, SubTabs.CURRENT_DELEGATION, SubTabs.STAKING_HISTORY]
   const defaultSubTab = SubTabs.DELEGATE_ADA
   const mainSubTab = SubTabs.SHELLEY_BALANCES
   return (
     <Fragment>
-      {isViewportSmall ? (
+      {isSmallerThanDesktop(screenType) ? (
         <div className="dashboard mobile">
           <DashboardMobileContent
             subTabs={subTabs}
@@ -75,17 +58,17 @@ const StakingPage = ({isViewportSmall}: {isViewportSmall: boolean}) => {
 
 const SendingPage = ({
   shouldShowExportOption,
-  isViewportSmall,
+  screenType,
 }: {
   shouldShowExportOption: boolean
-  isViewportSmall: boolean
+  screenType: ScreenType
 }) => {
   const subTabs = [SubTabs.SEND_ADA, SubTabs.TRANSACTIONS, SubTabs.ADDRESSES]
   const defaultSubTab = SubTabs.TRANSACTIONS
   const mainSubTab = SubTabs.BALANCE
   return (
     <Fragment>
-      {isViewportSmall ? (
+      {isSmallerThanDesktop(screenType) ? (
         <div className="dashboard mobile">
           <DashboardMobileContent
             subTabs={subTabs}
@@ -111,13 +94,13 @@ const SendingPage = ({
   )
 }
 
-const AdvancedPage = ({isViewportSmall}: {isViewportSmall: boolean}) => {
+const AdvancedPage = ({screenType}: {screenType: ScreenType}) => {
   const subTabs = [SubTabs.POOL_OWNER]
   const defaultSubTab = SubTabs.POOL_OWNER
   const mainSubTab = SubTabs.KEYS
   return (
     <Fragment>
-      {isViewportSmall ? (
+      {screenType < ScreenType.DESKTOP ? (
         <div className="dashboard mobile">
           <DashboardMobileContent
             subTabs={subTabs}
@@ -139,12 +122,12 @@ const AdvancedPage = ({isViewportSmall}: {isViewportSmall: boolean}) => {
   )
 }
 
-const AccountsPage = ({isViewportSmall}) => {
+const AccountsPage = ({screenType}: {screenType: ScreenType}) => {
   const subTabs = [SubTabs.ACCOUNTS]
   const defaultSubTab = SubTabs.ACCOUNTS
   return (
     <Fragment>
-      {isViewportSmall ? (
+      {isSmallerThanDesktop(screenType) ? (
         <div className="dashboard mobile">
           <DashboardMobileContent subTabs={subTabs} defaultSubTab={defaultSubTab} />
         </div>
@@ -196,18 +179,15 @@ const DashboardPage = ({
   shouldNumberAccountsFromOne,
   shouldShowExportOption,
 }: Props) => {
-  const isViewportSmall = useViewport()
+  const screenType = useViewport()
 
   const MainPages: {[key in MainTabs]: any} = {
-    [MainTabs.ACCOUNT]: <AccountsPage isViewportSmall={isViewportSmall} />,
-    [MainTabs.STAKING]: <StakingPage isViewportSmall={isViewportSmall} />,
+    [MainTabs.ACCOUNT]: <AccountsPage screenType={screenType} />,
+    [MainTabs.STAKING]: <StakingPage screenType={screenType} />,
     [MainTabs.SENDING]: (
-      <SendingPage
-        isViewportSmall={isViewportSmall}
-        shouldShowExportOption={shouldShowExportOption}
-      />
+      <SendingPage screenType={screenType} shouldShowExportOption={shouldShowExportOption} />
     ),
-    [MainTabs.ADVANCED]: <AdvancedPage isViewportSmall={isViewportSmall} />,
+    [MainTabs.ADVANCED]: <AdvancedPage screenType={screenType} />,
   }
   return (
     <div className="page-wrapper">

--- a/app/frontend/components/pages/login/loginPage.tsx
+++ b/app/frontend/components/pages/login/loginPage.tsx
@@ -38,9 +38,9 @@ const useViewport = () => {
 
 // TODO: extract to app/frontend/constants.ts after rebase
 const AUTH_METHOD_NAMES = {
-  'mnemonic': 'Mnemonic',
-  'hw-wallet': 'Hardware Wallet',
-  'file': 'Key file',
+  [AuthMethodEnum.Mnemonic]: 'Mnemonic',
+  [AuthMethodEnum.HwWallet]: 'Hardware Wallet',
+  [AuthMethodEnum.KeyFile]: 'Key file',
 }
 const getAuthMethodName = (authMethod: AuthMethodEnum): string => AUTH_METHOD_NAMES[authMethod]
 
@@ -53,7 +53,7 @@ const CurrentDropdownItem = ({
 }) => (
   <div
     className={`dropdown-item current ${authMethod} ${
-      authMethod === 'hw-wallet' ? 'recommended' : ''
+      authMethod === AuthMethodEnum.HwWallet ? 'recommended' : ''
     }`}
     onClick={toggleDropdown}
   >
@@ -138,16 +138,16 @@ const AuthCardInitial = () => (
     <h2 className="authentication-title">How do you want to access your Cardano Wallet?</h2>
     <div className="auth-options">
       <AuthOption
-        tabName={'mnemonic'}
+        tabName={AuthMethodEnum.Mnemonic}
         texts={['12, 15, 24 or 27 word passphrase']}
         tag={'fastest'}
       />
       <AuthOption
-        tabName={'hw-wallet'}
+        tabName={AuthMethodEnum.HwWallet}
         texts={['Trezor T', 'Ledger Nano S/X', 'Android device & Ledger']}
         tag={'recommended'}
       />
-      <AuthOption tabName={'file'} texts={['Encrypted .JSON file']} tag={''} />
+      <AuthOption tabName={AuthMethodEnum.KeyFile} texts={['Encrypted .JSON file']} tag={''} />
     </div>
   </div>
 )
@@ -169,28 +169,32 @@ const AuthCard = ({
         <ul className="dropdown-items">
           <DropdownItem
             authMethod={authMethod}
-            tabName={'mnemonic'}
+            tabName={AuthMethodEnum.Mnemonic}
             toggleDropdown={toggleDropdown}
           />
           <DropdownItem
-            tabName={'hw-wallet'}
+            tabName={AuthMethodEnum.HwWallet}
             toggleDropdown={toggleDropdown}
             authMethod={authMethod}
             recommended
           />
-          <DropdownItem authMethod={authMethod} tabName={'file'} toggleDropdown={toggleDropdown} />
+          <DropdownItem
+            authMethod={authMethod}
+            tabName={AuthMethodEnum.KeyFile}
+            toggleDropdown={toggleDropdown}
+          />
         </ul>
       </div>
     ) : (
       <ul className="auth-tabs">
-        <AuthTab tabName={'mnemonic'} authMethod={authMethod} />
-        <AuthTab tabName={'hw-wallet'} authMethod={authMethod} recommended />
-        <AuthTab tabName={'file'} authMethod={authMethod} />
+        <AuthTab tabName={AuthMethodEnum.Mnemonic} authMethod={authMethod} />
+        <AuthTab tabName={AuthMethodEnum.HwWallet} authMethod={authMethod} recommended />
+        <AuthTab tabName={AuthMethodEnum.KeyFile} authMethod={authMethod} />
       </ul>
     )}
-    {authMethod === 'mnemonic' && <MnemonicAuth />}
-    {authMethod === 'hw-wallet' && <HardwareAuth />}
-    {authMethod === 'file' && <KeyFileAuth />}
+    {authMethod === AuthMethodEnum.Mnemonic && <MnemonicAuth />}
+    {authMethod === AuthMethodEnum.HwWallet && <HardwareAuth />}
+    {authMethod === AuthMethodEnum.KeyFile && <KeyFileAuth />}
   </div>
 )
 
@@ -228,11 +232,11 @@ const LoginPage = () => {
   } = useActions(actions)
 
   useEffect(() => {
-    if (autoLogin && authMethod !== 'mnemonic') {
-      setAuthMethod('mnemonic')
+    if (autoLogin && authMethod !== AuthMethodEnum.Mnemonic) {
+      setAuthMethod(AuthMethodEnum.Mnemonic)
     }
     loadErrorBannerContent()
-  })
+  }, []) // eslint-disable-line
 
   return (
     <div className="page-wrapper">
@@ -240,7 +244,7 @@ const LoginPage = () => {
       {errorBannerContent && <ErrorBanner message={errorBannerContent} />}
       <div className="page-inner">
         <main className="page-main">
-          {authMethod === '' ? (
+          {authMethod === AuthMethodEnum.Initial ? (
             <AuthCardInitial />
           ) : (
             <AuthCard

--- a/app/frontend/components/pages/login/loginPage.tsx
+++ b/app/frontend/components/pages/login/loginPage.tsx
@@ -18,10 +18,21 @@ import {getTranslation} from '../../../translations'
 import {errorHasHelp} from '../../../helpers/errorsWithHelp'
 import {State} from '../../../state'
 import {AuthMethodType, ScreenType} from '../../../types'
-import {AuthMethodNames} from '../../../constants'
 import {useViewport, isBiggerThanMobile} from '../../common/viewPort'
+import assertUnreachable from '../../../helpers/assertUnreachable'
 
-const getAuthMethodName = (authMethod: AuthMethodType): string => AuthMethodNames[authMethod]
+const getAuthMethodName = (authMethod: AuthMethodType): string => {
+  switch (authMethod) {
+    case AuthMethodType.MNEMONIC:
+      return 'Mnemonic'
+    case AuthMethodType.HW_WALLET:
+      return 'Hardware Wallet'
+    case AuthMethodType.KEY_FILE:
+      return 'Key file'
+    default:
+      return assertUnreachable(authMethod)
+  }
+}
 
 const CurrentDropdownItem = ({
   authMethod,
@@ -130,6 +141,20 @@ const AuthCardInitial = () => (
     </div>
   </div>
 )
+
+const SubCardByAuthMethod = ({authMethod}: {authMethod: AuthMethodType}) => {
+  switch (authMethod) {
+    case AuthMethodType.MNEMONIC:
+      return <MnemonicAuth />
+    case AuthMethodType.HW_WALLET:
+      return <HardwareAuth />
+    case AuthMethodType.KEY_FILE:
+      return <KeyFileAuth />
+    default:
+      return assertUnreachable(authMethod)
+  }
+}
+
 const AuthCard = ({
   authMethod,
   screenType,
@@ -171,9 +196,7 @@ const AuthCard = ({
         </ul>
       </div>
     )}
-    {authMethod === AuthMethodType.MNEMONIC && <MnemonicAuth />}
-    {authMethod === AuthMethodType.HW_WALLET && <HardwareAuth />}
-    {authMethod === AuthMethodType.KEY_FILE && <KeyFileAuth />}
+    <SubCardByAuthMethod authMethod={authMethod} />
   </div>
 )
 

--- a/app/frontend/components/pages/login/loginPageSidebar.tsx
+++ b/app/frontend/components/pages/login/loginPageSidebar.tsx
@@ -2,6 +2,7 @@ import {h} from 'preact'
 import {useSelector} from '../../../helpers/connect'
 import {State} from '../../../state'
 import {AuthMethodType} from '../../../types'
+import assertUnreachable from '../../../helpers/assertUnreachable'
 
 import Alert from '../../common/alert'
 
@@ -166,14 +167,26 @@ const FileContent = () => (
   </div>
 )
 
+const SidebarContentByAuthMethod = ({authMethod}: {authMethod: AuthMethodType}) => {
+  switch (authMethod) {
+    case null:
+      return <InitialContent />
+    case AuthMethodType.MNEMONIC:
+      return <MnemonicContent />
+    case AuthMethodType.HW_WALLET:
+      return <WalletContent />
+    case AuthMethodType.KEY_FILE:
+      return <FileContent />
+    default:
+      return assertUnreachable(authMethod)
+  }
+}
+
 const LoginPageSidebar = () => {
   const {authMethod} = useSelector((state: State) => ({authMethod: state.authMethod}))
   return (
     <aside className="sidebar">
-      {authMethod === null && <InitialContent />}
-      {authMethod === AuthMethodType.MNEMONIC && <MnemonicContent />}
-      {authMethod === AuthMethodType.HW_WALLET && <WalletContent />}
-      {authMethod === AuthMethodType.KEY_FILE && <FileContent />}
+      <SidebarContentByAuthMethod authMethod={authMethod} />
     </aside>
   )
 }

--- a/app/frontend/components/pages/login/loginPageSidebar.tsx
+++ b/app/frontend/components/pages/login/loginPageSidebar.tsx
@@ -1,6 +1,6 @@
 import {h} from 'preact'
 import {useSelector} from '../../../helpers/connect'
-import {State} from '../../../state'
+import {AuthMethodEnum, State} from '../../../state'
 
 import Alert from '../../common/alert'
 
@@ -169,10 +169,10 @@ const LoginPageSidebar = () => {
   const {authMethod} = useSelector((state: State) => ({authMethod: state.authMethod}))
   return (
     <aside className="sidebar">
-      {authMethod === '' && <InitialContent />}
-      {authMethod === 'mnemonic' && <MnemonicContent />}
-      {authMethod === 'hw-wallet' && <WalletContent />}
-      {authMethod === 'file' && <FileContent />}
+      {authMethod === AuthMethodEnum.Initial && <InitialContent />}
+      {authMethod === AuthMethodEnum.Mnemonic && <MnemonicContent />}
+      {authMethod === AuthMethodEnum.HwWallet && <WalletContent />}
+      {authMethod === AuthMethodEnum.KeyFile && <FileContent />}
     </aside>
   )
 }

--- a/app/frontend/components/pages/login/loginPageSidebar.tsx
+++ b/app/frontend/components/pages/login/loginPageSidebar.tsx
@@ -1,5 +1,6 @@
-import {h, Component} from 'preact'
-import {connect} from '../../../helpers/connect'
+import {h} from 'preact'
+import {useSelector} from '../../../helpers/connect'
+import {State} from '../../../state'
 
 import Alert from '../../common/alert'
 
@@ -164,23 +165,16 @@ const FileContent = () => (
   </div>
 )
 
-interface Props {
-  authMethod: '' | 'mnemonic' | 'hw-walet' | 'file'
+const LoginPageSidebar = () => {
+  const {authMethod} = useSelector((state: State) => ({authMethod: state.authMethod}))
+  return (
+    <aside className="sidebar">
+      {authMethod === '' && <InitialContent />}
+      {authMethod === 'mnemonic' && <MnemonicContent />}
+      {authMethod === 'hw-wallet' && <WalletContent />}
+      {authMethod === 'file' && <FileContent />}
+    </aside>
+  )
 }
 
-class LoginPageSidebar extends Component<Props> {
-  render({authMethod}) {
-    return (
-      <aside className="sidebar">
-        {authMethod === '' && <InitialContent />}
-        {authMethod === 'mnemonic' && <MnemonicContent />}
-        {authMethod === 'hw-wallet' && <WalletContent />}
-        {authMethod === 'file' && <FileContent />}
-      </aside>
-    )
-  }
-}
-
-export default connect((state) => ({
-  authMethod: state.authMethod,
-}))(LoginPageSidebar)
+export default LoginPageSidebar

--- a/app/frontend/components/pages/login/loginPageSidebar.tsx
+++ b/app/frontend/components/pages/login/loginPageSidebar.tsx
@@ -1,6 +1,7 @@
 import {h} from 'preact'
 import {useSelector} from '../../../helpers/connect'
-import {AuthMethodEnum, State} from '../../../state'
+import {State} from '../../../state'
+import {AuthMethodType} from '../../../types'
 
 import Alert from '../../common/alert'
 
@@ -169,10 +170,10 @@ const LoginPageSidebar = () => {
   const {authMethod} = useSelector((state: State) => ({authMethod: state.authMethod}))
   return (
     <aside className="sidebar">
-      {authMethod === AuthMethodEnum.Initial && <InitialContent />}
-      {authMethod === AuthMethodEnum.Mnemonic && <MnemonicContent />}
-      {authMethod === AuthMethodEnum.HwWallet && <WalletContent />}
-      {authMethod === AuthMethodEnum.KeyFile && <FileContent />}
+      {authMethod === null && <InitialContent />}
+      {authMethod === AuthMethodType.MNEMONIC && <MnemonicContent />}
+      {authMethod === AuthMethodType.HW_WALLET && <WalletContent />}
+      {authMethod === AuthMethodType.KEY_FILE && <FileContent />}
     </aside>
   )
 }

--- a/app/frontend/constants.ts
+++ b/app/frontend/constants.ts
@@ -1,5 +1,3 @@
-import {AuthMethodType} from './types'
-
 export enum MainTabs {
   ACCOUNT = 'Accounts',
   SENDING = 'Sending',
@@ -19,10 +17,4 @@ export enum SubTabs {
   POOL_OWNER = 'Pool registration',
   BALANCE = 'Balance',
   SHELLEY_BALANCES = 'Shelley Balances',
-}
-
-export const AuthMethodNames = {
-  [AuthMethodType.MNEMONIC]: 'Mnemonic',
-  [AuthMethodType.HW_WALLET]: 'Hardware Wallet',
-  [AuthMethodType.KEY_FILE]: 'Key file',
 }

--- a/app/frontend/constants.ts
+++ b/app/frontend/constants.ts
@@ -1,3 +1,5 @@
+import {AuthMethodType} from './types'
+
 export enum MainTabs {
   ACCOUNT = 'Accounts',
   SENDING = 'Sending',
@@ -17,4 +19,10 @@ export enum SubTabs {
   POOL_OWNER = 'Pool registration',
   BALANCE = 'Balance',
   SHELLEY_BALANCES = 'Shelley Balances',
+}
+
+export const AuthMethodNames = {
+  [AuthMethodType.MNEMONIC]: 'Mnemonic',
+  [AuthMethodType.HW_WALLET]: 'Hardware Wallet',
+  [AuthMethodType.KEY_FILE]: 'Key file',
 }

--- a/app/frontend/helpers/assertUnreachable.ts
+++ b/app/frontend/helpers/assertUnreachable.ts
@@ -1,0 +1,6 @@
+// Required for typescript case exhaustiveness. Remove after strictNullChecks are turned on
+function assertUnreachable(x: never): never {
+  throw new Error('This should be unreachable.')
+}
+
+export default assertUnreachable

--- a/app/frontend/state.ts
+++ b/app/frontend/state.ts
@@ -1,7 +1,7 @@
 import {ADALITE_CONFIG} from './config'
 import {MainTabs} from './constants'
 import {localStorageVars} from './localStorage'
-import {AccountInfo, AuthMethodEnum, Lovelace} from './types'
+import {AccountInfo, AuthMethodType, Lovelace} from './types'
 export interface SendTransactionSummary {
   amount?: Lovelace
   donation?: Lovelace
@@ -36,7 +36,7 @@ export interface State {
 
   // login / logout
   autoLogin: boolean
-  authMethod: AuthMethodEnum
+  authMethod: AuthMethodType | null
   shouldShowDemoWalletWarningDialog: boolean
   logoutNotificationOpen: boolean
   walletIsLoaded: boolean
@@ -180,8 +180,8 @@ const initialState: State = {
   autoLogin:
     ADALITE_CONFIG.ADALITE_ENV === 'local' && ADALITE_CONFIG.ADALITE_DEVEL_AUTO_LOGIN === 'true',
   authMethod: ['#trezor', '#hw-wallet'].includes(window.location.hash)
-    ? AuthMethodEnum.HwWallet
-    : AuthMethodEnum.Initial,
+    ? AuthMethodType.HW_WALLET
+    : null,
   shouldShowDemoWalletWarningDialog: false,
   logoutNotificationOpen: false,
   walletIsLoaded: false,

--- a/app/frontend/state.ts
+++ b/app/frontend/state.ts
@@ -1,7 +1,7 @@
 import {ADALITE_CONFIG} from './config'
 import {MainTabs} from './constants'
 import {localStorageVars} from './localStorage'
-import {AccountInfo, AuthMethod, Lovelace} from './types'
+import {AccountInfo, AuthMethodEnum, Lovelace} from './types'
 export interface SendTransactionSummary {
   amount?: Lovelace
   donation?: Lovelace
@@ -36,7 +36,7 @@ export interface State {
 
   // login / logout
   autoLogin: boolean
-  authMethod: AuthMethod
+  authMethod: AuthMethodEnum
   shouldShowDemoWalletWarningDialog: boolean
   logoutNotificationOpen: boolean
   walletIsLoaded: boolean
@@ -179,7 +179,9 @@ const initialState: State = {
   // login / logout
   autoLogin:
     ADALITE_CONFIG.ADALITE_ENV === 'local' && ADALITE_CONFIG.ADALITE_DEVEL_AUTO_LOGIN === 'true',
-  authMethod: ['#trezor', '#hw-wallet'].includes(window.location.hash) ? 'hw-wallet' : '',
+  authMethod: ['#trezor', '#hw-wallet'].includes(window.location.hash)
+    ? AuthMethodEnum.HwWallet
+    : AuthMethodEnum.Initial,
   shouldShowDemoWalletWarningDialog: false,
   logoutNotificationOpen: false,
   walletIsLoaded: false,

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -71,7 +71,12 @@ export type _XPubKey = {
   xpubHex: HexString
 }
 
-export type AuthMethod = '' | 'hw-wallet' | 'mnemonic' // TODO
+export enum AuthMethodEnum {
+  Initial,
+  Mnemonic = 'mnemonic',
+  HwWallet = 'hw-wallet',
+  KeyFile = 'file',
+}
 export type Ada = number & {__typeAda: any}
 export type Lovelace = number & {__typeLovelace: any}
 

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -71,12 +71,18 @@ export type _XPubKey = {
   xpubHex: HexString
 }
 
-export enum AuthMethodEnum {
-  Initial,
-  Mnemonic = 'mnemonic',
-  HwWallet = 'hw-wallet',
-  KeyFile = 'file',
+export enum AuthMethodType {
+  MNEMONIC = 'mnemonic',
+  HW_WALLET = 'hw-wallet',
+  KEY_FILE = 'file',
 }
+
+export enum ScreenType {
+  MOBILE,
+  TABLET,
+  DESKTOP,
+}
+
 export type Ada = number & {__typeAda: any}
 export type Lovelace = number & {__typeLovelace: any}
 


### PR DESCRIPTION
- Converts loginPage and and loginPageSidebar from classes to components with hooks
- Removes now unnecessary ENABLE_HW_WALLETS constant
- Introduces types
- Renames misleading variables
- Uses useViewport to render components depending on the screen size instead of hiding desktop/mobile components
- Solves mobile bug of HW wallets login not having padding
- Prepares ground for private key login