### PR TITLE
Create multi assets page

### DIFF
--- a/app/frontend/components/common/asset.tsx
+++ b/app/frontend/components/common/asset.tsx
@@ -1,0 +1,59 @@
+import {h} from 'preact'
+import printAda from '../../helpers/printAda'
+import {AssetFamily, Lovelace, Token} from '../../types'
+import {StarIcon} from './svg'
+import LinkIcon from './linkIcon'
+
+type LinkToAssetProps = {
+  policyIdHex: string
+  assetNameHex: string
+}
+
+export const LinkToAsset = ({policyIdHex, assetNameHex}: LinkToAssetProps) => (
+  <LinkIcon url={`https://cardanoscan.io/token/${policyIdHex}.${assetNameHex}`} />
+)
+
+type FormattedAssetItemProps = Token & {
+  assetNameHex: string
+  type: AssetFamily
+  star?: boolean
+}
+
+// Use to share common formatting, but allow for usage in different layouts
+export const FormattedAssetItem = ({
+  type,
+  star,
+  assetName,
+  assetNameHex,
+  policyId,
+  quantity,
+  children,
+}: FormattedAssetItemProps & {
+  children: (props: {
+    starIcon: h.JSX.Element
+    formattedAssetName: h.JSX.Element | string
+    formattedAssetLink: h.JSX.Element
+    formattedAmount: string
+    formattedPolicy: h.JSX.Element
+  }) => h.JSX.Element
+}) => {
+  return children({
+    starIcon: star && <StarIcon />,
+    formattedAssetName: assetName || (
+      <span className="empty">
+        {'<'}no-name{'>'}
+      </span>
+    ),
+    formattedAssetLink: type === AssetFamily.TOKEN && (
+      <LinkToAsset policyIdHex={policyId} assetNameHex={assetNameHex} />
+    ),
+    formattedAmount:
+      type === AssetFamily.TOKEN ? `${quantity}` : printAda(Math.abs(quantity) as Lovelace),
+    formattedPolicy: policyId && (
+      <div className="multi-asset-hash">
+        <span className="ellipsis">{policyId.slice(0, -6)}</span>
+        <span>{policyId.slice(-6)}</span>
+      </div>
+    ),
+  })
+}

--- a/app/frontend/components/common/linkIcon.tsx
+++ b/app/frontend/components/common/linkIcon.tsx
@@ -1,0 +1,11 @@
+import {h} from 'preact'
+
+const LinkIcon = ({url}) => {
+  return (
+    <span className="link">
+      <a className="link-icon" href={url} target="_blank" rel="noopener" />
+    </span>
+  )
+}
+
+export default LinkIcon

--- a/app/frontend/components/pages/dashboard/dashboardPage.tsx
+++ b/app/frontend/components/pages/dashboard/dashboardPage.tsx
@@ -5,6 +5,7 @@ import Balance from '../../common/balance'
 import TransactionHistory from '../txHistory/transactionHistory'
 import ExportCard from '../exportWallet/exportCard'
 import SendAdaPage from '../sendAda/sendAdaPage'
+import MultiAssetsPage from '../sendAda/multiAssetsPage'
 import MyAddresses from '../receiveAda/myAddresses'
 import DelegatePage from '../delegations/delegatePage'
 import CurrentDelegationPage from '../delegations/currentDelegationPage'
