### PR TITLE
Add treasury rewards logic and reward types

### DIFF
--- a/app/frontend/components/pages/delegations/stakingHistoryPage.tsx
+++ b/app/frontend/components/pages/delegations/stakingHistoryPage.tsx
@@ -7,6 +7,7 @@ import printAda from '../../../helpers/printAda'
 import CopyOnClick from '../../common/copyOnClick'
 import {EpochDateTime} from '../common'
 import {Lovelace} from '../../../types'
+import {RewardType} from '../../../wallet/explorer-types'
 
 export enum StakingHistoryItemType {
   StakeDelegation,
@@ -64,6 +65,7 @@ export interface StakingReward extends StakingHistoryObject {
   forEpoch: number
   reward: Lovelace
   stakePool: StakePool
+  rewardType: RewardType
 }
 
 const StakingRewardItem = ({stakingReward}: {stakingReward: StakingReward}) => {
@@ -72,10 +74,15 @@ const StakingRewardItem = ({stakingReward}: {stakingReward: StakingReward}) => {
       <div className="space-between">
         <div>
           <div>
-            {stakingReward.forEpoch ? (
+            {/* TODO: Remake into exhaustive switch */}
+            {stakingReward.rewardType === RewardType.REGULAR && (
               <div className="label">Reward for epoch {stakingReward.forEpoch}</div>
-            ) : (
+            )}
+            {stakingReward.rewardType === RewardType.ITN && (
               <div className="label">Reward for ITN</div>
+            )}
+            {stakingReward.rewardType === RewardType.TREASURY && (
+              <div className="label">Reward for Catalyst</div>
             )}
             <div className="margin-bottom">
               <EpochDateTime epoch={stakingReward.epoch} dateTime={stakingReward.dateTime} />
@@ -83,7 +90,7 @@ const StakingRewardItem = ({stakingReward}: {stakingReward: StakingReward}) => {
           </div>
           <div>
             <div className="grey">
-              {stakingReward.stakePool.name}
+              {stakingReward.rewardType === RewardType.REGULAR && stakingReward.stakePool.name}
               {stakingReward.stakePool.id && (
                 <LinkIconToPool poolHash={stakingReward.stakePool.id} />
               )}

--- a/app/frontend/wallet/blockchain-explorer.ts
+++ b/app/frontend/wallet/blockchain-explorer.ts
@@ -311,6 +311,7 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
         forEpoch: reward.forDelegationInEpoch,
         reward: parseInt(reward.amount, 10) as Lovelace,
         stakePool: parseStakePool(reward),
+        rewardType: reward.rewardType,
       }
 
       return stakingReward

--- a/app/frontend/wallet/explorer-types.ts
+++ b/app/frontend/wallet/explorer-types.ts
@@ -30,11 +30,18 @@ export type DelegationHistoryEntry = StakePoolInfoExtended & {
   epochNo: number
 }
 
+export enum RewardType {
+  REGULAR = 'REGULAR',
+  ITN = 'ITN',
+  TREASURY = 'TREASURY',
+}
+
 export type RewardsHistoryEntry = StakePoolInfoExtended & {
   time: string
   epochNo: number
   forDelegationInEpoch: number
   amount: string
+  rewardType: RewardType
 }
 
 export type WithdrawalsHistoryEntry = {


### PR DESCRIPTION
- Adds rewards types - ITN, TREASURY, REGULAR. Shows different titles for each of them.
- Removes "UNKNOWN-POOL" for ITN and TREASURY rewards, since they're not bound to any pool.
![image](https://user-images.githubusercontent.com/22454337/107352409-169a0f80-6acc-11eb-823b-5a9110b0373c.png)
