### PR TITLE
Fix account discovery

### DIFF
--- a/app/frontend/wallet/account.ts
+++ b/app/frontend/wallet/account.ts
@@ -149,7 +149,7 @@ const MyAddresses = ({
   }
 
   async function areAddressesUsed() {
-    const baseExt = await baseExtAddrManager.discoverAddresses()
+    const baseExt = await baseExtAddrManager._deriveAddresses(0, gapLimit)
     return await blockchainExplorer.isSomeAddressUsed(baseExt)
   }
 


### PR DESCRIPTION
Changes:
- Check only for 20 addresses when discovering accounts

Motivation: 
- Previously we discovered all addresses and then called `isSomeAddressUsed` with all of them. So if a user had 60 used addresses we passed all of them to the endpoint even tho it allows only 50.
- the bug was "introduced" in commit https://github.com/vacuumlabs/adalite/commit/5c7232def7427d4cde727320d89000a745f7793a where discovery of internal addresses was dropped and there are generally fewer internal addresses as Adalite currently reuses them.


closes #838 