### PR TITLE
Type blockchain explorer

### DIFF
--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -1082,7 +1082,9 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
       const accountInfo = await nextAccount.getAccountInfo(state.validStakepools)
       const accountsInfo = [...state.accountsInfo, accountInfo]
       setState({
+        //@ts-ignore TODO: refactor type AccountInfo
         accountsInfo,
+        //@ts-ignore TODO: refactor type AccountInfo
         ...getWalletInfo(accountsInfo),
       })
       setActiveAccount(state, nextAccount.accountIndex)

--- a/app/frontend/state.ts
+++ b/app/frontend/state.ts
@@ -224,7 +224,6 @@ const initialState: State = {
         nonStakingBalance: 0,
         rewardsAccountBalance: 0,
       },
-      stakePubkeyHex: '',
       shelleyAccountInfo: {
         accountPubkeyHex: '',
         shelleyXpub: '',

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -60,6 +60,7 @@ export type Ada = number & {__typeAda: any}
 export type Lovelace = number & {__typeLovelace: any}
 
 export type AccountInfo = {
+  // TODO: refactor, update type
   accountXpubs: {
     shelleyAccountXpub: _XPubKey
     byronAccountXpub: _XPubKey
@@ -72,7 +73,6 @@ export type AccountInfo = {
     nonStakingBalance?: number
     rewardsAccountBalance?: number
   }
-  stakePubkeyHex: string
   shelleyAccountInfo: {
     accountPubkeyHex: string
     shelleyXpub: any

--- a/app/frontend/wallet/account.ts
+++ b/app/frontend/wallet/account.ts
@@ -451,9 +451,9 @@ const Account = ({
     }
   }
 
-  async function getPoolRecommendation(pool: any, stake: number): Promise<any> {
+  async function getPoolRecommendation(pool: any, stakeAmount: Lovelace): Promise<any> {
     const poolHash = pool ? pool.poolHash : null
-    const poolRecommendation = await blockchainExplorer.getPoolRecommendation(poolHash, stake)
+    const poolRecommendation = await blockchainExplorer.getPoolRecommendation(poolHash, stakeAmount)
     if (!poolRecommendation.recommendedPoolHash || config.ADALITE_ENFORCE_STAKEPOOL) {
       Object.assign(poolRecommendation, {
         recommendedPoolHash: config.ADALITE_STAKE_POOL_ID,

--- a/app/frontend/wallet/account.ts
+++ b/app/frontend/wallet/account.ts
@@ -340,7 +340,6 @@ const Account = ({
         stakingBalance: baseAddressBalance + shelleyAccountInfo.value,
         rewardsAccountBalance: shelleyAccountInfo.value,
       },
-      stakePubkeyHex: shelleyAccountInfo.stakePubKeyHex,
       shelleyAccountInfo,
       transactionHistory,
       stakingHistory,

--- a/app/frontend/wallet/blockchain-explorer.ts
+++ b/app/frontend/wallet/blockchain-explorer.ts
@@ -15,6 +15,24 @@ import distinct from '../helpers/distinct'
 import {UNKNOWN_POOL_NAME} from './constants'
 import {HexString, Lovelace} from '../types'
 import {captureMessage} from '@sentry/browser'
+import {
+  BulkAddressesSummaryResponse,
+  TxSummaryResponse,
+  SubmitResponse,
+  BulkAdressesUtxoResponse,
+  HostedPoolMetadata,
+  DelegationHistoryEntry,
+  RewardsHistoryEntry,
+  WithdrawalsHistoryEntry,
+  StakeRegistrationHistoryEntry,
+  NextRewardDetail,
+  ValidStakePools,
+  NextRewardDetailsFormatted,
+  RewardWithMetadata,
+  PoolRecommendationResponse,
+  AccountInfoResponse,
+  BestSlotResponse,
+} from './explorer-types'
 
 const cacheResults = (maxAge: number, cache_obj: Object = {}) => <T extends Function>(fn: T): T => {
   const wrapped = (...args) => {
@@ -34,24 +52,30 @@ const cacheResults = (maxAge: number, cache_obj: Object = {}) => <T extends Func
 const blockchainExplorer = (ADALITE_CONFIG) => {
   const gapLimit = ADALITE_CONFIG.ADALITE_GAP_LIMIT
 
-  async function _fetchBulkAddressInfo(addresses) {
+  async function _fetchBulkAddressInfo(addresses: Array<string>) {
     const url = `${ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL}/api/bulk/addresses/summary`
-    const result = await request(url, 'POST', JSON.stringify(addresses), {
-      'Accept': 'application/json',
-      'Content-Type': 'application/json',
-    })
+    const result: BulkAddressesSummaryResponse = await request(
+      url,
+      'POST',
+      JSON.stringify(addresses),
+      {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      }
+    )
+    // @ts-ignore (TODO, handle 'Left')
     return result.Right
   }
 
-  const getAddressInfos = cacheResults(5000)(_fetchBulkAddressInfo)
+  const _getAddressInfos = cacheResults(5000)(_fetchBulkAddressInfo)
 
-  async function getTxHistory(addresses) {
+  async function getTxHistory(addresses: Array<string>) {
     const transactions = []
     const chunks = range(0, Math.ceil(addresses.length / gapLimit))
     const cachedAddressInfos = (await Promise.all(
       chunks.map(async (index) => {
         const beginIndex = index * gapLimit
-        return await getAddressInfos(addresses.slice(beginIndex, beginIndex + gapLimit))
+        return await _getAddressInfos(addresses.slice(beginIndex, beginIndex + gapLimit))
       })
     )).reduce(
       (acc, elem) => {
@@ -87,26 +111,25 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
     return Object.values(transactions).sort((a, b) => b.ctbTimeIssued - a.ctbTimeIssued)
   }
 
-  async function fetchTxInfo(txHash) {
+  async function fetchTxInfo(txHash: string) {
     const url = `${ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL}/api/txs/summary/${txHash}`
-    const response = await request(url)
-
+    const response: TxSummaryResponse = await request(url)
+    // @ts-ignore (TODO, handle 'Left')
     return response.Right
   }
 
-  async function fetchTxRaw(txId) {
-    // eslint-disable-next-line no-undef
-    const url = `${ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL}/api/txs/raw/${txId}`
-    const result = await request(url)
-    return Buffer.from(result.Right, 'hex')
+  // TODO: delete, raw txs are no longer in the db sync database
+  // eslint-disable-next-line require-await
+  async function fetchTxRaw(txId): Promise<undefined> {
+    return undefined
   }
 
-  async function isSomeAddressUsed(addresses) {
-    return (await getAddressInfos(addresses)).caTxNum > 0
+  async function isSomeAddressUsed(addresses): Promise<boolean> {
+    return (await _getAddressInfos(addresses)).caTxNum > 0
   }
 
   // TODO: we should have an endpoint for this
-  async function filterUsedAddresses(addresses: Array<String>) {
+  async function filterUsedAddresses(addresses: Array<string>) {
     const txHistory = await getTxHistory(addresses)
     const usedAddresses = new Set()
     txHistory.forEach((trx) => {
@@ -126,7 +149,7 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
     const balance = (await Promise.all(
       chunks.map(async (index) => {
         const beginIndex = index * gapLimit
-        return await getAddressInfos(addresses.slice(beginIndex, beginIndex + gapLimit))
+        return await _getAddressInfos(addresses.slice(beginIndex, beginIndex + gapLimit))
       })
     )).reduce((acc, elem) => acc + parseInt(elem.caBalance.getCoin, 10), 0)
     return balance
@@ -134,7 +157,7 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
 
   async function submitTxRaw(txHash, txBody, params) {
     const token = ADALITE_CONFIG.ADALITE_BACKEND_TOKEN
-    const response = await request(
+    const response: SubmitResponse = await request(
       `${ADALITE_CONFIG.ADALITE_SERVER_URL}/api/txs/submit`,
       'POST',
       JSON.stringify({
@@ -147,10 +170,12 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
         ...(token ? {token} : {}),
       }
     )
-    if (!response.Right) {
+    if (!('Right' in response)) {
       debugLog(`Unexpected tx submission response: ${JSON.stringify(response)}`)
       if (response.statusCode && response.statusCode === 400) {
-        throw NamedError('TransactionRejectedByNetwork', {message: response.Left})
+        throw NamedError('TransactionRejectedByNetwork', {
+          message: response.Left,
+        })
       } else {
         throw NamedError('ServerError')
       }
@@ -166,7 +191,7 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
     const response = (await Promise.all(
       chunks.map(async (index) => {
         const beginIndex = index * gapLimit
-        const response = await request(
+        const response: BulkAdressesUtxoResponse = await request(
           url,
           'POST',
           JSON.stringify(addresses.slice(beginIndex, beginIndex + gapLimit)),
@@ -175,6 +200,7 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
             'Content-Type': 'application/json',
           }
         )
+        // @ts-ignore (TODO, handle 'Left')
         return response.Right
       })
     )).reduce((acc, cur) => acc.concat(cur), [])
@@ -189,8 +215,8 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
     })
   }
 
-  async function getPoolInfo(url) {
-    const response = await request(
+  async function getPoolInfo(url: string) {
+    const response: HostedPoolMetadata = await request(
       `${ADALITE_CONFIG.ADALITE_SERVER_URL}/api/poolMeta`,
       'POST',
       JSON.stringify({poolUrl: url}),
@@ -216,7 +242,12 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
       ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL
     }/api/account/stakeRegistrationHistory/${accountPubkeyHex}`
 
-    const [delegations, rewards, withdrawals, stakingKeyRegistrations] = await Promise.all([
+    const [delegations, rewards, withdrawals, stakingKeyRegistrations]: [
+      Array<DelegationHistoryEntry>,
+      Array<RewardsHistoryEntry>,
+      Array<WithdrawalsHistoryEntry>,
+      Array<StakeRegistrationHistoryEntry>
+    ] = await Promise.all([
       request(delegationsUrl).catch(() => []),
       request(rewardsUrl).catch(() => []),
       request(withdrawalsUrl).catch(() => []),
@@ -318,13 +349,13 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
   }
 
   async function getRewardDetails(
-    nextRewardDetails,
-    currentDelegationPoolHash,
-    validStakepools,
-    epochsToRewardDistribution
-  ) {
-    const nextRewardDetailsWithMetaData: any[] = await Promise.all(
-      nextRewardDetails.map(async (nextRewardDetail) => {
+    nextRewardDetails: Array<NextRewardDetail>,
+    currentDelegationPoolHash: string,
+    validStakepools: ValidStakePools,
+    epochsToRewardDistribution: number
+  ): Promise<NextRewardDetailsFormatted> {
+    const nextRewardDetailsWithMetaData: Array<RewardWithMetadata> = await Promise.all(
+      nextRewardDetails.map(async (nextRewardDetail: NextRewardDetail) => {
         const poolHash = nextRewardDetail.poolHash
         if (poolHash) {
           return {
@@ -337,18 +368,18 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
         } else {
           return {
             ...nextRewardDetail,
-            pool: {},
+            pool: {}, // TODO: why does this not have {name: UNKNOWN_POOL_NAME}?
           }
         }
       })
     )
-    const nearestRewardDetails = nextRewardDetailsWithMetaData
-      .filter((rewardDetails) => rewardDetails.poolHash != null)
-      .sort((a, b) => a.forEpoch - b.forEpoch)[0]
-    const currentDelegationRewardDetails = nextRewardDetailsWithMetaData
-      .filter((rewardDetails) => rewardDetails.poolHash != null)
+    const sortedValidRewardDetails = nextRewardDetailsWithMetaData
+      .filter((rewardDetail) => rewardDetail.poolHash != null)
       .sort((a, b) => a.forEpoch - b.forEpoch)
-      .find((rewardDetails) => rewardDetails.poolHash === currentDelegationPoolHash)
+    const nearestRewardDetails = sortedValidRewardDetails[0]
+    const currentDelegationRewardDetails = sortedValidRewardDetails.find(
+      (rewardDetail) => rewardDetail.poolHash === currentDelegationPoolHash
+    )
 
     return {
       upcoming: nextRewardDetailsWithMetaData,
@@ -357,7 +388,10 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
     }
   }
 
-  function getPoolRecommendation(poolHash: string, stake: number): Promise<any> {
+  function getPoolRecommendation(
+    poolHash: string,
+    stake: number
+  ): Promise<PoolRecommendationResponse> {
     const url = `${
       ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL
     }/api/account/poolRecommendation/poolHash/${poolHash}/stake/${stake}`
@@ -372,16 +406,16 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
     const url = `${
       ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL
     }/api/account/info/${stakingKeyHashHex}`
-    const response = await request(url)
+    const response: AccountInfoResponse = await request(url)
     return response
   }
 
-  function getValidStakepools(): Promise<any> {
+  function getValidStakepools(): Promise<ValidStakePools> {
     const url = `${ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL}/api/v2/stakePools`
     return request(url)
   }
 
-  function getBestSlot(): Promise<any> {
+  function getBestSlot(): Promise<BestSlotResponse> {
     return request(`${ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL}/api/v2/bestSlot`)
   }
 

--- a/app/frontend/wallet/blockchain-explorer.ts
+++ b/app/frontend/wallet/blockchain-explorer.ts
@@ -30,7 +30,7 @@ import {
   NextRewardDetailsFormatted,
   RewardWithMetadata,
   PoolRecommendationResponse,
-  AccountInfoResponse,
+  StakingInfoResponse,
   BestSlotResponse,
 } from './explorer-types'
 
@@ -134,7 +134,7 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
   // TODO: we should have an endpoint for this
   async function filterUsedAddresses(addresses: Array<string>) {
     const txHistory = await getTxHistory(addresses)
-    const usedAddresses = new Set()
+    const usedAddresses = new Set<string>()
     txHistory.forEach((trx) => {
       ;(trx.ctbOutputs || []).forEach((output) => {
         usedAddresses.add(output[0])
@@ -409,7 +409,7 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
     const url = `${
       ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL
     }/api/account/info/${stakingKeyHashHex}`
-    const response: AccountInfoResponse = await request(url)
+    const response: StakingInfoResponse = await request(url)
     return response
   }
 

--- a/app/frontend/wallet/blockchain-explorer.ts
+++ b/app/frontend/wallet/blockchain-explorer.ts
@@ -393,11 +393,11 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
 
   function getPoolRecommendation(
     poolHash: string,
-    stake: number
+    stakeAmount: Lovelace
   ): Promise<PoolRecommendationResponse> {
     const url = `${
       ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL
-    }/api/account/poolRecommendation/poolHash/${poolHash}/stake/${stake}`
+    }/api/account/poolRecommendation/poolHash/${poolHash}/stake/${stakeAmount}`
     return request(url).catch(() => ({
       recommendedPoolHash: ADALITE_CONFIG.ADALITE_STAKE_POOL_ID,
       isInRecommendedPoolSet: true,

--- a/app/frontend/wallet/blockchain-explorer.ts
+++ b/app/frontend/wallet/blockchain-explorer.ts
@@ -127,7 +127,7 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
     return Buffer.from(result.Right, 'hex')
   }
 
-  async function isSomeAddressUsed(addresses): Promise<boolean> {
+  async function isSomeAddressUsed(addresses: Array<string>): Promise<boolean> {
     return (await _getAddressInfos(addresses)).caTxNum > 0
   }
 
@@ -147,7 +147,7 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
     return usedAddresses
   }
 
-  async function getBalance(addresses) {
+  async function getBalance(addresses: Array<string>) {
     const chunks = range(0, Math.ceil(addresses.length / gapLimit))
     const balance = (await Promise.all(
       chunks.map(async (index) => {
@@ -187,7 +187,7 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
     return response.Right
   }
 
-  async function fetchUnspentTxOutputs(addresses) {
+  async function fetchUnspentTxOutputs(addresses: Array<string>) {
     const chunks = range(0, Math.ceil(addresses.length / gapLimit))
 
     const url = `${ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL}/api/bulk/addresses/utxo`

--- a/app/frontend/wallet/blockchain-explorer.ts
+++ b/app/frontend/wallet/blockchain-explorer.ts
@@ -119,9 +119,12 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
   }
 
   // TODO: delete, raw txs are no longer in the db sync database
-  // eslint-disable-next-line require-await
-  async function fetchTxRaw(txId): Promise<undefined> {
-    return undefined
+  // TODO: remove tests for byron which use this
+  async function fetchTxRaw(txId) {
+    // eslint-disable-next-line no-undef
+    const url = `${ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL}/api/txs/raw/${txId}`
+    const result = await request(url)
+    return Buffer.from(result.Right, 'hex')
   }
 
   async function isSomeAddressUsed(addresses): Promise<boolean> {

--- a/app/frontend/wallet/blockchain-explorer.ts
+++ b/app/frontend/wallet/blockchain-explorer.ts
@@ -26,7 +26,7 @@ import {
   WithdrawalsHistoryEntry,
   StakeRegistrationHistoryEntry,
   NextRewardDetail,
-  ValidStakePools,
+  ValidStakePoolsMapping,
   NextRewardDetailsFormatted,
   RewardWithMetadata,
   PoolRecommendationResponse,
@@ -354,7 +354,7 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
   async function getRewardDetails(
     nextRewardDetails: Array<NextRewardDetail>,
     currentDelegationPoolHash: string,
-    validStakepools: ValidStakePools,
+    validStakepools: ValidStakePoolsMapping,
     epochsToRewardDistribution: number
   ): Promise<NextRewardDetailsFormatted> {
     const nextRewardDetailsWithMetaData: Array<RewardWithMetadata> = await Promise.all(
@@ -413,7 +413,7 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
     return response
   }
 
-  function getValidStakepools(): Promise<ValidStakePools> {
+  function getValidStakepools(): Promise<ValidStakePoolsMapping> {
     const url = `${ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL}/api/v2/stakePools`
     return request(url)
   }

--- a/app/frontend/wallet/explorer-types.ts
+++ b/app/frontend/wallet/explorer-types.ts
@@ -1,0 +1,169 @@
+export type HostedPoolMetadata = {
+  name: string
+  description: string
+  ticker: string
+  homepage: string
+  extended?: string
+}
+
+export type StakePoolInfoExtended = {
+  pledge: string
+  margin: number
+  fixedCost: string
+  name: string
+  ticker: string
+  homepage: string
+  poolHash: string
+  liveStake: string
+  roa: string
+  epochBlocks: string
+  lifeTimeBlocks: string
+  saturatedPercentage: number
+}
+
+export type DelegationHistoryEntry = StakePoolInfoExtended & {
+  txHash: string
+  time: string
+  epochNo: number
+}
+
+export type RewardsHistoryEntry = StakePoolInfoExtended & {
+  time: string
+  epochNo: number
+  forDelegationInEpoch: number
+  amount: string
+}
+
+export type WithdrawalsHistoryEntry = {
+  time: string
+  epochNo: number
+  txHash: string
+  amount: string
+}
+
+export type StakeRegistrationHistoryEntry = {
+  txHash: string
+  time: string
+  epochNo: number
+  action: 'registration' | 'deregistration'
+}
+
+export type ValidStakePools = {
+  [poolId: string]: {
+    pledge: string
+    margin: number
+    fixedCost: string
+    url: string
+    name: string
+    ticker: string
+    homepage: string
+  }
+}
+
+export type NextRewardDetail = StakePoolInfoExtended & {
+  forEpoch: number
+  rewardDate: string
+}
+
+export type AccountInfoResponse = {
+  currentEpoch: number
+  delegation: StakePoolInfoExtended & {
+    retiringEpoch: number | null
+    url: string
+  }
+  hasStakingKey: boolean
+  rewards: string
+  nextRewardDetails: Array<NextRewardDetail>
+}
+
+export type BestSlotResponse = {
+  Right: {
+    bestSlot: number
+  }
+}
+
+export type RewardWithMetadata = NextRewardDetail & {
+  distributionEpoch?: number
+  pool: HostedPoolMetadata | Object // TODO after refactor
+}
+
+export type NextRewardDetailsFormatted = {
+  upcoming: Array<RewardWithMetadata>
+  nearest: RewardWithMetadata
+  currentDelegation: RewardWithMetadata
+}
+
+export enum PoolRecommendationStatus {
+  INVALID = 'GivenPoolInvalid',
+  SATURATED = 'GivenPoolSaturated',
+  BEYOND_OPTIMUM = 'GivenPoolBeyondOptimum',
+  OK = 'GivenPoolOk',
+  UNDER_MINIMUM = 'GivenPoolUnderMinimum',
+}
+
+export type PoolRecommendationResponse = StakePoolInfoExtended & {
+  status: PoolRecommendationStatus
+  recommendedPoolHash: string
+  isInRecommendedPoolSet: boolean
+}
+
+export type CoinObject = {
+  getCoin: string
+}
+
+export type AddressCoinTuple = [string, CoinObject]
+
+export type CaTxEntry = {
+  ctbId: string
+  ctbTimeIssued: number
+  ctbInputs: Array<AddressCoinTuple>
+  ctbOutputs: Array<AddressCoinTuple>
+  ctbInputSum: CoinObject
+  ctbOutputSum: CoinObject
+  fee: string
+}
+
+export type BulkAddressesSummary = {
+  caAddresses: Array<string>
+  caTxNum: number
+  caBalance: CoinObject
+  caTxList: Array<CaTxEntry>
+}
+
+export type TxSummary = {
+  ctsId: string
+  ctsTxTimeIssued: number
+  ctsBlockTimeIssued: number
+  ctsBlockHeight: number
+  ctsBlockEpoch: number
+  ctsBlockSlot: number
+  ctsBlockHash: string
+  ctsRelayedBy: null
+  ctsTotalInput: CoinObject
+  ctsTotalOutput: CoinObject
+  ctsFees: CoinObject
+  ctsInputs: Array<AddressCoinTuple>
+  ctsOutputs: Array<AddressCoinTuple>
+}
+
+export type FailureResponse = {Left: string}
+export type SuccessResponse<T> = {
+  Right: T
+}
+
+export type TxSummaryResponse = SuccessResponse<TxSummary> | FailureResponse
+export type BulkAddressesSummaryResponse = SuccessResponse<BulkAddressesSummary> | FailureResponse
+
+export type TxSubmission = {txHash: string}
+export type TxSubmissionFailure = FailureResponse & {
+  statusCode?: number
+}
+export type SubmitResponse = SuccessResponse<TxSubmission> | TxSubmissionFailure
+export type Utxo = {
+  tag: string
+  cuId: string
+  cuOutIndex: number
+  cuAddress: string
+  cuCoins: CoinObject
+}
+export type BulkAdressesUtxoResponse = SuccessResponse<Array<Utxo>> | TxSubmissionFailure

--- a/app/frontend/wallet/explorer-types.ts
+++ b/app/frontend/wallet/explorer-types.ts
@@ -62,7 +62,7 @@ export type NextRewardDetail = StakePoolInfoExtended & {
   rewardDate: string
 }
 
-export type AccountInfoResponse = {
+export type StakingInfoResponse = {
   currentEpoch: number
   delegation: StakePoolInfoExtended & {
     retiringEpoch: number | null

--- a/app/frontend/wallet/explorer-types.ts
+++ b/app/frontend/wallet/explorer-types.ts
@@ -6,13 +6,16 @@ export type HostedPoolMetadata = {
   extended?: string
 }
 
-export type StakePoolInfoExtended = {
+type StakePoolInfo = {
   pledge: string
   margin: number
   fixedCost: string
   name: string
   ticker: string
   homepage: string
+}
+
+export type StakePoolInfoExtended = StakePoolInfo & {
   poolHash: string
   liveStake: string
   roa: string
@@ -48,15 +51,9 @@ export type StakeRegistrationHistoryEntry = {
   action: 'registration' | 'deregistration'
 }
 
-export type ValidStakePools = {
-  [poolId: string]: {
-    pledge: string
-    margin: number
-    fixedCost: string
+export type ValidStakePoolsMapping = {
+  [poolId: string]: StakePoolInfo & {
     url: string
-    name: string
-    ticker: string
-    homepage: string
   }
 }
 

--- a/app/frontend/wallet/shelley-wallet.ts
+++ b/app/frontend/wallet/shelley-wallet.ts
@@ -2,7 +2,7 @@ import BlockchainExplorer from './blockchain-explorer'
 import {AccountManager} from './account-manager'
 import {AccountInfo, CryptoProvider, CryptoProviderFeature} from '../types'
 import {MAX_ACCOUNT_INDEX} from './constants'
-import {ValidStakePools} from './explorer-types'
+import {ValidStakePoolsMapping} from './explorer-types'
 
 type WalletParams = {
   config: any
@@ -62,7 +62,9 @@ const ShelleyWallet = ({config, cryptoProvider}: WalletParams) => {
     return null
   }
 
-  async function getAccountsInfo(validStakepools: ValidStakePools): Promise<Array<AccountInfo>> {
+  async function getAccountsInfo(
+    validStakepools: ValidStakePoolsMapping
+  ): Promise<Array<AccountInfo>> {
     const accounts = await accountManager.discoverAccounts()
     //@ts-ignore TODO: refactor type AccountInfo
     return Promise.all(accounts.map((account) => account.getAccountInfo(validStakepools)))

--- a/app/frontend/wallet/shelley-wallet.ts
+++ b/app/frontend/wallet/shelley-wallet.ts
@@ -2,6 +2,7 @@ import BlockchainExplorer from './blockchain-explorer'
 import {AccountManager} from './account-manager'
 import {AccountInfo, CryptoProvider, CryptoProviderFeature} from '../types'
 import {MAX_ACCOUNT_INDEX} from './constants'
+import {ValidStakePools} from './explorer-types'
 
 type WalletParams = {
   config: any
@@ -61,7 +62,7 @@ const ShelleyWallet = ({config, cryptoProvider}: WalletParams) => {
     return null
   }
 
-  async function getAccountsInfo(validStakepools): Promise<Array<AccountInfo>> {
+  async function getAccountsInfo(validStakepools: ValidStakePools): Promise<Array<AccountInfo>> {
     const accounts = await accountManager.discoverAccounts()
     //@ts-ignore TODO: refactor type AccountInfo
     return Promise.all(accounts.map((account) => account.getAccountInfo(validStakepools)))

--- a/app/frontend/wallet/shelley-wallet.ts
+++ b/app/frontend/wallet/shelley-wallet.ts
@@ -63,6 +63,7 @@ const ShelleyWallet = ({config, cryptoProvider}: WalletParams) => {
 
   async function getAccountsInfo(validStakepools): Promise<Array<AccountInfo>> {
     const accounts = await accountManager.discoverAccounts()
+    //@ts-ignore TODO: refactor type AccountInfo
     return Promise.all(accounts.map((account) => account.getAccountInfo(validStakepools)))
   }
 


### PR DESCRIPTION
Assigns types to data retrieved from BE endpoints. Leaves space for future refactors. Only patches up new typescript errors due to inconsistency of the state, however, such changes and refactors are out of scope of this PR.

Possible changes:
- WHERE (which file) to store the new types
- Split up purely BE types and any follow-up types of stuff created freshly on FE