### PR TITLE
Fix error handling

### DIFF
--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -603,17 +603,24 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
 
   const prepareTxPlan = async (args) => {
     const state = getState()
-    const plan: any = await wallet.getAccount(state.sourceAccountIndex).getTxPlan(args)
-    // FIXME: this cant be any
-    if (plan.error) {
-      stopLoadingAction(state, {})
-      resetDelegationWithoutHash(state)
-      setState({
-        calculatingDelegationFee: false,
-        calculatingFee: false,
-      })
+    try {
+      const plan: any = await wallet.getAccount(state.sourceAccountIndex).getTxPlan(args)
+      // FIXME: this cant be any
+      if (plan.error) {
+        stopLoadingAction(state, {})
+        resetDelegationWithoutHash(state)
+        setState({
+          calculatingDelegationFee: false,
+          calculatingFee: false,
+        })
+      }
+      return plan
+    } catch (e) {
+      return {
+        estimatedFee: 0,
+        error: {code: e.name},
+      }
     }
-    return plan
   }
 
   const calculateFee = async () => {

--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -616,6 +616,10 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
       }
       return plan
     } catch (e) {
+      if (e.name !== 'NetworkError' || e.name !== 'ServerError') {
+        throw e
+      }
+
       return {
         estimatedFee: 0,
         error: {code: e.name},

--- a/app/frontend/components/pages/advanced/keys.tsx
+++ b/app/frontend/components/pages/advanced/keys.tsx
@@ -64,7 +64,7 @@ const Keys = ({byronAccountXpub, shelleyAccountXpub, stakingAddress, stakingXpub
       </div>
       <div className="advanced-value">{stakingAddress}</div>
       <div className="advanced-label">
-        Staking key hex <LinkIconToKey stakeKey={bechAddressToHex(stakingAddress)} />
+        Staking key hex <LinkIconToKey stakeKey={stakingAddress} />
       </div>
       <div className="advanced-value">{bechAddressToHex(stakingAddress)}</div>
     </div>

--- a/app/frontend/helpers/captureBySentry.ts
+++ b/app/frontend/helpers/captureBySentry.ts
@@ -1,7 +1,7 @@
 import {getTranslation} from '../translations'
 
 function captureBySentry(e) {
-  if (!getTranslation(e.name)) {
+  if (!getTranslation(e.name, {message: e.message})) {
     throw e
   }
   return

--- a/app/frontend/helpers/errorsWithHelp.ts
+++ b/app/frontend/helpers/errorsWithHelp.ts
@@ -4,6 +4,9 @@ const errorsWithHelp = new Set([
   'CryptoProviderError',
   'TrezorSignTxError',
   'TrezorError',
+  'DisconnectedDeviceDuringOperation',
+  'TransportWebUSBGestureRequired',
+  'Error',
 ])
 
 function errorHasHelp(code) {

--- a/app/frontend/translations.ts
+++ b/app/frontend/translations.ts
@@ -6,6 +6,9 @@ import {Lovelace, CryptoProviderFeature} from './types'
 
 const {ADALITE_MIN_DONATION_VALUE} = ADALITE_CONFIG
 
+const ledgerTroubleshootingSuggestion =
+  'If you are using Ledger, please try connecting your device using the "Connect with WebUSB" functionality (the button underneath "Unlock with Ledger"). For more information please read the section concerning Ledger in our troubleshooting suggestions.'
+
 const translations = {
   SendAddressInvalidAddress: () => 'Invalid address',
   SendAmountIsNan: () => 'Invalid format: Amount has to be a number',
@@ -55,6 +58,10 @@ const translations = {
     }
     return `TransportInterfaceNotAvailable: ${message} ${errors[message] || ''}`
   },
+  DisconnectedDeviceDuringOperation: () =>
+    `DisconnectedDeviceDuringOperation: ${ledgerTroubleshootingSuggestion}`,
+  TransportWebUSBGestureRequired: () =>
+    `TransportWebUSBGestureRequired: ${ledgerTroubleshootingSuggestion}`,
 
   TransactionRejectedByNetwork: () =>
     'TransactionRejectedByNetwork: Submitting the transaction into Cardano network failed. We received this error and we will investigate the cause.',
@@ -130,6 +137,19 @@ const translations = {
   PoolRegNoTtl: () =>
     'TTL parameter is missing in the transaction. It is explicitly required even for the Allegra era.',
   PoolRegTxParserError: ({message}) => `Parser error: ${message}`,
+
+  Error: ({message}) => {
+    const errors = {
+      'NotFoundError: The device was disconnected.': `${message}${ledgerTroubleshootingSuggestion}`,
+      'AbortError: The transfer was cancelled.': `${message}${ledgerTroubleshootingSuggestion}`,
+      // an issue with CryptoToken extension allowing 2-step verification
+      // https://askubuntu.com/questions/844090/what-is-cryptotokenextension-in-chromium-extensions
+      "SyntaxError: Failed to execute 'postMessage' on 'Window': Invalid target origin 'chrome-extension://kmendfapggjehodndflmmgagdbamhnfd' in a call to 'postMessage'": `${message}${ledgerTroubleshootingSuggestion}`,
+    }
+    // we return undefined in case of unmached message on purpose since we
+    // want to treat such errors as unexpected
+    return errors[message]
+  },
 }
 
 function getTranslation(code, params = {}) {


### PR DESCRIPTION
Motivation: 

- Lot of ledger related errors come to sentry daily, and all we can do is to advice users to try using webUsb or to our trouble shooting guide. 
- If a network error happens during the fee calculation it results in unexpected error since its not cached.

Changes: 

- catch errors when calculating fee
- add translations for general `Error` and modify the `captureBySentry` helper to send also the params into translations so if the for example the `Error` is present in the translations but doest have a translation matching its params it returns undefined thus resulting in the error being considered unexpected.
- add the ledger errors to `errorsWithHelp` so it automatically recommends user to read the troubleshooting guide, and if that doesn't help he can send us the error if he really wants to.

Gotcha: 

- We should probably refactor and type the translations and also sentry capturing logic a bit but this is mostly a hotfix so we don't have to respond manually to every user.
- I also update our troubleshooting guide and added a ledger section
- the `SyntaxError: Failed to execute 'postMessage' on 'Window'` is a issue for quite some time and I havent been able to find any fix or reasoning behind it happening, only that it has to do something with some build in chrome crypto extension. Anyway the only thing I  usually respond to the users is to checkout the trouble shooting guide anyway.

What user will see from now on:
 
![image](https://user-images.githubusercontent.com/22474126/106602453-4e99d380-655d-11eb-8c60-3a613bf93d3e.png)
