### PR TITLE
Type blockchain explorer endpoints

### DIFF
--- a/app/frontend/components/pages/delegations/stakingHistoryPage.tsx
+++ b/app/frontend/components/pages/delegations/stakingHistoryPage.tsx
@@ -6,7 +6,7 @@ import {getActiveAccountInfo, State} from '../../../state'
 import printAda from '../../../helpers/printAda'
 import CopyOnClick from '../../common/copyOnClick'
 import {EpochDateTime} from '../common'
-import {RewardType} from '../../../wallet/explorer-types'
+import {RewardType} from '../../../wallet/backend-types'
 import {
   StakingHistoryItemType,
   StakingHistoryObject,

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -198,3 +198,29 @@ export type StakepoolDataProvider = {
   getPoolInfoByPoolHash: (poolHash: string) => Stakepool
   hasTickerMapping: boolean
 }
+
+export type Utxo = {
+  txHash: string
+  address: string
+  coins: Lovelace
+  outputIndex: number
+}
+
+export type HostedPoolMetadata = {
+  name: string
+  description: string
+  ticker: string
+  homepage: string
+  extended?: string
+}
+
+export type RewardWithMetadata = NextRewardDetail & {
+  distributionEpoch?: number
+  pool: HostedPoolMetadata | Object // TODO after refactor
+}
+
+export type NextRewardDetailsFormatted = {
+  upcoming: Array<RewardWithMetadata>
+  nearest: RewardWithMetadata
+  currentDelegation: RewardWithMetadata
+}

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -1,4 +1,4 @@
-import {CaTxEntry, RewardType} from './wallet/explorer-types'
+import {CaTxEntry, NextRewardDetail, RewardType} from './wallet/backend-types'
 import {Network} from './wallet/types'
 
 export type BIP32Path = number[]
@@ -61,7 +61,7 @@ export type DerivationScheme = {
 }
 
 export type HexString = string
-export type TxSummaryEntry = CaTxEntry & {
+export type TxSummaryEntry = Omit<CaTxEntry, 'fee'> & {
   fee: Lovelace
   effect: Lovelace
 }

--- a/app/frontend/wallet/backend-types.ts
+++ b/app/frontend/wallet/backend-types.ts
@@ -1,12 +1,4 @@
-export type HostedPoolMetadata = {
-  name: string
-  description: string
-  ticker: string
-  homepage: string
-  extended?: string
-}
-
-export type StakePoolInfo = {
+type StakePoolInfo = {
   pledge: string
   margin: number
   fixedCost: string
@@ -15,7 +7,7 @@ export type StakePoolInfo = {
   homepage: string
 }
 
-export type StakePoolInfoExtended = StakePoolInfo & {
+type StakePoolInfoExtended = StakePoolInfo & {
   poolHash: string
   liveStake: string
   roa: string
@@ -78,17 +70,6 @@ export type BestSlotResponse = {
   Right: {
     bestSlot: number
   }
-}
-
-export type RewardWithMetadata = NextRewardDetail & {
-  distributionEpoch?: number
-  pool: HostedPoolMetadata | Object // TODO after refactor
-}
-
-export type NextRewardDetailsFormatted = {
-  upcoming: Array<RewardWithMetadata>
-  nearest: RewardWithMetadata
-  currentDelegation: RewardWithMetadata
 }
 
 export enum PoolRecommendationStatus {
@@ -157,16 +138,11 @@ export type TxSubmissionFailure = FailureResponse & {
   statusCode?: number
 }
 export type SubmitResponse = SuccessResponse<TxSubmission> | TxSubmissionFailure
-export type Utxo = {
+export type _Utxo = {
   tag: string
   cuId: string
   cuOutIndex: number
   cuAddress: string
   cuCoins: CoinObject
 }
-export type BulkAdressesUtxoResponse = SuccessResponse<Array<Utxo>> | TxSubmissionFailure
-
-export interface TxHistoryEntry extends Omit<CaTxEntry, 'fee'> {
-  fee: number
-  effect: number
-}
+export type BulkAdressesUtxoResponse = SuccessResponse<Array<_Utxo>> | TxSubmissionFailure

--- a/app/frontend/wallet/backend-types.ts
+++ b/app/frontend/wallet/backend-types.ts
@@ -1,4 +1,4 @@
-type StakePoolInfo = {
+export type StakePoolInfo = {
   pledge: string
   margin: number
   fixedCost: string

--- a/app/frontend/wallet/backend-types.ts
+++ b/app/frontend/wallet/backend-types.ts
@@ -86,8 +86,15 @@ export type PoolRecommendationResponse = StakePoolInfoExtended & {
   isInRecommendedPoolSet: boolean
 }
 
+export declare type Token = {
+  policyId: string
+  assetName: string
+  quantity: string // possibly huge amounts
+}
+
 export type CoinObject = {
   getCoin: string
+  getTokens: Token[]
 }
 
 export type AddressCoinTuple = [string, CoinObject]

--- a/app/frontend/wallet/blockchain-explorer.ts
+++ b/app/frontend/wallet/blockchain-explorer.ts
@@ -99,7 +99,12 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
       {caTxList: []}
     )
 
-    const txHistoryEntries = cachedAddressInfos.caTxList.map((tx) => {
+    const filteredTxs: {[ctbId: string]: CaTxEntry} = {}
+    cachedAddressInfos.caTxList.forEach((tx) => {
+      filteredTxs[tx.ctbId] = tx
+    })
+
+    const txHistoryEntries = Object.values(filteredTxs).map((tx) => {
       if (!tx.ctbId) captureMessage(`Tx without hash: ${JSON.stringify(tx)}`)
       let effect = 0 //effect on wallet balance accumulated
       for (const input of tx.ctbInputs || []) {
@@ -248,7 +253,7 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
   async function getStakingHistory(
     stakingKeyHashHex: HexString,
     validStakepoolDataProvider: StakepoolDataProvider
-  ): Promise<StakingHistoryObject[]>  {
+  ): Promise<StakingHistoryObject[]> {
     const delegationsUrl = `${ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL}/api/account/delegationHistory/${stakingKeyHashHex}`
     const rewardsUrl = `${ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL}/api/account/rewardHistory/${stakingKeyHashHex}`
     const withdrawalsUrl = `${ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL}/api/account/withdrawalHistory/${stakingKeyHashHex}`
@@ -431,9 +436,7 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
   }
 
   async function getStakingInfo(stakingKeyHashHex: HexString): Promise<StakingInfoResponse> {
-    const url = `${
-      ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL
-    }/api/account/info/${stakingKeyHashHex}`
+    const url = `${ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL}/api/account/info/${stakingKeyHashHex}`
     const response = await request(url)
     // if we fail to recieve poolMeta from backend
     // TODO: IMHO we shouldn't freestyle append poolInfo here, it breaks types easily

--- a/app/frontend/wallet/explorer-types.ts
+++ b/app/frontend/wallet/explorer-types.ts
@@ -165,3 +165,8 @@ export type Utxo = {
   cuCoins: CoinObject
 }
 export type BulkAdressesUtxoResponse = SuccessResponse<Array<Utxo>> | TxSubmissionFailure
+
+export interface TxHistoryEntry extends Omit<CaTxEntry, 'fee'> {
+  fee: number
+  effect: number
+}


### PR DESCRIPTION
- Separates backend types and frontend types regarding blockchain explorer
- Assigns types to each blockchain explorer endpoint
- Removes mutable logic from getTxsHistory 