@@ -86,8 +87,9 @@ const SendingPage = ({
             <Balance />
             <TransactionHistory />
           </div>
-          <div className="dashboard-column">
+          <div className="dashboard-column shrinkable">
             <SendAdaPage />
+            <MultiAssetsPage />
             <ReceiveRedirect />
             {shouldShowExportOption && <ExportCard />}
           </div>
@@ -161,11 +163,20 @@ const AccountsPage = ({screenType}: {screenType: ScreenType}) => {
   )
 }
 
+const MobileSendAdaPage = () => (
+  <Fragment>
+    <SendAdaPage />
+    <div className="mobile-multi-assets-page-wrapper">
+      <MultiAssetsPage />
+    </div>
+  </Fragment>
+)
+
 const SubPages: {[key in SubTabs]: any} = {
   [SubTabs.DELEGATE_ADA]: <DelegatePage />,
   [SubTabs.CURRENT_DELEGATION]: <CurrentDelegationPage />,
   [SubTabs.STAKING_HISTORY]: <StakingHistoryPage />,
-  [SubTabs.SEND_ADA]: <SendAdaPage />,
+  [SubTabs.SEND_ADA]: <MobileSendAdaPage />,
   [SubTabs.TRANSACTIONS]: <TransactionHistory />,
   [SubTabs.ADDRESSES]: <MyAddresses />,
   [SubTabs.KEYS]: <Keys />,

--- a/app/frontend/components/pages/delegations/common.tsx
+++ b/app/frontend/components/pages/delegations/common.tsx
@@ -1,4 +1,5 @@
 import CopyOnClick from '../../common/copyOnClick'
+import LinkIcon from '../../common/linkIcon'
 import {h} from 'preact'
 
 export const CopyPoolId = ({value}) => {
@@ -13,27 +14,10 @@ export const CopyPoolId = ({value}) => {
   )
 }
 
-export const LinkIcon = ({url}) => {
-  return (
-    <span className="link">
-      <a className="link-icon" href={url} target="_blank" rel="noopener" />
-    </span>
-  )
-}
-
 export const LinkIconToPool = ({poolHash}) => (
   <LinkIcon url={`https://cardanoscan.io/pool/${poolHash}`} />
 )
 
 export const LinkIconToKey = ({stakeKey}) => (
   <LinkIcon url={`https://cardanoscan.io/stakekey/${stakeKey}`} />
-)
-
-type LinkToAssetProps = {
-  policyIdHex: string
-  assetNameHex: string
-}
-
-export const LinkToAsset = ({policyIdHex, assetNameHex}: LinkToAssetProps) => (
-  <LinkIcon url={`https://cardanoscan.io/token/${policyIdHex}.${assetNameHex}`} />
 )

--- a/app/frontend/components/pages/sendAda/multiAssetsPage.tsx
+++ b/app/frontend/components/pages/sendAda/multiAssetsPage.tsx
@@ -1,0 +1,73 @@
+import {h} from 'preact'
+import {useSelector} from '../../../helpers/connect'
+import {getSourceAccountInfo, State} from '../../../state'
+import {AssetFamily, Token} from '../../../types'
+import {assetNameHex2Readable} from '../../../wallet/shelley/helpers/addresses'
+import {FormattedAssetItem} from '../../common/asset'
+import CopyOnClick from '../../common/copyOnClick'
+
+const MultiAssetsPage = () => {
+  const {tokenBalance} = useSelector((state: State) => getSourceAccountInfo(state))
+
+  const multiAssets = [
+    ...tokenBalance
+      .sort((a: Token, b: Token) => b.quantity - a.quantity)
+      .map((token: Token) => ({
+        ...token,
+        assetNameHex: token.assetName,
+        assetName: assetNameHex2Readable(token.assetName),
+        type: AssetFamily.TOKEN,
+        star: false,
+      })),
+  ]
+
+  // For now the layout is very similar as in `sendAdaPage`, however we expect it to change,
+  // therefore the duplication to allow for more versatility later on
+  return (
+    <div className="card">
+      <h2 className="card-title">Digital assets</h2>
+      <div className="multi-assets-page-list">
+        {multiAssets.map((asset) => (
+          <FormattedAssetItem key={asset.assetName} {...asset}>
+            {({
+              starIcon,
+              formattedAssetName,
+              formattedAssetLink,
+              formattedAmount,
+              formattedPolicy,
+            }) => {
+              return (
+                <div className="multi-asset-page-item multi-asset-item">
+                  <div className="multi-asset-name-amount">
+                    <div className="multi-asset-name">
+                      {starIcon}
+                      {formattedAssetName}
+                      {formattedAssetLink}
+                    </div>
+                    <div className="multi-asset-amount">{formattedAmount}</div>
+                  </div>
+                  <div className="multi-asset-page-policy">
+                    <CopyOnClick
+                      value={asset.policyId}
+                      elementClass="copy"
+                      tooltipMessage="Policy id copied to clipboard"
+                    >
+                      <div className="multi-asset-page-copy-on-click">
+                        {formattedPolicy}
+                        <div className="desktop">
+                          <span className="copy-text margin-left" />
+                        </div>
+                      </div>
+                    </CopyOnClick>
+                  </div>
+                </div>
+              )
+            }}
+          </FormattedAssetItem>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default MultiAssetsPage

--- a/app/frontend/components/pages/sendAda/sendAdaPage.tsx
+++ b/app/frontend/components/pages/sendAda/sendAdaPage.tsx
@@ -20,11 +20,11 @@ import {
   Token,
   TransactionSummary,
 } from '../../../types'
-import {AdaIcon, StarIcon} from '../../common/svg'
+import {AdaIcon} from '../../common/svg'
 import {parseCoins} from '../../../../frontend/helpers/validators'
 import {assetNameHex2Readable} from '../../../../frontend/wallet/shelley/helpers/addresses'
 import tooltip from '../../common/tooltip'
-import {LinkToAsset} from '../delegations/common'
+import {FormattedAssetItem} from '../../common/asset'
 
 const CalculatingFee = () => <div className="validation-message send">Calculating fee...</div>
 
@@ -76,38 +76,24 @@ type DropdownAssetItem = Token & {
   star?: boolean
 }
 
-const displayDropdownAssetItem = ({
-  type,
-  star,
-  assetName,
-  assetNameHex,
-  policyId,
-  quantity,
-}: DropdownAssetItem) => (
-  <div className="multi-asset-item">
-    <div className="multi-asset-name-amount">
-      <div className="multi-asset-name">
-        {star && <StarIcon />}
-        {assetName || (
-          <span className="empty">
-            {'<'}no-name{'>'}
-          </span>
-        )}
-        {type === AssetFamily.TOKEN && (
-          <LinkToAsset policyIdHex={policyId} assetNameHex={assetNameHex} />
-        )}
-      </div>
-      <div className="multi-asset-amount">
-        {type === AssetFamily.TOKEN ? quantity : printAda(Math.abs(quantity) as Lovelace)}
-      </div>
-    </div>
-    {policyId && (
-      <div className="multi-asset-hash">
-        <span className="ellipsis">{policyId.slice(0, -6)}</span>
-        <span>{policyId.slice(-6)}</span>
-      </div>
-    )}
-  </div>
+const displayDropdownAssetItem = (props: DropdownAssetItem) => (
+  <FormattedAssetItem key={props.assetName} {...props}>
+    {({starIcon, formattedAssetName, formattedAssetLink, formattedAmount, formattedPolicy}) => {
+      return (
+        <div className="multi-asset-item">
+          <div className="multi-asset-name-amount">
+            <div className="multi-asset-name">
+              {starIcon}
+              {formattedAssetName}
+              {formattedAssetLink}
+            </div>
+            <div className="multi-asset-amount">{formattedAmount}</div>
+          </div>
+          {formattedPolicy}
+        </div>
+      )
+    }}
+  </FormattedAssetItem>
 )
 
 const SendAdaPage = ({

--- a/app/frontend/components/pages/txHistory/transactionHistory.tsx
+++ b/app/frontend/components/pages/txHistory/transactionHistory.tsx
@@ -16,7 +16,7 @@ import {
   Token,
 } from '../../../types'
 import {AdaIcon, StarIcon} from '../../common/svg'
-import {LinkToAsset} from '../delegations/common'
+import {LinkToAsset} from '../../common/asset'
 import moment = require('moment')
 
 const FormattedAmount = ({amount}: {amount: Lovelace}): h.JSX.Element => {

--- a/app/public/css/0-767px.css
+++ b/app/public/css/0-767px.css
@@ -911,6 +911,11 @@
     margin-bottom: -24px;
   }
 
+  .mobile-multi-assets-page-wrapper {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
   /* ACCOUNTS */
   .accounts-wrapper {
     display: flex;

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -696,21 +696,21 @@ p.hey {
   display: none;
 }
 
-.searchable-select-item .multi-asset-item {
+.multi-asset-item {
   display: flex;
   flex-direction: column;
 }
 
-.searchable-select-item .multi-asset-name-amount {
+.multi-asset-name-amount {
   display: flex;
   justify-content: space-between;
 }
 
-.searchable-select-item .multi-asset-name {
+.multi-asset-name {
   margin: unset;
 }
 
-.searchable-select-item .multi-asset-amount {
+.multi-asset-amount {
   margin: unset;
   padding-right: 12px;
 }
@@ -3774,6 +3774,41 @@ input:checked + .slider:before {
 .review-bottom .button:first-child {
   margin-bottom: 32px;
 }
+
+/* MULTI ASSETS SCREEN: START */
+.mobile-multi-assets-page-wrapper {
+  margin-top: 32px;
+  margin-bottom: 32px;
+}
+
+.multi-asset-page-copy-on-click {
+  display: flex;
+}
+
+.multi-asset-page-policy .multi-asset-hash {
+  padding-right: 0;
+  max-width: calc(100% - 150px);
+}
+
+.multi-asset-page-item {
+  border-top: 1px solid var(--color-border);
+  padding: 4px 0;
+}
+
+.multi-assets-page-list {
+  /* Hack due to Tooltip being cut due to overflow property */
+  padding-top: 12px;
+  margin-top: -12px;
+
+  max-height: 300px;
+  overflow: auto;
+}
+
+.multi-asset-page-policy {
+  color: var(--color-grey);
+  padding-bottom: 8px;
+}
+/* MULTI ASSETS SCREEN: END */
 
 /* ANIMATIONS */
 


### PR DESCRIPTION
* Display "multi-assets" data from "sendAdaPage" in a standalone card & make it scrollable
* Adjust for all resolutions
* Create `FormattedAssetItem` for shared Asset formatting, with the freedom to use in any layout

// desktop
![a1](https://user-images.githubusercontent.com/10008234/110936564-60774f00-8331-11eb-851f-af6fafea4de8.png)

// mobile
![a2](https://user-images.githubusercontent.com/10008234/110936573-64a36c80-8331-11eb-9451-5cbda00290e4.png)

