### PR TITLE
Test tx plannig

### DIFF
--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -1511,6 +1511,7 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
     openWelcome,
     closeWelcome,
     calculateFee,
+    calculateDelegationFee,
     confirmTransaction,
     cancelTransaction,
     submitTransaction,

--- a/app/tests/src/actions/actions.js
+++ b/app/tests/src/actions/actions.js
@@ -6,13 +6,13 @@ import {default as actions} from '../../../frontend/actions'
 window.wasm = null
 before(loadWasmModule)
 
-export const setStateFn = function(state, changes) {
+export const setMockState = function(state, changes) {
   for (const [key, val] of Object.entries(changes)) {
     state[key] = val
   }
 }
 
-export const getStateFn = function(state) {
+export const getMockState = function(state) {
   return state
 }
 
@@ -22,12 +22,12 @@ export function assertPropertiesEqual(state, expectedState) {
   }
 }
 
-export function setupInitialState() {
+export function setupInitialMockState() {
   const cloneDeep = require('lodash/fp/cloneDeep')
   const state = cloneDeep(initialState)
 
-  const getState = () => getStateFn(state)
-  const setState = (change) => setStateFn(state, change)
+  const getState = () => getMockState(state)
+  const setState = (change) => setMockState(state, change)
   const action = actions({setState, getState})
   return [state, action]
 }

--- a/app/tests/src/actions/transaction-actions.js
+++ b/app/tests/src/actions/transaction-actions.js
@@ -1,4 +1,4 @@
-import {setStateFn, setupInitialState} from './actions'
+import {setMockState, setupInitialMockState} from './actions'
 import {ADALITE_CONFIG} from '../../../frontend/config'
 import mockNetwork from '../common/mock'
 import {CryptoProviderType} from '../../../frontend/wallet/constants'
@@ -9,7 +9,7 @@ import {walletSettings} from '../common/wallet-settings'
 let state, action
 
 beforeEach(() => {
-  ;[state, action] = setupInitialState()
+  ;[state, action] = setupInitialMockState()
 })
 
 before(() => {
@@ -30,11 +30,12 @@ before(() => {
   mockNet.mockPoolRecommendation()
 })
 
-const loadTestWallet = async () => {
+const loadTestWallet = async (mockState) => {
   await action.loadWallet(state, {
     cryptoProviderType: CryptoProviderType.WALLET_SECRET,
     walletSecretDef: await mnemonicToWalletSecretDef(walletSettings.Shelley15Word.secret),
   })
+  setMockState(state, mockState)
 }
 
 const sendAdaTxSettings = {
@@ -95,8 +96,7 @@ const withdrawalSettings = {
 describe('Send ADA fee calculation', () => {
   Object.entries(sendAdaTxSettings).forEach(([name, setting]) =>
     it(`should calculate fee for tx with ${name}`, async () => {
-      await loadTestWallet()
-      setStateFn(state, setting.state)
+      await loadTestWallet(setting.state)
       await action.calculateFee()
       assert.deepEqual(state.sendTransactionSummary.fee, setting.sendTransactionSummary.fee)
     })
@@ -106,8 +106,7 @@ describe('Send ADA fee calculation', () => {
 describe('Delegation fee calculation', () => {
   Object.entries(delegationSettings).forEach(([name, setting]) =>
     it(`should calculate fee for tx with ${name}`, async () => {
-      await loadTestWallet()
-      setStateFn(state, setting.state)
+      await loadTestWallet(setting.state)
       await action.calculateDelegationFee()
       assert.deepEqual(state.sendTransactionSummary.fee, setting.sendTransactionSummary.fee)
     })
@@ -117,8 +116,7 @@ describe('Delegation fee calculation', () => {
 describe('Withdrawal fee calculation', () => {
   Object.entries(withdrawalSettings).forEach(([name, setting]) =>
     it(`should calculate fee for tx with ${name}`, async () => {
-      await loadTestWallet()
-      setStateFn(state, setting.state)
+      await loadTestWallet(setting.state)
       await action.withdrawRewards(state)
       assert.deepEqual(state.sendTransactionSummary.fee, setting.sendTransactionSummary.fee)
     })

--- a/app/tests/src/actions/transaction-actions.js
+++ b/app/tests/src/actions/transaction-actions.js
@@ -31,7 +31,7 @@ it('Calculate fee - shelley', async () => {
 
   await action.loadWallet(state, {
     cryptoProviderType: CryptoProviderType.WALLET_SECRET,
-    walletSecretDef: await mnemonicToWalletSecretDef(walletSettings[0].secret),
+    walletSecretDef: await mnemonicToWalletSecretDef(walletSettings.Shelley15Word.secret),
   })
 
   state.sendAddress.fieldValue =

--- a/app/tests/src/actions/wallet-actions.js
+++ b/app/tests/src/actions/wallet-actions.js
@@ -3,13 +3,13 @@ import {ADALITE_CONFIG} from '../../../frontend/config'
 import {CryptoProviderType} from '../../../frontend/wallet/constants'
 import mnemonicToWalletSecretDef from '../../../frontend/wallet/helpers/mnemonicToWalletSecretDef'
 import assert from 'assert'
-import {assertPropertiesEqual, setupInitialState} from './actions'
+import {assertPropertiesEqual, setupInitialMockState} from './actions'
 import {walletSettings} from '../common/wallet-settings'
 
 let state, action
 
 beforeEach(() => {
-  ;[state, action] = setupInitialState()
+  ;[state, action] = setupInitialMockState()
 })
 
 const expectedStateChanges = {

--- a/app/tests/src/actions/wallet-actions.js
+++ b/app/tests/src/actions/wallet-actions.js
@@ -66,7 +66,7 @@ it('Should properly load shelley wallet', async () => {
 
   await action.loadWallet(state, {
     cryptoProviderType: CryptoProviderType.WALLET_SECRET,
-    walletSecretDef: await mnemonicToWalletSecretDef(walletSettings[0].secret),
+    walletSecretDef: await mnemonicToWalletSecretDef(walletSettings.Shelley15Word.secret),
     shouldExportPubKeyBulk: true,
   })
   assertPropertiesEqual(state, expectedStateChanges)

--- a/app/tests/src/address-manager.js
+++ b/app/tests/src/address-manager.js
@@ -4,16 +4,11 @@ import derivationSchemes from '../../frontend/wallet/helpers/derivation-schemes'
 import CardanoWalletSecretCryptoProvider from '../../frontend/wallet/byron/cardano-wallet-secret-crypto-provider'
 import AddressManager from '../../frontend/wallet/address-manager'
 import mnemonicToWalletSecretDef from '../../frontend/wallet/helpers/mnemonicToWalletSecretDef'
-import {
-  byronAddressManagerSettings,
-  addressManagerSettings,
-} from './common/address-manager-settings'
+import {byronAddressManagerSettings} from './common/address-manager-settings'
 import BlockchainExplorer from '../../frontend/wallet/blockchain-explorer'
 
 import mockNetwork from './common/mock'
 import {ByronAddressProvider} from '../../frontend/wallet/byron/byron-address-provider'
-import ShelleyJsCryptoProvider from '../../frontend/wallet/shelley/shelley-js-crypto-provider'
-import {ShelleyBaseAddressProvider} from '../../frontend/wallet/shelley/shelley-address-provider'
 
 const mockConfig = {
   ADALITE_BLOCKCHAIN_EXPLORER_URL: 'https://explorer.adalite.io',
@@ -25,35 +20,6 @@ const mockConfig = {
 const blockchainExplorer = BlockchainExplorer(mockConfig, {})
 
 const byronAddressManagers = []
-const addressManagers = []
-
-const initAddressManager = async (settings, i) => {
-  const {accountIndex, isChange, cryptoSettings, shouldExportPubKeyBulk} = settings
-
-  let walletSecretDef
-  if (cryptoSettings.type === 'walletSecretDef') {
-    walletSecretDef = {
-      rootSecret: Buffer.from(cryptoSettings.secret, 'hex'),
-      derivationScheme: derivationSchemes[cryptoSettings.derivationSchemeType],
-    }
-  } else {
-    walletSecretDef = await mnemonicToWalletSecretDef(cryptoSettings.secret)
-  }
-
-  const cryptoProvider = await ShelleyJsCryptoProvider({
-    walletSecretDef,
-    network: cryptoSettings.network,
-    config: {shouldExportPubKeyBulk},
-  })
-
-  const addressProvider = ShelleyBaseAddressProvider(cryptoProvider, accountIndex, isChange)
-
-  addressManagers[i] = AddressManager({
-    addressProvider,
-    gapLimit: mockConfig.ADALITE_GAP_LIMIT,
-    blockchainExplorer,
-  })
-}
 
 const initByronAddressManager = async (settings, i) => {
   const {cryptoSettings, isChange} = settings
@@ -87,7 +53,6 @@ const initByronAddressManager = async (settings, i) => {
 
 before(async () => {
   await Promise.all(byronAddressManagerSettings.map(initByronAddressManager))
-  await Promise.all(addressManagerSettings.map(initAddressManager))
 })
 
 describe('byron wallet addresses derivation scheme V1', () => {
@@ -185,115 +150,5 @@ describe('byron wallet addresses discovery scheme V2', () => {
     assert.equal(JSON.stringify(walletAddresses), JSON.stringify(expectedWalletAddresses))
     assert.equal(JSON.stringify(walletChangeAddresses), JSON.stringify(expectedWalletChangeAddrs))
     mockNet.clean()
-  })
-})
-
-describe('shelley wallet addresses derivation scheme V2', () => {
-  it('should derive the right sequence of change addresses from the root secret key', async () => {
-    const expectedAddresses = [
-      'addr1q9p4n2m7tnrvckjlu5y2y2t73c9g2j7ykwz48dcxhlw6tlg2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsrhcxe0',
-      'addr1q86s0h8020kv93f6uqndm6zg9t93nsrjmll4hsea3a55vjq2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpstqypk3',
-      'addr1q9a3gwe3wyrsxwe83y9f0wj6twmu5dx0y7h8dj2n02qlx5g2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpspvz2as',
-      'addr1qylqas4rkk6fshqc9hcktrr7p3u2frrvs5mad6836mes9kq2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvps8n355h',
-      'addr1q9n0gqt43ak8n62tpsy0z43zh0dr6qedv3nkq5zxl79cels2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpse7pksy',
-      'addr1qysjvr8gmqvl5np0as883xzqej8v53x2uar7efqvg5maq7g2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvps4ra78k',
-      'addr1qxljdpsghlel5dyhzye3xe4l828slu3fgfshkj3n5dsnr0q2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpss88jsd',
-      'addr1q80t7vczkumzd6d9r5xz2s5ektadas8tjrfxqc3ysuyy0tc2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsc5ydet',
-      'addr1q895zcg0ah8qpsx65qjfjd6w94klsht9e0azwlvdzrm2dqg2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvps2wwrwq',
-      'addr1qxclyzqt7gvvkdr3adyg0as5s8u3k8rm43yu5n5n5gad52q2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsc2vp6p',
-      'addr1qx53ku2t54h5xyl02u4yuf7ck7ckvtktwzj886j3zhujgxq2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpshjaad5',
-      'addr1q9f9dljkktl8g82rjwy308cdkzejcs090ewaa7069v2xgzq2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpspqmee3',
-      'addr1q8ran6js80kpfutgp34lzdprg9yw0h3lpr5c36dtuxhtqqq2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvps67z6fm',
-      'addr1qyc6rx94e8d4exxdjzq4m6rv78pmn09m5q7euv9yxsqmj3g2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsh2gtsn',
-      'addr1q8ffhesgk4zhr4ltr78shumtsddmddaak598fu4anlye6zg2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsc244ca',
-      'addr1qy95z8rhl9675srl5v7tcu59ychttthpkc25wj4uc5sqjgc2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsrt6cjx',
-      'addr1qy0jcnu8a0ncxpkavsrkp0xagvetcas83ep086xcfz5z6yq2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsnqj5tv',
-      'addr1q83ajttara8d7fe7yeplfmkskkn509r0hxpvfv2fv5ue0sg2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpswt7xsd',
-      'addr1q9ju078yx3j8wmcsyjrgprdvqsy7wpgajgtymc28nxm93ec2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsqttql5',
-      'addr1qx7azzc53k6lc77k5x2cl2ph8fhgjncxzl6zcm9jg8tr5jg2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsy2p9y9',
-    ]
-    const walletAddresses = await addressManagers[0]._deriveAddresses(0, 20)
-    assert.equal(JSON.stringify(walletAddresses), JSON.stringify(expectedAddresses))
-  })
-
-  it('should derive the right sequence of addresses from the root secret key', async () => {
-    const expectedAddresses = [
-      'addr1q8eakg39wqlye7lzyfmh900s2luc99zf7x9vs839pn4srjs2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsjv0zk3',
-      'addr1q9vyuwgmpez9nrzyk8k9ctk34pw4lfay2r9a3v4qlhc6yrs2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpskh4jl3',
-      'addr1qxsl8fks5z02q9jrqluqcq5x54jvwvlg6s84s3nrgrrnzhc2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsu7t87t',
-      'addr1qyxmavwva6su3xy8wf3gap3f43vktw38qwdr4edp5f47t7g2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvps73h0fk',
-      'addr1q83gj5ydpqq9sxx8kg6jxktwlu0vrwfmg5azqfzm5d984zs2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvps97k8sp',
-      'addr1q84vflkn60my500vm8qmka0lgaezl43mlrweh29gdw2temg2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsquk02w',
-      'addr1qytaz96l2s6dz07ac5mudnykqh0hm3hqt48yqk06vhrczzc2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsxq206f',
-      'addr1q8utasddg033kns4u4d3z0rlth9ylaur3fnukgjf6v5rdqs2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsps5qmn',
-      'addr1q9rt7mq9n56rudeagesz64gje6dq7vyr29eeqvkk0xqclnq2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvps0ng07v',
-      'addr1q98x0m4u6vnfmghvhuv6y3qhch7yxeynpdcsyrdcehsjkmc2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsfa05ry',
-      'addr1qyqfn05rxpq34lncgxtt9an302glm9697uqazu0ssvxet4s2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvps3g6ats',
-      'addr1q9hqcp8j8zesn8suyhvjmlesdq8j9y9m5s0y9r9c474dv7g2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsnz3hk0',
-      'addr1q8d8k874xz789uadev8uxxdesy0t7cwn23c8wku6w60ts7g2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvps0wcm9a',
-      'addr1qynq44pfsq9l5cgk9kl5xac90gczgu2kc8nkxt95xvw626g2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpssepj42',
-      'addr1q9jh2tdg3hjetcnp0ecsssfw8kytpgz3z3qkafhtc8n9mms2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsxz6ftq',
-      'addr1qxgrdcxs4t8a7turztct70wxlxr6t7lt2p72fnkma9epjnq2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvps08flyx',
-      'addr1qyeydz953rwduwdp0wepemvvjwq3g555lvh25h65c6wq3ss2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsnvhpa6',
-      'addr1qx7vxa7sckg29nf3sz80y7mtrsfn4jn8u8nshgu3chz6rps2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpszy75nn',
-      'addr1q98wuwmvcm2e608tvnjjawqrewhfh42cyt9hjpdw3d9elsc2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvps5etmj7',
-      'addr1qx39zdl4lym6hjmz6yzq5y4jw02jfyvjkwpwve49may288c2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsjrny7r',
-    ]
-    const walletAddresses = await addressManagers[1]._deriveAddresses(0, 20)
-    assert.equal(JSON.stringify(walletAddresses), JSON.stringify(expectedAddresses))
-  })
-
-  it('should derive the right sequence of change addresses from Account 1', async () => {
-    const expectedAddresses = [
-      'addr1qy7sntl48nnrsz2zjwraxh8e732jrzzs0ngqp5k5ujhh6nl4nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qsqkd6y',
-      'addr1q85xs0g86ygpze3xg3dth3a6xg8c8jgq68qx6lvpehfdefh4nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8quha566',
-      'addr1qy6v02n7r858z75qre6ztnan89g55gyy0cqepacwh2rptw04nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8q6nzvjx',
-      'addr1qx3lad69a25s42z5caz2vu2slwvxwsynf3q3lm9twcscqnh4nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qfkq6xa',
-      'addr1q8rcsk3eel90957s7f79xxlqvdmypn07nkwtdtkp08fckk84nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qlwhall',
-      'addr1q83atwe9peryqag0p5mxxd07wuum8wnqnhp4jyl36qy530h4nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8q5anz47',
-      'addr1qx6vkgychkxyu67sllfrexcdwhylvjd5jj86lsyd4p62drl4nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qyepsgd',
-      'addr1qxcltpwxsckkw8jv8z0pxmtn2ey5pn9uzw8wp5xqr5y907l4nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qs99umt',
-      'addr1qxf6ymqnr2hmhzq8unsq8nrxn48x9r9w6m3svn4d6uh3c284nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qr3mf0z',
-      'addr1q9swhfju307uhhzhgsw6lv2zuhhle42gsxz7fdmfd5hnms84nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qnavfqx',
-      'addr1q8e2hzh40w2lh545l6yvlarv4jhcv68pw9c4pqksrz694a84nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qxcxx42',
-      'addr1q8upt2qaclyuzc6se345cmsap7rz6ls0tlumx0u5cthy5k04nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qh54fjf',
-      'addr1qyvfs5whmsta66p4687qj3r30np2a3da8vrzn4naqh3cla84nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qhc3sjx',
-      'addr1qxp9zhauy5vajd4xcuzka32tnjurcj0vkr4rk02d445vde04nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qvg37hv',
-      'addr1q837j24hw9qnsv0fk55yjhlttv5d5f70rjyqqtyvtcgrl084nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qm9wt2l',
-      'addr1q803r0rqq6uzettpq0qcqh5c25cndu9d67wad5886akz6v84nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8q8xamjd',
-      'addr1qyyk6v70jntdv9d8v7ave2rn4y9nwapl6vun3w7lzy9u2qh4nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qn3n50q',
-      'addr1q9y8rskghzd4pyw46pmjwh4qlhdqqscnffvaw805pjclrd84nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qwjrjvj',
-      'addr1qxrpy5ljyufg5pkzayjf74jv6etjmefpgzyzyt22gxypd284nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qj06pfp',
-      'addr1qytts74ph383kmm6snplk7tz0lgzhk8nldjhxr5vtx3w2nh4nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qqav62r',
-    ]
-    const walletAddresses = await addressManagers[2]._deriveAddresses(0, 20)
-    assert.equal(JSON.stringify(walletAddresses), JSON.stringify(expectedAddresses))
-  })
-
-  it('should derive the right sequence of addresses from Account 1', async () => {
-    const expectedAddresses = [
-      'addr1qxgcexwttk64d4tx4jd5zh8aqhdx3mlqkl9mujv50fungkh4nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qg8cy6z',
-      'addr1qxkz3zqcj05kpqmrj722yl5jndre47sndfewes4gye3aluh4nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8q47eyzd',
-      'addr1qy2e6qvw6gx6yq2tech003dm9hgcrrn6qr05zd7lruhu9w04nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qyjq9t5',
-      'addr1qxnuvhygpsxwlr9ntalqzvr5vuqefsz73vek54uf6qk3sph4nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qvzx58v',
-      'addr1q8tg2uhxmee5kqyu9wnxkkf39gasfy7tw8hwfr5zw2tjk004nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8q3fk6vk',
-      'addr1q8n42e4lq889we0m7qkn0zpnpnu3s76tvqq6rlq4hat9hn84nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qhd7cn3',
-      'addr1qxgz68uwxp7njc76fnfs8xmqrdghm02frtqzn36mt5za0lh4nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qrup8jd',
-      'addr1qytysuatl0symre0hmp8zvwfzkhdcxmmuavpxj7m4eu02rl4nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8q0z4yts',
-      'addr1q8zufh3l2dasfd44zl04qsmkrdy622uxz8j8vjwla0w6h7h4nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qw3u3ec',
-      'addr1qxr2ream9hgh9cr4vgwcu5y7awk09lm3kdsy4ztlyxa8y8l4nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qgn3v3v',
-      'addr1qy70lyw2vjuq89k8tjmyxzgrlhm0r0w62hfury334wzgkt04nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qvvn785',
-      'addr1qyal3ttz49wfy7cmf8e70g5vk37y08pqezuvfa9ld99vpx04nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qalq7qs',
-      'addr1qxqqah75n5gytnm0xzmwe3nnsc3c0erdwxd2wfhe73gm7ch4nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qqskwhw',
-      'addr1qxjjrhnehxe9j8n5ageqsp7tz6rc3seqlaawadqxc78scj04nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qdklf4u',
-      'addr1q894mdfd405e4vj2rey3hfymm2mfqwdv7mgv99zymj3r9y84nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qq5tz82',
-      'addr1q9x8qj0r9dumnfuzav92jf240gsvaww30w39v083ze548l84nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qdn8lhj',
-      'addr1q97a8lde7azy92vz966w8jusvuwze3yyd96dl9lu7l4dr5h4nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qz8ltgd',
-      'addr1qynnulmfm0l7rmctz6t9ataz4eh542k9gurh39llnh0tjx04nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8q028wsy',
-      'addr1q9hsg6rjwpwj0d8hu9grcs2ta8u79qw6h0ezslzqtrv0s4h4nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qx094f2',
-      'addr1q9k6d04pff2mtccuyge6537042md4249u5gl9majlpk2de84nns4m7jjdmrc6qh6dae4yt4aqm8j9v29ccvz7ph5ve8qa6np3t',
-    ]
-    const walletAddresses = await addressManagers[3]._deriveAddresses(0, 20)
-    assert.equal(JSON.stringify(walletAddresses), JSON.stringify(expectedAddresses))
   })
 })

--- a/app/tests/src/cardano-wallet-secret-crypto-provider.js
+++ b/app/tests/src/cardano-wallet-secret-crypto-provider.js
@@ -6,7 +6,7 @@ import derivationSchemes from '../../frontend/wallet/helpers/derivation-schemes'
 import CardanoWalletSecretCryptoProvider from '../../frontend/wallet/byron/cardano-wallet-secret-crypto-provider'
 import {TxInputFromUtxo, TxOutput, TxAux} from '../../frontend/wallet/byron/byron-transaction'
 import mnemonicToWalletSecretDef from '../../frontend/wallet/helpers/mnemonicToWalletSecretDef'
-import cryptoProviderSettings from './common/crypto-provider-settings'
+import {cryptoProviderSettings} from './common/crypto-provider-settings'
 
 const cryptoProviders = []
 

--- a/app/tests/src/common/account-manager-settings.js
+++ b/app/tests/src/common/account-manager-settings.js
@@ -1,32 +1,28 @@
 import {walletSettings} from './wallet-settings'
 
-export const accountManagerSettings = [
-  {
-    ...walletSettings[0],
-    description: 'with multiple used accounts',
+export const accountManagerSettings = {
+  withMultipleUsedAccounts: {
+    ...walletSettings.Shelley15Word,
     shouldExportPubKeyBulk: true,
     numberOfDiscoveredAccounts: 4,
     maxAccountIndex: 30,
   },
-  {
-    ...walletSettings[0],
-    description: 'with disabled bulk export',
+  withDisabledBulkExport: {
+    ...walletSettings.Shelley15Word,
     shouldExportPubKeyBulk: false,
     numberOfDiscoveredAccounts: 1,
     maxAccountIndex: 30,
   },
-  {
-    ...walletSettings[1],
-    description: 'with shelley incompatible wallet',
+  withShelleyIncompatibleWallet: {
+    ...walletSettings.Byron12Word,
     shouldExportPubKeyBulk: true,
     numberOfDiscoveredAccounts: 1,
     maxAccountIndex: 30,
   },
-  {
-    ...walletSettings[2],
-    description: 'with shelley unused wallet',
+  withShelleyUnusedWallet: {
+    ...walletSettings.Shelley15WordUnused,
     shouldExportPubKeyBulk: true,
     numberOfDiscoveredAccounts: 1,
     maxAccountIndex: 30,
   },
-]
+}

--- a/app/tests/src/common/account-manager-settings.js
+++ b/app/tests/src/common/account-manager-settings.js
@@ -4,25 +4,25 @@ export const accountManagerSettings = {
   withMultipleUsedAccounts: {
     ...walletSettings.Shelley15Word,
     shouldExportPubKeyBulk: true,
-    numberOfDiscoveredAccounts: 4,
+    expectedNumberOfDiscoveredAccounts: 4,
     maxAccountIndex: 30,
   },
   withDisabledBulkExport: {
     ...walletSettings.Shelley15Word,
     shouldExportPubKeyBulk: false,
-    numberOfDiscoveredAccounts: 1,
+    expectedNumberOfDiscoveredAccounts: 1,
     maxAccountIndex: 30,
   },
   withShelleyIncompatibleWallet: {
     ...walletSettings.Byron12Word,
     shouldExportPubKeyBulk: true,
-    numberOfDiscoveredAccounts: 1,
+    expectedNumberOfDiscoveredAccounts: 1,
     maxAccountIndex: 30,
   },
   withShelleyUnusedWallet: {
     ...walletSettings.Shelley15WordUnused,
     shouldExportPubKeyBulk: true,
-    numberOfDiscoveredAccounts: 1,
+    expectedNumberOfDiscoveredAccounts: 1,
     maxAccountIndex: 30,
   },
 }

--- a/app/tests/src/common/account-settings.js
+++ b/app/tests/src/common/account-settings.js
@@ -2,8 +2,9 @@ import {accountManagerSettings} from './account-manager-settings'
 
 const testSeed = 39
 
-export const accountSettings = [
-  {
+export const accountSettings = {
+  ShelleyAccount0: {
+    ...accountManagerSettings.withMultipleUsedAccounts,
     description: '',
     accountIndex: 0,
     randomInputSeed: testSeed,
@@ -65,9 +66,9 @@ export const accountSettings = [
       },
     },
     stakingAddress: 'stake1uy9ggsc9qls4pu9qvyyacwnmr9tt0gzcdt5s0zj4au8qkqc65geks',
-    ...accountManagerSettings[0],
   },
-  {
+  ShelleyAccount1: {
+    ...accountManagerSettings.withMultipleUsedAccounts,
     description: '',
     accountIndex: 1,
     randomInputSeed: testSeed,
@@ -125,6 +126,5 @@ export const accountSettings = [
       byronAccountXpub: null,
     },
     stakingAddress: 'stake1u86eec2alffxa3udqtax7u6j967sdnezk9zuvxp0qm6xvns252x9a',
-    ...accountManagerSettings[0],
   },
-]
+}

--- a/app/tests/src/common/address-manager-settings.js
+++ b/app/tests/src/common/address-manager-settings.js
@@ -1,5 +1,5 @@
 import {accountSettings} from './account-settings'
-import cryptoProviderSettings from './crypto-provider-settings'
+import {cryptoProviderSettings} from './crypto-provider-settings'
 
 const byronAddressManagerSettings = [
   {
@@ -51,23 +51,28 @@ const addressManagerSettings = [
   },
 ]
 
-const addressManagerSettings2 = [
-  {
+// these are used for the new tests
+const addressManagerSettings2 = {
+  changeAddressProviderForAccount0: {
+    ...accountSettings.ShelleyAccount0,
     isChange: true,
-    ...accountSettings[0],
+    addresses: accountSettings.ShelleyAccount0.internalAddresses,
   },
-  {
+  nonChangeAddressProviderForAccount0: {
+    ...accountSettings.ShelleyAccount0,
     isChange: false,
-    ...accountSettings[0],
+    addresses: accountSettings.ShelleyAccount0.externalAddresses,
   },
-  {
+  changeAddressProviderForAccount1: {
+    ...accountSettings.ShelleyAccount1,
     isChange: true,
-    ...accountSettings[0],
+    addresses: accountSettings.ShelleyAccount1.internalAddresses,
   },
-  {
+  nonChangeAddressProviderForAccount1: {
+    ...accountSettings.ShelleyAccount1,
     isChange: false,
-    ...accountSettings[0],
+    addresses: accountSettings.ShelleyAccount1.externalAddresses,
   },
-]
+}
 
 export {byronAddressManagerSettings, addressManagerSettings, addressManagerSettings2}

--- a/app/tests/src/common/address-manager-settings.js
+++ b/app/tests/src/common/address-manager-settings.js
@@ -24,35 +24,34 @@ const byronAddressManagerSettings = [
   },
 ]
 
-const addressManagerSettings = [
-  {
-    accountIndex: 0,
-    isChange: true,
-    cryptoSettings: cryptoProviderSettings[4],
-    shouldExportPubKeyBulk: true,
-  },
-  {
-    accountIndex: 0,
-    isChange: false,
-    cryptoSettings: cryptoProviderSettings[4],
-    shouldExportPubKeyBulk: true,
-  },
-  {
-    accountIndex: 1,
-    isChange: true,
-    cryptoSettings: cryptoProviderSettings[4],
-    shouldExportPubKeyBulk: true,
-  },
-  {
-    accountIndex: 1,
-    isChange: false,
-    cryptoSettings: cryptoProviderSettings[4],
-    shouldExportPubKeyBulk: true,
-  },
-]
+// const addressManagerSettings = [
+//   {
+//     accountIndex: 0,
+//     isChange: true,
+//     cryptoSettings: cryptoProviderSettings[4],
+//     shouldExportPubKeyBulk: true,
+//   },
+//   {
+//     accountIndex: 0,
+//     isChange: false,
+//     cryptoSettings: cryptoProviderSettings[4],
+//     shouldExportPubKeyBulk: true,
+//   },
+//   {
+//     accountIndex: 1,
+//     isChange: true,
+//     cryptoSettings: cryptoProviderSettings[4],
+//     shouldExportPubKeyBulk: true,
+//   },
+//   {
+//     accountIndex: 1,
+//     isChange: false,
+//     cryptoSettings: cryptoProviderSettings[4],
+//     shouldExportPubKeyBulk: true,
+//   },
+// ]
 
-// these are used for the new tests
-const addressManagerSettings2 = {
+const addressManagerSettings = {
   changeAddressProviderForAccount0: {
     ...accountSettings.ShelleyAccount0,
     isChange: true,

--- a/app/tests/src/common/crypto-provider-settings.js
+++ b/app/tests/src/common/crypto-provider-settings.js
@@ -37,14 +37,25 @@ const cryptoProviderSettings = [
     type: 'mnemonic',
     isShelleyCompatible: true,
   },
-  {
+]
+
+const shelleyCryptoProviderSettings = {
+  mnemonic15Word: {
+    description: '',
+    secret:
+      'odor match funny accuse spatial copper purse milk quote wine salute three drip weasel fall',
+    network: NETWORKS.SHELLEY.MAINNET,
+    type: 'mnemonic',
+    isShelleyCompatible: true,
+  },
+  mnemonic12Word: {
     description: '',
     secret: 'cruise bike bar reopen mimic title style fence race solar million clean',
     network: NETWORKS.SHELLEY.MAINNET,
     type: 'mnemonic',
     isShelleyCompatible: false,
   },
-  {
+  mnemonic15WordUnused: {
     description: '',
     secret:
       'hazard circle fossil diamond oxygen ankle tribe broken must comic duck chef bacon truly dish',
@@ -52,6 +63,6 @@ const cryptoProviderSettings = [
     type: 'mnemonic',
     isShelleyCompatible: true,
   },
-]
+}
 
-export default cryptoProviderSettings
+export {cryptoProviderSettings, shelleyCryptoProviderSettings}

--- a/app/tests/src/common/mock.js
+++ b/app/tests/src/common/mock.js
@@ -48,7 +48,7 @@ const mock = (ADALITE_CONFIG) => {
     fetchMock.config.overwriteRoutes = true
     const acctInfoMock = {
       delegation: {},
-      value: 0,
+      rewards: 5000000,
       hasStakingKey: false,
       nextRewardDetails: [{forEpoch: 212}, {forEpoch: 213}, {forEpoch: 214}, {forEpoch: 215}],
     }

--- a/app/tests/src/common/tx-plan-settings.js
+++ b/app/tests/src/common/tx-plan-settings.js
@@ -1,0 +1,121 @@
+const transactionPlanSettings = {
+  donation: {
+    args: {
+      address:
+        'addr1qjag9rgwe04haycr283datdrjv3mlttalc2waz34xcct0g4uvf6gdg3dpwrsne4uqng3y47ugp2pp5dvuq0jqlperwj83r4pwxvwuxsgds90s0',
+      coins: 1000000,
+      donationAmount: 5000000,
+      txType: 'sendAda',
+    },
+    plan: {
+      inputs: [
+        {
+          txHash: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+          address:
+            'addr1q8eakg39wqlye7lzyfmh900s2luc99zf7x9vs839pn4srjs2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsjv0zk3',
+          coins: 10000000,
+          outputIndex: 1,
+        },
+      ],
+      outputs: [
+        {
+          address:
+            'addr1qjag9rgwe04haycr283datdrjv3mlttalc2waz34xcct0g4uvf6gdg3dpwrsne4uqng3y47ugp2pp5dvuq0jqlperwj83r4pwxvwuxsgds90s0',
+          coins: 1000000,
+          accountAddress: 'stake1uy9ggsc9qls4pu9qvyyacwnmr9tt0gzcdt5s0zj4au8qkqc65geks',
+        },
+        {
+          address:
+            'addr1qxfxlatvpnl7wywyz6g4vqyfgmf9mdyjsh3hnec0yuvrhk8jh8axm6pzha46j5e7j3a2mjdvnpufphgjawhyh0tg9r3sk85ls4',
+          coins: 5000000,
+          accountAddress: 'stake1uy9ggsc9qls4pu9qvyyacwnmr9tt0gzcdt5s0zj4au8qkqc65geks',
+        },
+      ],
+      change: {
+        address:
+          'addr1q8eakg39wqlye7lzyfmh900s2luc99zf7x9vs839pn4srjs2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsjv0zk3',
+        coins: 3816581,
+        accountAddress: 'stake1uy9ggsc9qls4pu9qvyyacwnmr9tt0gzcdt5s0zj4au8qkqc65geks',
+      },
+      certs: [],
+      deposit: 0,
+      fee: 183419,
+      withdrawals: [],
+    },
+  },
+  delegation: {
+    args: {
+      poolHash: '04c60c78417132a195cbb74975346462410f72612952a7c4ade7e438',
+      stakingKeyRegistered: false,
+      txType: 'delegate',
+    },
+    plan: {
+      inputs: [
+        {
+          txHash: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+          address:
+            'addr1q8eakg39wqlye7lzyfmh900s2luc99zf7x9vs839pn4srjs2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsjv0zk3',
+          coins: 10000000,
+          outputIndex: 1,
+        },
+      ],
+      outputs: [],
+      change: {
+        address:
+          'addr1q8eakg39wqlye7lzyfmh900s2luc99zf7x9vs839pn4srjs2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsjv0zk3',
+        coins: 7806122,
+        accountAddress: 'stake1uy9ggsc9qls4pu9qvyyacwnmr9tt0gzcdt5s0zj4au8qkqc65geks',
+      },
+      certs: [
+        {
+          type: 0,
+          accountAddress: 'stake1uy9ggsc9qls4pu9qvyyacwnmr9tt0gzcdt5s0zj4au8qkqc65geks',
+          poolHash: null,
+        },
+        {
+          type: 2,
+          accountAddress: 'stake1uy9ggsc9qls4pu9qvyyacwnmr9tt0gzcdt5s0zj4au8qkqc65geks',
+          poolHash: '04c60c78417132a195cbb74975346462410f72612952a7c4ade7e438',
+        },
+      ],
+      deposit: 2000000,
+      fee: 193878,
+      withdrawals: [],
+    },
+  },
+  rewardWithdrawal: {
+    args: {
+      rewards: 50000,
+      txType: 'withdraw',
+    },
+    plan: {
+      inputs: [
+        {
+          txHash: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+          address:
+            'addr1q8eakg39wqlye7lzyfmh900s2luc99zf7x9vs839pn4srjs2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsjv0zk3',
+          coins: 10000000,
+          outputIndex: 1,
+        },
+      ],
+      outputs: [],
+      change: {
+        address:
+          'addr1q8eakg39wqlye7lzyfmh900s2luc99zf7x9vs839pn4srjs2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsjv0zk3',
+        coins: 9864999,
+        accountAddress: 'stake1uy9ggsc9qls4pu9qvyyacwnmr9tt0gzcdt5s0zj4au8qkqc65geks',
+      },
+      certs: [],
+      deposit: 0,
+      fee: 185001,
+      withdrawals: [
+        {
+          accountAddress: 'stake1uy9ggsc9qls4pu9qvyyacwnmr9tt0gzcdt5s0zj4au8qkqc65geks',
+          rewards: 50000,
+        },
+      ],
+    },
+  },
+}
+
+export {transactionPlanSettings}

--- a/app/tests/src/common/wallet-settings.js
+++ b/app/tests/src/common/wallet-settings.js
@@ -1,16 +1,13 @@
-import cryptoProviderSettings from './crypto-provider-settings'
+import {shelleyCryptoProviderSettings} from './crypto-provider-settings'
 
-export const walletSettings = [
-  {
-    description: 'Shelley 15 word',
-    ...cryptoProviderSettings[4],
+export const walletSettings = {
+  Shelley15Word: {
+    ...shelleyCryptoProviderSettings.mnemonic15Word,
   },
-  {
-    description: 'Byron 12 word',
-    ...cryptoProviderSettings[5],
+  Byron12Word: {
+    ...shelleyCryptoProviderSettings.mnemonic12Word,
   },
-  {
-    description: 'Shelley 15 word not used',
-    ...cryptoProviderSettings[6],
+  Shelley15WordUnused: {
+    ...shelleyCryptoProviderSettings.mnemonic15WordUnused,
   },
-]
+}

--- a/app/tests/src/wallet/account-manager.js
+++ b/app/tests/src/wallet/account-manager.js
@@ -46,7 +46,6 @@ before(async () => {
   await Promise.all(
     Object.entries(accountManagerSettings).map(async ([name, setting]) => {
       accountManagers[name] = await initAccountManager(setting)
-      return accountManagers[name]
     })
   )
 })

--- a/app/tests/src/wallet/account-manager.js
+++ b/app/tests/src/wallet/account-manager.js
@@ -21,7 +21,6 @@ const initAccountManager = async (settings, i) => {
     maxAccountIndex,
   } = settings
   const config = {...ADALITE_CONFIG, isShelleyCompatible, shouldExportPubKeyBulk}
-
   const blockchainExplorer = BlockchainExplorer(ADALITE_CONFIG, {})
 
   let walletSecretDef
@@ -43,20 +42,23 @@ const initAccountManager = async (settings, i) => {
   return AccountManager({config, cryptoProvider, blockchainExplorer, maxAccountIndex})
 }
 
-before(() => {
-  Object.entries(accountManagerSettings).forEach(([name, setting]) => {
-    accountManagers[name] = initAccountManager(setting)
-  })
+before(async () => {
+  await Promise.all(
+    Object.entries(accountManagerSettings).map(async ([name, setting]) => {
+      accountManagers[name] = await initAccountManager(setting)
+      return accountManagers[name]
+    })
+  )
 })
 
 describe('Account discovery', () => {
   Object.entries(accountManagerSettings).forEach(([name, setting]) =>
     it(`should discover the right amount of accounts ${name}`, async () => {
-      const accountManager = await accountManagers[name]
+      const accountManager = accountManagers[name]
       const mockNet = mockNetwork(ADALITE_CONFIG)
       mockNet.mockBulkAddressSummaryEndpoint()
       const accounts = await accountManager.discoverAccounts()
-      assert.equal(accounts.length, setting.numberOfDiscoveredAccounts)
+      assert.equal(accounts.length, setting.expectedNumberOfDiscoveredAccounts)
       mockNet.clean()
     })
   )
@@ -66,7 +68,7 @@ describe('Account exploration', () => {
   it('should not add account if previous wasnt used', async () => {
     const mockNet = mockNetwork(ADALITE_CONFIG)
     mockNet.mockBulkAddressSummaryEndpoint()
-    const accountManager = await accountManagers.withMultipleUsedAccounts
+    const accountManager = accountManagers.withMultipleUsedAccounts
     const accountsLength = (await accountManager.discoverAccounts()).length
     // TODO: fix issue with assert.rejects
     try {
@@ -80,9 +82,11 @@ describe('Account exploration', () => {
     }
   })
   it('should add consequent new account if previous was used', async () => {
+    // this concerns the case when the bulk export is disabled
+    // as with enabled bulk export all used accounts are discovered at first go
     const mockNet = mockNetwork(ADALITE_CONFIG)
     mockNet.mockBulkAddressSummaryEndpoint()
-    const accountManager = await accountManagers.withDisabledBulkExport
+    const accountManager = accountManagers.withDisabledBulkExport
     const accountsLength = (await accountManager.discoverAccounts()).length
     const nextAccount = await accountManager.exploreNextAccount()
     assert.equal(accountsLength, nextAccount.accountIndex)

--- a/app/tests/src/wallet/account-manager.js
+++ b/app/tests/src/wallet/account-manager.js
@@ -1,19 +1,14 @@
+import assert from 'assert'
 import {AccountManager} from '../../../frontend/wallet/account-manager'
 import {accountManagerSettings} from '../common/account-manager-settings'
 import {ADALITE_CONFIG} from '../../../frontend/config'
-
-import assert from 'assert'
-
 import derivationSchemes from '../../../frontend/wallet/helpers/derivation-schemes'
-
 import mnemonicToWalletSecretDef from '../../../frontend/wallet/helpers/mnemonicToWalletSecretDef'
-
 import BlockchainExplorer from '../../../frontend/wallet/blockchain-explorer'
-
 import ShelleyJsCryptoProvider from '../../../frontend/wallet/shelley/shelley-js-crypto-provider'
 import mockNetwork from '../common/mock'
 
-const accountManagers = []
+const accountManagers = {}
 
 const initAccountManager = async (settings, i) => {
   const {
@@ -26,7 +21,7 @@ const initAccountManager = async (settings, i) => {
     maxAccountIndex,
   } = settings
   const config = {...ADALITE_CONFIG, isShelleyCompatible, shouldExportPubKeyBulk}
-  // console.log(JSON.stringify(settings))
+
   const blockchainExplorer = BlockchainExplorer(ADALITE_CONFIG, {})
 
   let walletSecretDef
@@ -45,62 +40,40 @@ const initAccountManager = async (settings, i) => {
     config,
   })
 
-  accountManagers.push(
-    AccountManager({config, cryptoProvider, blockchainExplorer, maxAccountIndex})
-  )
+  return AccountManager({config, cryptoProvider, blockchainExplorer, maxAccountIndex})
 }
 
-before(async () => {
-  for (const accountManagerSetting of accountManagerSettings) {
-    await initAccountManager(accountManagerSetting)
-  }
-})
-
-describe('account discovery', () => {
-  // TODO: refactor to foreach
-  it('should discover the right amount of accounts', async () => {
-    const mockNet = mockNetwork(ADALITE_CONFIG)
-    mockNet.mockBulkAddressSummaryEndpoint()
-    const accounts = await accountManagers[0].discoverAccounts()
-    // console.log(accounts, accountManagerSettings[0])
-    assert.equal(accounts.length, accountManagerSettings[0].numberOfDiscoveredAccounts)
-    mockNet.clean()
-  })
-  it('should not discover accounts if bulk export is disabled', async () => {
-    const mockNet = mockNetwork(ADALITE_CONFIG)
-    mockNet.mockBulkAddressSummaryEndpoint()
-    const accounts = await accountManagers[1].discoverAccounts()
-    // console.log(accounts, accountManagerSettings[1])
-    assert.equal(accounts.length, accountManagerSettings[1].numberOfDiscoveredAccounts)
-    mockNet.clean()
-  })
-  it('should not discover accounts if wallet is not shelley compatible', async () => {
-    const mockNet = mockNetwork(ADALITE_CONFIG)
-    mockNet.mockBulkAddressSummaryEndpoint()
-    const accounts = await accountManagers[2].discoverAccounts()
-    assert.equal(accounts.length, accountManagerSettings[2].numberOfDiscoveredAccounts)
-    mockNet.clean()
-  })
-  it('should discover one account if no accounts were used', async () => {
-    const mockNet = mockNetwork(ADALITE_CONFIG)
-    mockNet.mockBulkAddressSummaryEndpoint()
-    const accounts = await accountManagers[3].discoverAccounts()
-    assert.equal(accounts.length, accountManagerSettings[3].numberOfDiscoveredAccounts)
-    mockNet.clean()
+before(() => {
+  Object.entries(accountManagerSettings).forEach(([name, setting]) => {
+    accountManagers[name] = initAccountManager(setting)
   })
 })
 
-describe('account exploration', () => {
+describe('Account discovery', () => {
+  Object.entries(accountManagerSettings).forEach(([name, setting]) =>
+    it(`should discover the right amount of accounts ${name}`, async () => {
+      const accountManager = await accountManagers[name]
+      const mockNet = mockNetwork(ADALITE_CONFIG)
+      mockNet.mockBulkAddressSummaryEndpoint()
+      const accounts = await accountManager.discoverAccounts()
+      assert.equal(accounts.length, setting.numberOfDiscoveredAccounts)
+      mockNet.clean()
+    })
+  )
+})
+
+describe('Account exploration', () => {
   it('should not add account if previous wasnt used', async () => {
     const mockNet = mockNetwork(ADALITE_CONFIG)
     mockNet.mockBulkAddressSummaryEndpoint()
-    const accountsLength = (await accountManagers[0].discoverAccounts()).length
+    const accountManager = await accountManagers.withMultipleUsedAccounts
+    const accountsLength = (await accountManager.discoverAccounts()).length
     // TODO: fix issue with assert.rejects
     try {
-      await accountManagers[0].exploreNextAccount()
+      await accountManager.exploreNextAccount()
       assert.fail()
     } catch (e) {
-      const newAccountsLength = (await accountManagers[0].discoverAccounts()).length
+      const newAccountsLength = (await accountManager.discoverAccounts()).length
       assert.equal(accountsLength, newAccountsLength)
     } finally {
       mockNet.clean()
@@ -109,8 +82,9 @@ describe('account exploration', () => {
   it('should add consequent new account if previous was used', async () => {
     const mockNet = mockNetwork(ADALITE_CONFIG)
     mockNet.mockBulkAddressSummaryEndpoint()
-    const accountsLength = (await accountManagers[1].discoverAccounts()).length
-    const nextAccount = await accountManagers[1].exploreNextAccount()
+    const accountManager = await accountManagers.withDisabledBulkExport
+    const accountsLength = (await accountManager.discoverAccounts()).length
+    const nextAccount = await accountManager.exploreNextAccount()
     assert.equal(accountsLength, nextAccount.accountIndex)
     mockNet.clean()
   })

--- a/app/tests/src/wallet/account.js
+++ b/app/tests/src/wallet/account.js
@@ -71,7 +71,6 @@ before(async () => {
   await Promise.all(
     Object.entries(accountSettings).map(async ([name, setting]) => {
       accounts[name] = await initAccount(setting)
-      return accounts[name]
     })
   )
 })

--- a/app/tests/src/wallet/account.js
+++ b/app/tests/src/wallet/account.js
@@ -5,6 +5,8 @@ import mnemonicToWalletSecretDef from '../../../frontend/wallet/helpers/mnemonic
 import BlockchainExplorer from '../../../frontend/wallet/blockchain-explorer'
 import ShelleyJsCryptoProvider from '../../../frontend/wallet/shelley/shelley-js-crypto-provider'
 import {ADALITE_CONFIG} from '../../../frontend/config'
+import {transactionPlanSettings} from '../common/tx-plan-settings'
+import mockNetwork from '../common/mock'
 
 const accounts = {}
 
@@ -50,6 +52,22 @@ const initAccount = async (settings, i) => {
 }
 
 before(() => {
+  ADALITE_CONFIG.ADALITE_CARDANO_VERSION = 'shelley'
+  ADALITE_CONFIG.ADALITE_NETWORK = 'MAINNET'
+  const mockNet = mockNetwork(ADALITE_CONFIG)
+  mockNet.mockBulkAddressSummaryEndpoint()
+  mockNet.mockGetAccountInfo()
+  mockNet.mockGetStakePools()
+  mockNet.mockGetConversionRates()
+  mockNet.mockUtxoEndpoint()
+  mockNet.mockPoolMeta()
+  mockNet.mockGetAccountState()
+  mockNet.mockAccountDelegationHistory()
+  mockNet.mockAccountStakeRegistrationHistory()
+  mockNet.mockWithdrawalHistory()
+  mockNet.mockRewardHistory()
+  mockNet.mockPoolRecommendation()
+
   Object.entries(accountSettings).forEach(([name, setting]) => {
     accounts[name] = initAccount(setting)
   })
@@ -61,6 +79,16 @@ describe('Account info', () => {
       const account = await accounts[name]
       const xpubs = await account._getAccountXpubs()
       assert.deepEqual(xpubs, setting.accountXpubs)
+    })
+  )
+})
+
+describe('Tx plan', () => {
+  Object.entries(transactionPlanSettings).forEach(([name, setting]) =>
+    it(`should create the right tx plan for tx with ${name}`, async () => {
+      const account = await accounts.ShelleyAccount0
+      const txPlan = await account.getTxPlan({...setting.args})
+      assert.deepEqual(txPlan, setting.plan)
     })
   )
 })

--- a/app/tests/src/wallet/account.js
+++ b/app/tests/src/wallet/account.js
@@ -51,7 +51,7 @@ const initAccount = async (settings, i) => {
   })
 }
 
-before(() => {
+before(async () => {
   ADALITE_CONFIG.ADALITE_CARDANO_VERSION = 'shelley'
   ADALITE_CONFIG.ADALITE_NETWORK = 'MAINNET'
   const mockNet = mockNetwork(ADALITE_CONFIG)
@@ -68,9 +68,12 @@ before(() => {
   mockNet.mockRewardHistory()
   mockNet.mockPoolRecommendation()
 
-  Object.entries(accountSettings).forEach(([name, setting]) => {
-    accounts[name] = initAccount(setting)
-  })
+  await Promise.all(
+    Object.entries(accountSettings).map(async ([name, setting]) => {
+      accounts[name] = await initAccount(setting)
+      return accounts[name]
+    })
+  )
 })
 
 describe('Account info', () => {

--- a/app/tests/src/wallet/account.js
+++ b/app/tests/src/wallet/account.js
@@ -1,12 +1,12 @@
+import assert from 'assert'
 import {accountSettings} from '../common/account-settings'
 import {Account} from '../../../frontend/wallet/account'
 import mnemonicToWalletSecretDef from '../../../frontend/wallet/helpers/mnemonicToWalletSecretDef'
 import BlockchainExplorer from '../../../frontend/wallet/blockchain-explorer'
 import ShelleyJsCryptoProvider from '../../../frontend/wallet/shelley/shelley-js-crypto-provider'
 import {ADALITE_CONFIG} from '../../../frontend/config'
-import assert from 'assert'
 
-const accounts = []
+const accounts = {}
 
 const initAccount = async (settings, i) => {
   const {
@@ -39,26 +39,27 @@ const initAccount = async (settings, i) => {
     config,
   })
 
-  accounts.push(
-    Account({
-      config,
-      randomInputSeed,
-      randomChangeSeed,
-      cryptoProvider,
-      blockchainExplorer,
-      accountIndex,
-    })
-  )
+  return Account({
+    config,
+    randomInputSeed,
+    randomChangeSeed,
+    cryptoProvider,
+    blockchainExplorer,
+    accountIndex,
+  })
 }
 
-before(async () => {
-  await Promise.all(accountSettings.map(initAccount))
+before(() => {
+  Object.entries(accountSettings).forEach(([name, setting]) => {
+    accounts[name] = initAccount(setting)
+  })
 })
 
 describe('Account info', () => {
-  accountSettings.map((setting, i) =>
-    it('should get the right account xpubs for account', async () => {
-      const xpubs = await accounts[i]._getAccountXpubs()
+  Object.entries(accountSettings).forEach(([name, setting]) =>
+    it(`should get the right account xpubs for ${name}`, async () => {
+      const account = await accounts[name]
+      const xpubs = await account._getAccountXpubs()
       assert.deepEqual(xpubs, setting.accountXpubs)
     })
   )

--- a/app/tests/src/wallet/address-manager.js
+++ b/app/tests/src/wallet/address-manager.js
@@ -3,7 +3,7 @@ import assert from 'assert'
 import derivationSchemes from '../../../frontend/wallet/helpers/derivation-schemes'
 import AddressManager from '../../../frontend/wallet/address-manager'
 import mnemonicToWalletSecretDef from '../../../frontend/wallet/helpers/mnemonicToWalletSecretDef'
-import {addressManagerSettings2 as addressManagerSettings} from '../common/address-manager-settings'
+import {addressManagerSettings} from '../common/address-manager-settings'
 import BlockchainExplorer from '../../../frontend/wallet/blockchain-explorer'
 import ShelleyJsCryptoProvider from '../../../frontend/wallet/shelley/shelley-js-crypto-provider'
 import {ShelleyBaseAddressProvider} from '../../../frontend/wallet/shelley/shelley-address-provider'
@@ -54,16 +54,18 @@ const initAddressManager = async (settings, i) => {
   })
 }
 
-before(() => {
-  Object.entries(addressManagerSettings).forEach(([name, setting]) => {
-    addressManagers[name] = initAddressManager(setting)
-  })
+before(async () => {
+  await Promise.all(
+    Object.entries(addressManagerSettings).map(async ([name, setting]) => {
+      addressManagers[name] = await initAddressManager(setting)
+    })
+  )
 })
 
 describe('Address derivation shelley', () => {
   Object.entries(addressManagerSettings).forEach(([name, setting]) =>
     it(`should derive the right sequence of addresses with ${name}`, async () => {
-      const addressManager = await addressManagers[name]
+      const addressManager = addressManagers[name]
       const expectedAddresses = setting.addresses
       const walletAddresses = await addressManager._deriveAddresses(0, 20)
       assert.equal(JSON.stringify(walletAddresses), JSON.stringify(expectedAddresses))


### PR DESCRIPTION
Motivation: 
Test for tx planning were not present at all.

Changes:
- refactor tests and refactors settings to objects
- adds tests for calculating fee
- adds tests for getting tx plan and tx plan settings

Gotcha:

- test for calculating fee is divided into three parts, sendAda, delegation and reward withdrawal, all three containing only one test for now and not having tx plan in its settings. Testing the contents of the plan is the responsibility of the account and these tests are supposed to just test if the fee was calculated, an error was thrown or a behavior caused by the success of getting the tx plan.