### PR TITLE
Fix "Cannot read property 'url'" for pools missing from validStakepools mapping

### DIFF
--- a/app/frontend/wallet/explorer-types.ts
+++ b/app/frontend/wallet/explorer-types.ts
@@ -6,7 +6,7 @@ export type HostedPoolMetadata = {
   extended?: string
 }
 
-type StakePoolInfo = {
+export type StakePoolInfo = {
   pledge: string
   margin: number
   fixedCost: string


### PR DESCRIPTION
Motivation: A user reported running into a `Cannot read property 'url' of undefined` error due to given pool not being among the "valid stake pools"

Changes:
* fix the logic fetching pool info to gracefully fall back to `UNKNOWN_POOL_NAME` if pool URL is missing

Testing:
* I was not able to reproduce the exact error, but I tested the wallet loads fine and given logic is triggered by logging from the respective function