### PR TITLE
Extend pool recommendation API

### DIFF
--- a/app/frontend/state.ts
+++ b/app/frontend/state.ts
@@ -252,7 +252,9 @@ const initialState: State = {
       stakingHistory: [],
       visibleAddresses: [],
       poolRecommendation: {
-        isInRecommendedPoolSet: true,
+        isInRecommendedPoolSet: false,
+        isInPrivatePoolSet: false,
+        isRecommendationPrivate: false,
         recommendedPoolHash: '',
         status: '',
         shouldShowSaturatedBanner: false,

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -111,6 +111,8 @@ export type Lovelace = number & {__typeLovelace: any}
 
 export type PoolRecommendation = {
   isInRecommendedPoolSet: boolean
+  isInPrivatePoolSet: boolean
+  isRecommendationPrivate: boolean
   recommendedPoolHash: string
   status: string
   shouldShowSaturatedBanner: boolean

--- a/app/frontend/wallet/backend-types.ts
+++ b/app/frontend/wallet/backend-types.ts
@@ -86,6 +86,8 @@ export type PoolRecommendationResponse = StakePoolInfoExtended & {
   status: PoolRecommendationStatus
   recommendedPoolHash: string
   isInRecommendedPoolSet: boolean
+  isInPrivatePoolSet: boolean
+  isRecommendationPrivate: boolean
 }
 
 export type TokenObject = {

--- a/app/frontend/wallet/blockchain-explorer.ts
+++ b/app/frontend/wallet/blockchain-explorer.ts
@@ -463,6 +463,8 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
       recommendedPoolHash: ADALITE_CONFIG.ADALITE_STAKE_POOL_ID,
       isInRecommendedPoolSet: true,
       status: 'GivedPoolOk',
+      isInPrivatePoolSet: false,
+      isRecommendationPrivate: false,
     }))
   }
 

--- a/app/tests/src/common/mock.js
+++ b/app/tests/src/common/mock.js
@@ -293,6 +293,8 @@ const mock = (ADALITE_CONFIG) => {
           recommendedPoolHash: ADALITE_CONFIG.ADALITE_STAKE_POOL_ID,
           isInRecommendedPoolSet: true,
           status: 'GivedPoolOk',
+          isInPrivatePoolSet: false,
+          isRecommendationPrivate: false,
         },
         sendAsJson: true,
       },


### PR DESCRIPTION
testable with changing
const url = `${ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL}/api/account/poolRecommendation/poolHash/${poolHash}/stake/${stakeAmount}`
to e.g.
const url = `${ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL}/api/account/poolRecommendation/poolHash/${poolHash}/stake/25000000000000`

and with staging explorer

For accounts with >=25M, recommend a private pool, handled by BE