### PR TITLE
Optimilize-account-info

### DIFF
--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -938,20 +938,22 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
     // maybe also check if tab changed
   }
 
-  const setPoolInfo = async (state) => {
+  const setPoolInfo = async (state: State) => {
     if (hasPoolIdentifiersChanged(state)) {
       return
     }
-    const poolInfo = await wallet
-      .getAccount(state.sourceAccountIndex)
-      .getPoolInfo(state.shelleyDelegation.selectedPool.url)
+    const poolInfo = !state.shelleyDelegation.selectedPool.name
+      ? await wallet
+        .getAccount(state.sourceAccountIndex)
+        .getPoolInfo(state.shelleyDelegation.selectedPool.url)
+      : {}
     if (hasPoolIdentifiersChanged(state)) {
       return
     }
     const newState = getState()
     setState({
       shelleyDelegation: {
-        ...state.shelleyDelation,
+        ...state.shelleyDelegation,
         selectedPool: {
           ...state.shelleyDelegation.selectedPool,
           ...poolInfo,

--- a/app/frontend/wallet/account.ts
+++ b/app/frontend/wallet/account.ts
@@ -142,12 +142,8 @@ const MyAddresses = ({
   }
 
   async function areAddressesUsed() {
-    const baseInt = await baseIntAddrManager.discoverAddresses()
     const baseExt = await baseExtAddrManager.discoverAddresses()
-    return (
-      (await blockchainExplorer.isSomeAddressUsed(baseInt)) ||
-      (await blockchainExplorer.isSomeAddressUsed(baseExt))
-    )
+    return await blockchainExplorer.isSomeAddressUsed(baseExt)
   }
 
   async function getStakingAddress() {

--- a/app/frontend/wallet/account.ts
+++ b/app/frontend/wallet/account.ts
@@ -381,7 +381,6 @@ const Account = ({
     const {nextRewardDetails, ...accountInfo} = await blockchainExplorer.getStakingInfo(
       stakingAddressHex
     )
-    const poolInfo = await getPoolInfo(accountInfo.delegation.url)
     const rewardDetails = await blockchainExplorer.getRewardDetails(
       nextRewardDetails,
       accountInfo.delegation.poolHash,
@@ -391,10 +390,6 @@ const Account = ({
 
     return {
       ...accountInfo,
-      delegation: {
-        ...accountInfo.delegation,
-        ...poolInfo,
-      },
       rewardDetails,
       value: accountInfo.rewards ? parseInt(accountInfo.rewards, 10) : 0,
     }


### PR DESCRIPTION
Changes: 
Removes unnessary calls to poolInfo and uses it only as a fallback
When exploring accounts, only external addresses are checked 

Gotcha: 
These are just hot fixed so we dont send so many requests to poolMeta, (which can slow the page a lot). Since both @xdzurman and @DavidTranDucVL  are working on blockchain explorer I didnt try to refactor any of the current behavior and left it for their PRs.