### PR TITLE
Refactor transaction building 1

### DIFF
--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -938,20 +938,22 @@ export default ({setState, getState}: {setState: SetStateFn; getState: GetStateF
     // maybe also check if tab changed
   }
 
-  const setPoolInfo = async (state) => {
+  const setPoolInfo = async (state: State) => {
     if (hasPoolIdentifiersChanged(state)) {
       return
     }
-    const poolInfo = await wallet
-      .getAccount(state.sourceAccountIndex)
-      .getPoolInfo(state.shelleyDelegation.selectedPool.url)
+    const poolInfo = !state.shelleyDelegation.selectedPool.name
+      ? await wallet
+        .getAccount(state.sourceAccountIndex)
+        .getPoolInfo(state.shelleyDelegation.selectedPool.url)
+      : {}
     if (hasPoolIdentifiersChanged(state)) {
       return
     }
     const newState = getState()
     setState({
       shelleyDelegation: {
-        ...state.shelleyDelation,
+        ...state.shelleyDelegation,
         selectedPool: {
           ...state.shelleyDelegation.selectedPool,
           ...poolInfo,

--- a/app/frontend/components/pages/sendAda/donationButtons.tsx
+++ b/app/frontend/components/pages/sendAda/donationButtons.tsx
@@ -110,7 +110,8 @@ class DonationButtons extends Component<Props> {
 }
 
 export default connect(
-  (state) => ({
+  // TODO: hotfix until we refactor this to functional component
+  (state: any) => ({
     sendAmount: state.sendAmount.fieldValue,
     sendAmountValidationError: state.sendAmountValidationError,
     checkedDonationType: state.checkedDonationType,

--- a/app/frontend/components/pages/sendAda/sendAdaPage.tsx
+++ b/app/frontend/components/pages/sendAda/sendAdaPage.tsx
@@ -38,7 +38,7 @@ const SendValidation = ({sendFormValidationError, txSuccessTab}) =>
 
 interface Props {
   sendResponse: any
-  sendAddress: any
+  sendAddress: string
   sendAddressValidationError: any
   sendAmount: any
   sendAmountValidationError: any

--- a/app/frontend/helpers/validators.ts
+++ b/app/frontend/helpers/validators.ts
@@ -6,7 +6,8 @@ import {Lovelace, Ada, CertificateType} from '../types'
 import {NETWORKS} from '../wallet/constants'
 
 const {ADALITE_MIN_DONATION_VALUE} = ADALITE_CONFIG
-const parseToLovelace = (str): Lovelace => Math.trunc(toCoins(parseFloat(str) as Ada)) as Lovelace
+const parseToLovelace = (str: string): Lovelace =>
+  Math.trunc(toCoins(parseFloat(str) as Ada)) as Lovelace
 
 const _sendAddressValidators = {
   byron: isValidBootstrapAddress,

--- a/app/frontend/state.ts
+++ b/app/frontend/state.ts
@@ -12,112 +12,122 @@ export interface SendTransactionSummary {
 }
 
 export interface State {
+  // general
   loading: boolean
   loadingMessage: string
   alert: any // TODO
-  displayWelcome: boolean
-  displayInfoModal: boolean
-  currentTab: 'wallet-info'
-  walletIsLoaded: boolean
-  shouldShowStakingBanner: boolean
-  errorBannerContent: string
-  sendAddress: any // TODO
-  sendAmount: any // TODO
-  keepConfirmationDialogOpen: boolean
-
-  sendTransactionSummary: SendTransactionSummary
-
-  router: {
-    pathname: string
-    hash: string
+  sendSentry: {
+    event?: any
+    resolve?: (shouldSend: boolean) => void
   }
+  errorBannerContent: string
+  shouldShowUnexpectedErrorModal: boolean
+  error?: any
+  activeMainTab: MainTabs
+  shouldShowContactFormModal?: boolean
+  shouldShowExportOption?: boolean
+  conversionRates?: {data: {USD: number; EUR: number}}
+
+  // cache
+  displayWelcome: boolean
+  shouldShowStakingBanner: boolean
+  displayInfoModal: boolean
+  shouldShowPremiumBanner?: boolean
+
+  // login / logout
+  autoLogin: boolean
+  authMethod: AuthMethod
+  shouldShowDemoWalletWarningDialog: boolean
+  logoutNotificationOpen: boolean
+  walletIsLoaded: boolean
+  isShelleyCompatible: any
+  shouldShowNonShelleyCompatibleDialog: any
+  walletLoadingError?: any
+  shouldShowWalletLoadingErrorModal?: boolean
+  usingHwWallet?: boolean
+  isBigDelegator: boolean
+  shouldShowSaturatedBanner?: boolean
   mnemonicAuthForm: {
     mnemonicInputValue: string
     mnemonicInputError: {code: string}
     formIsValid: boolean
   }
-
-  isShelleyCompatible: any
-  shouldShowNonShelleyCompatibleDialog: any
-
-  authMethod: AuthMethod
-  shouldShowDemoWalletWarningDialog: boolean
-  logoutNotificationOpen: boolean
-  rawTransactionOpen: boolean
-  rawTransaction: string
+  hwWalletName?: string
+  isDemoWallet?: boolean
+  shouldShowGenerateMnemonicDialog?: boolean
   shouldShowMnemonicInfoAlert: boolean
-  sendResponse: any // TODO
+
+  // send form
+  sendAddress: {
+    fieldValue: string
+  }
+  sendAmount: {
+    fieldValue: string
+    coins: Lovelace
+  }
+  sendAddressValidationError?: any
+  sendAmountValidationError?: any
+  calculatingFee?: boolean
+
+  // donation
+  donationAmount: {
+    fieldValue: string
+    coins: Lovelace
+  }
   checkedDonationType: string // TODO: enum
+  donationAmountValidationError?: any
   shouldShowCustomDonationInput: boolean
-  donationAmount: any // TODO
   maxDonationAmount: number
   percentageDonationValue: number
   percentageDonationText: string
   isThresholdAmountReached: boolean
 
-  shouldShowUnexpectedErrorModal: boolean
-  sendSentry: {
-    event?: any
-    resolve?: (shouldSend: boolean) => void
+  // delegation form
+  calculatingDelegationFee?: any
+  isDelegationValid?: any
+  shelleyDelegation?: {
+    selectedPool?: any
+    delegationFee?: any
   }
-  autoLogin: boolean
+  delegationValidationError?: any
+  gettingPoolInfo: boolean
 
-  // TODO
-  waitingForHwWallet?: boolean
+  // transaction
+  sendTransactionSummary: SendTransactionSummary
+  rawTransactionOpen: boolean
+  rawTransaction: string
+  transactionFee?: any
+  sendResponse: any // TODO
+  txConfirmType: string
+  txSuccessTab: string
+  transactionSubmissionError?: any
   shouldShowConfirmTransactionDialog?: boolean
   shouldShowTransactionErrorModal?: boolean
   shouldShowThanksForDonation?: boolean
-  shouldShowContactFormModal?: boolean
-  shouldShowPremiumBanner?: boolean
+  waitingForHwWallet?: boolean
+  keepConfirmationDialogOpen: boolean
+
+  // router
+  router: {
+    pathname: string
+    hash: string
+  }
+
+  // pool registration
   poolCertTxVars: {
     shouldShowPoolCertSignModal: boolean
     ttl: any
     signature: any
     plan: any
   }
+  poolRegTxError?: any
 
-  calculatingFee?: boolean
-  transactionFee?: any
-
-  sendAmountValidationError?: any
-  shouldShowExportOption?: boolean
-
-  conversionRates?: {data: {USD: number; EUR: number}}
-  shouldShowGenerateMnemonicDialog?: boolean
-
-  walletLoadingError?: any
-  shouldShowWalletLoadingErrorModal?: boolean
-  usingHwWallet?: boolean
+  // address detail
   addressVerificationError?: boolean
   showAddressDetail?: {address: string; bip32path: string; copyOnClick: boolean}
-  hwWalletName?: string
-  isDemoWallet?: boolean
-  error?: any
   shouldShowAddressVerification?: boolean
 
-  donationAmountValidationError?: any
-  sendAddressValidationError?: any
-  transactionSubmissionError?: any
-
-  calculatingDelegationFee?: any
-  isDelegationValid?: any
-
-  shelleyDelegation?: {
-    selectedPool?: any
-    delegationFee?: any
-  }
-  activeMainTab: MainTabs
-  currentDelegation?: {
-    stakePool?: any
-  }
-  validStakepools?: any | null
-  ticker2Id?: any | null
-  delegationValidationError?: any
-  gettingPoolInfo: boolean
-  txConfirmType: string
-  txSuccessTab: string
-  shouldShowSaturatedBanner?: boolean
-  isBigDelegator: boolean
+  // accounts info
   accountsInfo: Array<AccountInfo>
   maxAccountIndex: number
   shouldNumberAccountsFromOne: boolean
@@ -126,14 +136,21 @@ export interface State {
   targetAccountIndex: number
   totalWalletBalance: number
   totalRewardsBalance: number
+
   shouldShowSendTransactionModal: boolean
   shouldShowDelegationModal: boolean
   sendTransactionTitle: string
   delegationTitle: string
-  poolRegTxError?: any
+
+  currentDelegation?: {
+    // TODO: probably useless
+    stakePool?: any
+  }
+  validStakepools?: any | null
 }
 
 const initialState: State = {
+  //general
   loading: false,
   loadingMessage: '',
   alert: {
@@ -142,11 +159,15 @@ const initialState: State = {
     title: 'Wrong mnemonic',
     hint: 'Hint: Ensure that your mnemonic is without mistake.',
   },
+  sendSentry: {},
+  errorBannerContent: '',
+  shouldShowUnexpectedErrorModal: false,
+  activeMainTab: MainTabs.SENDING,
+
+  // cache
   displayWelcome:
     !(window.localStorage.getItem(localStorageVars.WELCOME) === 'true') &&
     ADALITE_CONFIG.ADALITE_DEVEL_AUTO_LOGIN !== 'true',
-  currentTab: 'wallet-info',
-  walletIsLoaded: false,
   shouldShowStakingBanner: !(
     window.localStorage.getItem(localStorageVars.STAKING_BANNER) === 'true'
   ),
@@ -154,51 +175,39 @@ const initialState: State = {
     window.localStorage.getItem(localStorageVars.PREMIUM_BANNER) === 'true'
   ),
   displayInfoModal: !(window.localStorage.getItem(localStorageVars.INFO_MODAL) === 'true'),
-  errorBannerContent: '',
-  // todo - object (sub-state) from send-ada form
-  sendAddress: {fieldValue: ''},
-  sendAmount: {fieldValue: 0, coins: 0},
-  transactionFee: 0,
-  sendTransactionSummary: {
-    amount: 0 as Lovelace,
-    fee: 0 as Lovelace,
-    donation: 0 as Lovelace,
-    plan: null,
-    deposit: 0,
-  },
-  router: {
-    pathname: window.location.pathname,
-    hash: window.location.hash,
-  },
+
+  // login / logout
+  autoLogin:
+    ADALITE_CONFIG.ADALITE_ENV === 'local' && ADALITE_CONFIG.ADALITE_DEVEL_AUTO_LOGIN === 'true',
+  authMethod: ['#trezor', '#hw-wallet'].includes(window.location.hash) ? 'hw-wallet' : '',
+  shouldShowDemoWalletWarningDialog: false,
+  logoutNotificationOpen: false,
+  walletIsLoaded: false,
+  isShelleyCompatible: true,
+  shouldShowNonShelleyCompatibleDialog: false,
+  isBigDelegator: false,
   mnemonicAuthForm: {
     mnemonicInputValue: '',
     mnemonicInputError: null,
     formIsValid: false,
   },
-  isShelleyCompatible: true,
-  shouldShowNonShelleyCompatibleDialog: false,
-  authMethod: ['#trezor', '#hw-wallet'].includes(window.location.hash) ? 'hw-wallet' : '',
-  shouldShowDemoWalletWarningDialog: false,
-  logoutNotificationOpen: false,
-  rawTransactionOpen: false,
-  rawTransaction: '',
   shouldShowMnemonicInfoAlert: false,
-  sendResponse: {},
+
+  // send form
+  // todo - object (sub-state) from send-ada form
+  sendAddress: {fieldValue: ''},
+  sendAmount: {fieldValue: '0', coins: 0 as Lovelace},
+
+  // donation
+  donationAmount: {fieldValue: '0', coins: 0 as Lovelace},
   checkedDonationType: '',
   shouldShowCustomDonationInput: false,
-  donationAmount: {fieldValue: 0, coins: 0},
   maxDonationAmount: Infinity,
   percentageDonationValue: 0,
   percentageDonationText: '0.2%', // What is this and why it isn't in config?
   isThresholdAmountReached: false,
 
-  shouldShowUnexpectedErrorModal: false,
-  sendSentry: {},
-  autoLogin:
-    ADALITE_CONFIG.ADALITE_ENV === 'local' && ADALITE_CONFIG.ADALITE_DEVEL_AUTO_LOGIN === 'true',
-
-  // shelley
-  activeMainTab: MainTabs.SENDING,
+  // delegation
   shelleyDelegation: {
     delegationFee: 0.0,
     selectedPool: {
@@ -206,10 +215,38 @@ const initialState: State = {
     },
   },
   gettingPoolInfo: false,
+
+  // transaction
+  sendTransactionSummary: {
+    amount: 0 as Lovelace,
+    fee: 0 as Lovelace,
+    donation: 0 as Lovelace,
+    plan: null,
+    deposit: 0,
+  },
+  rawTransactionOpen: false,
+  rawTransaction: '',
+  transactionFee: 0,
+  sendResponse: {},
   txConfirmType: '',
   txSuccessTab: '',
   keepConfirmationDialogOpen: false,
-  isBigDelegator: false,
+
+  // router
+  router: {
+    pathname: window.location.pathname,
+    hash: window.location.hash,
+  },
+
+  // pool registration
+  poolCertTxVars: {
+    shouldShowPoolCertSignModal: false,
+    ttl: 0,
+    signature: null,
+    plan: null,
+  },
+
+  // accounts info
   accountsInfo: [
     {
       accountXpubs: {
@@ -261,16 +298,11 @@ const initialState: State = {
   targetAccountIndex: 0,
   totalWalletBalance: 0,
   totalRewardsBalance: 0,
+
   shouldShowSendTransactionModal: false,
   shouldShowDelegationModal: false,
   sendTransactionTitle: '',
   delegationTitle: '',
-  poolCertTxVars: {
-    shouldShowPoolCertSignModal: false,
-    ttl: 0,
-    signature: null,
-    plan: null,
-  },
 }
 export type SetStateFn = (newState: Partial<State>) => void
 export type GetStateFn = () => State

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -11,6 +11,16 @@ export type AddressProvider = (
   address: _Address
 }>
 
+export type AddressWithMeta = {
+  address: _Address
+  bip32StringPath: string
+  isUsed: boolean
+}
+
+export type AddressToPathMapping = {
+  [key: string]: BIP32Path
+}
+
 export interface CryptoProvider {
   network: Network
   signTx: (
@@ -103,4 +113,11 @@ export type AccountInfo = {
   }
   isUsed: boolean
   accountIndex: number
+}
+
+export const enum TxType {
+  SEND_ADA,
+  CONVERT_LEGACY,
+  DELEGATE,
+  WITHDRAW,
 }

--- a/app/frontend/wallet/account.ts
+++ b/app/frontend/wallet/account.ts
@@ -142,12 +142,8 @@ const MyAddresses = ({
   }
 
   async function areAddressesUsed() {
-    const baseInt = await baseIntAddrManager.discoverAddresses()
     const baseExt = await baseExtAddrManager.discoverAddresses()
-    return (
-      (await blockchainExplorer.isSomeAddressUsed(baseInt)) ||
-      (await blockchainExplorer.isSomeAddressUsed(baseExt))
-    )
+    return await blockchainExplorer.isSomeAddressUsed(baseExt)
   }
 
   async function getStakingAddress() {

--- a/app/frontend/wallet/account.ts
+++ b/app/frontend/wallet/account.ts
@@ -381,7 +381,6 @@ const Account = ({
     const {nextRewardDetails, ...accountInfo} = await blockchainExplorer.getStakingInfo(
       stakingAddressHex
     )
-    const poolInfo = await getPoolInfo(accountInfo.delegation.url)
     const rewardDetails = await blockchainExplorer.getRewardDetails(
       nextRewardDetails,
       accountInfo.delegation.poolHash,
@@ -391,10 +390,6 @@ const Account = ({
 
     return {
       ...accountInfo,
-      delegation: {
-        ...accountInfo.delegation,
-        ...poolInfo,
-      },
       rewardDetails,
       value: accountInfo.rewards ? parseInt(accountInfo.rewards, 10) : 0,
     }

--- a/app/frontend/wallet/address-manager.ts
+++ b/app/frontend/wallet/address-manager.ts
@@ -1,6 +1,6 @@
 import {toBip32StringPath} from './helpers/bip32'
 import NamedError from '../helpers/NamedError'
-import {AddressProvider, BIP32Path, _Address} from '../types'
+import {AddressProvider, AddressToPathMapping, AddressWithMeta, BIP32Path, _Address} from '../types'
 import blockchainExplorer from './blockchain-explorer'
 
 type AddressManagerParams = {
@@ -54,7 +54,8 @@ const AddressManager = ({addressProvider, gapLimit, blockchainExplorer}: Address
 
   // TODO(ppershing): we can probably get this info more easily
   // just by testing filterUnusedAddresses() backend call
-  async function discoverAddressesWithMeta() {
+
+  async function discoverAddressesWithMeta(): Promise<AddressWithMeta[]> {
     const addresses = await discoverAddresses()
     const usedAddresses = await blockchainExplorer.filterUsedAddresses(addresses)
 
@@ -69,7 +70,8 @@ const AddressManager = ({addressProvider, gapLimit, blockchainExplorer}: Address
 
   // this is supposed to return {[key: _Address]: BIP32Path} but ts does support
   // only strings and number as index signatures
-  function getAddressToAbsPathMapping(): {[key: string]: BIP32Path} {
+
+  function getAddressToAbsPathMapping(): AddressToPathMapping {
     const result = {}
     Object.values(deriveAddressMemo).map((value) => {
       result[value.address] = value.path

--- a/app/frontend/wallet/blockchain-explorer.ts
+++ b/app/frontend/wallet/blockchain-explorer.ts
@@ -262,7 +262,7 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
     const poolMetaUrls = distinct(
       [...delegations, ...rewards]
         .filter(({name}) => !name)
-        .map((historyEntry) => extractUrl(historyEntry.poolHash))
+        .map(({poolHash}) => extractUrl(poolHash))
     ).filter((url) => url != null)
 
     const metaUrlToPoolNameMap = (await Promise.all(

--- a/app/tests/src/common/tx-settings.js
+++ b/app/tests/src/common/tx-settings.js
@@ -1,4 +1,6 @@
-const transactionPlanSettings = {
+const ttl = 8493834
+
+const transactionSettings = {
   donation: {
     args: {
       address:
@@ -42,6 +44,8 @@ const transactionPlanSettings = {
       fee: 183419,
       withdrawals: [],
     },
+    ttl,
+    txHash: '1ec20e39ecd3a4ecc0c53a7ff02a38492431a808eb4ed77c4f5cd73d1d234e5a',
   },
   delegation: {
     args: {
@@ -82,6 +86,8 @@ const transactionPlanSettings = {
       fee: 193878,
       withdrawals: [],
     },
+    ttl,
+    txHash: '14fbbd80cd9f04367cab3f81255816881629431bd54233c4c8bbf57001e352e0',
   },
   rewardWithdrawal: {
     args: {
@@ -115,7 +121,9 @@ const transactionPlanSettings = {
         },
       ],
     },
+    ttl,
+    txHash: '58d9451f5f28d6ee6e00c55cbd77645ea2888f155122619546f580a678ba24a4',
   },
 }
 
-export {transactionPlanSettings}
+export {transactionSettings}

--- a/app/tests/src/wallet/account.js
+++ b/app/tests/src/wallet/account.js
@@ -5,7 +5,7 @@ import mnemonicToWalletSecretDef from '../../../frontend/wallet/helpers/mnemonic
 import BlockchainExplorer from '../../../frontend/wallet/blockchain-explorer'
 import ShelleyJsCryptoProvider from '../../../frontend/wallet/shelley/shelley-js-crypto-provider'
 import {ADALITE_CONFIG} from '../../../frontend/config'
-import {transactionPlanSettings} from '../common/tx-plan-settings'
+import {transactionSettings} from '../common/tx-settings'
 import mockNetwork from '../common/mock'
 
 const accounts = {}
@@ -86,11 +86,21 @@ describe('Account info', () => {
 })
 
 describe('Tx plan', () => {
-  Object.entries(transactionPlanSettings).forEach(([name, setting]) =>
+  Object.entries(transactionSettings).forEach(([name, setting]) =>
     it(`should create the right tx plan for tx with ${name}`, async () => {
       const account = await accounts.ShelleyAccount0
       const txPlan = await account.getTxPlan({...setting.args})
       assert.deepEqual(txPlan, setting.plan)
+    })
+  )
+})
+
+describe('TxAux', () => {
+  Object.entries(transactionSettings).forEach(([name, setting]) =>
+    it(`should calcualte the right tx hash for tx with ${name}`, async () => {
+      const account = await accounts.ShelleyAccount0
+      const txHash = (await account.prepareTxAux(setting.plan, setting.ttl)).getId()
+      assert.deepEqual(txHash, setting.txHash)
     })
   )
 })


### PR DESCRIPTION
Changes: 

- Adds a simple tests for tx building just so we can refactor the tx building more safely
- Reorder state entries into groups so there are easier to track and work with
- Types sendAda, sendAmount and adds enum for tx plan type