### PR TITLE
Fix mirroring of wrong version of prettier dependency in app dir

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -59,6 +59,7 @@
     "minimist": "^1.2.2",
     "acorn": "^5.7.4",
     "kind-of": "^6.0.3",
-    "elliptic": "^6.5.3"
+    "elliptic": "^6.5.3",
+    "prettier": "^1.19.1"
   }
 }

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2751,10 +2751,10 @@ preact@^10.5.11:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.11.tgz#2c8a431f16613e442901068175771806cf1cc0f6"
   integrity sha512-BdtFePVilR1430kDuzh3VkkZktCmp8RTqHOjG8qesyGZXHNYJjdrjEBuc2f7O/vthhVENxJd0/aTjWtYeH46aw==
 
-prettier@^1.13.7:
-  version "1.13.7"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.7.tgz#850f3b8af784a49a6ea2d2eaa7ed1428a34b7281"
-  integrity sha512-KIU72UmYPGk4MujZGYMFwinB7lOf2LsDNGSOC8ufevsrPLISrZbNJlWstRi3m0AMuszbH+EFSQ/r6w56RSPK6w==
+prettier@^1.13.7, prettier@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test-chrome-headless": "cd app && yarn install && yarn test-chrome-headless",
     "mocha": "cd app && mocha-chrome --help",
     "eslint": "eslint . --max-warnings=0 --ext .ts,.tsx,.js,.jsx",
-    "fix": "prettier-eslint --write \"{{app/frontend,app/tests/src,server}/**/*.{ts,tsx,js,jsx,json,css},,package.json}\"",
+    "fix": "prettier-eslint --write \"{{app/frontend,app/tests/src,server}/**/*.{ts,tsx,js,jsx,json,css},package.json}\"",
     "heroku-postbuild": "cd app && yarn install && yarn build",
     "generate-cert": "test -e server.cert && echo \"certificate already exists\" || openssl req -nodes -new -x509 -keyout server.key -out server.cert -subj \"/C=US\""
   },


### PR DESCRIPTION
Motivation: optional chaining was not working in the codebase. Turned out that prettier-eslint was taking the wrong version of prettier in the app directory - it was mirroring a recursive dependency of fetch-mock (prettier version 1.13) which did not support that operation which resulted in the error:

```
prettier-eslint-cli [ERROR]: There was an error formatting "app/frontend/wallet/account.ts": 
    SyntaxError: Expression expected. (193:17)
      191 | }: AccountParams) => {
      192 |   const x = null
    > 193 |   console.log(x?.dsfd?.sdf)
          |                 ^
      194 | 
      195 |   const {
      196 |     getMaxDonationAmount: _getMaxDonationAmount,
        at e (/home/rafael/workplace/cardano/adalite/app/node_modules/prettier/parser-typescript.js:1:267)
        at Object.parse (/home/rafael/workplace/cardano/adalite/app/node_modules/prettier/parser-typescript.js:1:1844242)
        at Object.parse$2 [as parse] (/home/rafael/workplace/cardano/adalite/app/node_modules/prettier/index.js:7000:19)
        at coreFormat (/home/rafael/workplace/cardano/adalite/app/node_modules/prettier/index.js:10196:23)
        at format (/home/rafael/workplace/cardano/adalite/app/node_modules/prettier/index.js:10367:16)
        at formatWithCursor (/home/rafael/workplace/cardano/adalite/app/node_modules/prettier/index.js:10379:12)
        at /home/rafael/workplace/cardano/adalite/app/node_modules/prettier/index.js:31222:15
        at Object.format (/home/rafael/workplace/cardano/adalite/app/node_modules/prettier/index.js:31241:12)
        at prettify (/home/rafael/workplace/cardano/adalite/node_modules/prettier-eslint/dist/index.js:141:31)
        at format (/home/rafael/workplace/cardano/adalite/node_modules/prettier-eslint/dist/index.js:126:20)
failure formatting 1 file with prettier-eslint
```

As you can notice the failure occurred in node_modules in the app directory (even though prettier is being called from the project root :facepalm: )

`yarn why prettier` showed the following:

```
yarn why prettier         
yarn why v1.22.4
[1/4] Why do we have the module "prettier"...?
[2/4] Initialising dependency graph...
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "prettier@1.13.7"
info Reasons this module exists
   - "fetch-mock" depends on it
   - Hoisted from "fetch-mock#prettier"
info Disk size without dependencies: "7.89MB"
info Disk size with unique dependencies: "7.89MB"
info Disk size with transitive dependencies: "7.89MB"
info Number of shared dependencies: 0
Done in 0.31s.
```

So apparently the version of fetch mock we are using had prettier accidentally set as a non-development dependency...

Changes:
* force the same version of prettier used in the project root

Testing:
* tried sample code with optional chaining in the codebase and prettier no longer complained

Gotchas:
* yarn fix will modify a bunch of files - possibly due to the prettier version missalignement so far. The precommit hook which also runs the prettier does so only on staged changes that's why there are not so many changes now. Later on it is probably worth running `yarn fix` and fixing the pending linting errors