### PR TITLE
Track crypto provider versions

### DIFF
--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -44,6 +44,7 @@ export interface CryptoProvider {
   ensureFeatureIsSupported: (feature: CryptoProviderFeature) => void
   isFeatureSupported: (feature: CryptoProviderFeature) => boolean
   displayAddressForPath: (absDerivationPath: BIP32Path, stakingPath: BIP32Path) => void
+  getVersion: () => string | null
 }
 
 // TODO: remove this and replace with TxCertificateType

--- a/app/frontend/wallet/shelley-wallet.ts
+++ b/app/frontend/wallet/shelley-wallet.ts
@@ -36,6 +36,8 @@ const ShelleyWallet = ({config, cryptoProvider}: WalletParams) => {
   function submitTx(signedTx): Promise<any> {
     const params = {
       walletType: getWalletName(),
+      walletVersion: cryptoProvider.getVersion(),
+      walletDerivationScheme: cryptoProvider.getDerivationScheme().type,
       // TODO: add stake key for debugging purposes
     }
     const {txBody, txHash} = signedTx

--- a/app/frontend/wallet/shelley/shelley-js-crypto-provider.ts
+++ b/app/frontend/wallet/shelley/shelley-js-crypto-provider.ts
@@ -48,6 +48,8 @@ CryptoProviderParams): Promise<CryptoProvider> => {
 
   const getDerivationScheme = () => derivationScheme
 
+  const getVersion = () => null
+
   const deriveXpub = CachedDeriveXpubFactory(
     derivationScheme,
     config.shouldExportPubKeyBulk,
@@ -179,6 +181,7 @@ CryptoProviderParams): Promise<CryptoProvider> => {
     ensureFeatureIsSupported,
     isFeatureSupported,
     displayAddressForPath,
+    getVersion,
   }
 }
 

--- a/app/frontend/wallet/shelley/shelley-ledger-crypto-provider.ts
+++ b/app/frontend/wallet/shelley/shelley-ledger-crypto-provider.ts
@@ -116,6 +116,8 @@ const ShelleyLedgerCryptoProvider = async ({
 
   const version = await ledger.getVersion()
 
+  const getVersion = (): string => `${version.major}.${version.minor}.${version.patch}`
+
   ensureFeatureIsSupported(CryptoProviderFeature.MINIMAL)
 
   const isHwWallet = () => true
@@ -421,6 +423,7 @@ const ShelleyLedgerCryptoProvider = async ({
     _sign: sign,
     isFeatureSupported,
     ensureFeatureIsSupported,
+    getVersion,
   }
 }
 

--- a/app/frontend/wallet/shelley/shelley-trezor-crypto-provider.ts
+++ b/app/frontend/wallet/shelley/shelley-trezor-crypto-provider.ts
@@ -62,14 +62,16 @@ const ShelleyTrezorCryptoProvider = async ({
     appUrl: config.ADALITE_SERVER_URL,
   })
 
-  const getVersion = async (): Promise<any> => {
+  const getTrezorVersion = async (): Promise<any> => {
     // TODO: add return type
     const {payload: features} = await TrezorConnect.getFeatures()
     const {major_version: major, minor_version: minor, patch_version: patch} = features
     return {major, minor, patch}
   }
 
-  const version = await getVersion()
+  const version = await getTrezorVersion()
+
+  const getVersion = (): string => `${version.major}.${version.minor}.${version.patch}`
 
   const isHwWallet = (): boolean => true
   const getWalletName = (): string => 'Trezor' // TODO: return enum
@@ -375,6 +377,7 @@ const ShelleyTrezorCryptoProvider = async ({
     ensureFeatureIsSupported,
     isFeatureSupported,
     getHdPassphrase,
+    getVersion,
   }
 }
 

--- a/server/helpers/parseTxBody.js
+++ b/server/helpers/parseTxBody.js
@@ -8,10 +8,11 @@ const parseTxBodyOutAmount = (txBody) => {
    * The following code works because AdaLite sends 1 or 2-output txs
    * depending on the presence of change address, and the first one
    * is always the amount intended to be sent out
-   * format - [txAux][outputs][0-th output][amount]
+   * format - [txAux]{1: outputs}[0-th output][amount]}
    * amount = coins | [coins, multiasset]
    */
-  const outputAmount = cbor.decode(txBody)[0].get(1)[0][1]
+  const firstTxOutput = cbor.decode(txBody)[0].get(1)[0]
+  const outputAmount = firstTxOutput ? firstTxOutput[1] : 0
   return coinsFromOutputAmount(outputAmount)
 }
 

--- a/server/middlewares/statsGoogleAnalytics.js
+++ b/server/middlewares/statsGoogleAnalytics.js
@@ -69,6 +69,8 @@ const trackTxSubmissions = mung.jsonAsync(async (body, req, res) => {
         : 'otherTxSubmissions'
     const txSubmissionSuccess = body.Right ? 'successful' : 'unsuccessful'
     const txWalletType = req.get('walletType')
+    const txWalletVersion = req.get('walletVersion')
+    const txWalletDerivationScheme = req.get('walletDerivationScheme')
 
     try {
       const baseEventData = {
@@ -81,6 +83,22 @@ const trackTxSubmissions = mung.jsonAsync(async (body, req, res) => {
         ...baseEventData,
         action: `${txSubmissionType}:${txWalletType}`,
         label: 'Wallet type',
+        value: undefined,
+      })
+
+      if (txWalletType === 'Mnemonic') {
+        await trackEvent({
+          ...baseEventData,
+          action: txWalletDerivationScheme,
+          label: 'Wallet derivation scheme',
+          value: undefined,
+        })
+      }
+
+      await trackEvent({
+        ...baseEventData,
+        action: txWalletVersion,
+        label: `${txWalletType} version`,
         value: undefined,
       })
 


### PR DESCRIPTION
Changes:
 - adds tracking of crypto provider version when submitting transaction
 - for mnemonic it tracks derivationScheme version
 - fixes zero output transactions in refis stats