### PR TITLE
Add handling of common Ledger errors, instruct to turn off ledger live

### DIFF
--- a/app/frontend/helpers/errorsWithHelp.ts
+++ b/app/frontend/helpers/errorsWithHelp.ts
@@ -6,6 +6,8 @@ const errorsWithHelp = new Set([
   'TrezorError',
   'DisconnectedDeviceDuringOperation',
   'TransportWebUSBGestureRequired',
+  'NotFoundError',
+  'AbortError',
   'Error',
 ])
 

--- a/app/frontend/translations.ts
+++ b/app/frontend/translations.ts
@@ -7,7 +7,7 @@ import {Lovelace, CryptoProviderFeature} from './types'
 const {ADALITE_MIN_DONATION_VALUE} = ADALITE_CONFIG
 
 const ledgerTroubleshootingSuggestion =
-  'If you are using Ledger, please try connecting your device using the "Connect with WebUSB" functionality (the button underneath "Unlock with Ledger"). For more information please read the section concerning Ledger in our troubleshooting suggestions.'
+  'If you are using Ledger, please make sure Ledger Live app is closed and try connecting your device using the "Connect with WebUSB" functionality (the button underneath "Unlock with Ledger"). For more information please read the section concerning Ledger in our troubleshooting suggestions.'
 
 const translations = {
   SendAddressInvalidAddress: () => 'Invalid address',
@@ -71,6 +71,8 @@ const translations = {
     `DisconnectedDeviceDuringOperation: ${ledgerTroubleshootingSuggestion}`,
   TransportWebUSBGestureRequired: () =>
     `TransportWebUSBGestureRequired: ${ledgerTroubleshootingSuggestion}`,
+  NotFoundError: () => `NotFoundError: ${ledgerTroubleshootingSuggestion}`,
+  AbortError: () => `NotFoundError: ${ledgerTroubleshootingSuggestion}`,
 
   TransactionRejectedByNetwork: () =>
     'TransactionRejectedByNetwork: Submitting the transaction into Cardano network failed. We received this error and we will investigate the cause.',


### PR DESCRIPTION
Motivation: Users are frequently reporting on Sentry NotFoundError and AbortError which after troubleshooting consistently turns out to be due to interference from Ledger Live (though I wasn't able to replicate it myself even on Windows).

Changes: add handling of the aformenetioned errors and update the troubleshooting suggestion for Ledger to explicitly instruct users to close Ledger Live

Testing:
* Adalite loads without problems locally, will see the effect upon deploying to production - given that those are just additions to an existing mapping and the handling logic still allows for sending the error to sentry, this should not have any negative impact

closes #856