### PR TITLE
Staking key deregister

### DIFF
--- a/app/frontend/components/pages/accounts/accountTile.tsx
+++ b/app/frontend/components/pages/accounts/accountTile.tsx
@@ -157,8 +157,6 @@ const AccountTile = ({
 
 export default connect(
   (state: State) => ({
-    shouldShowSendTransactionModal: state.shouldShowSendTransactionModal,
-    shouldShowDelegationModal: state.shouldShowDelegationModal,
     activeAccountIndex: state.activeAccountIndex,
   }),
   actions

--- a/app/frontend/components/pages/accounts/accountsDashboard.tsx
+++ b/app/frontend/components/pages/accounts/accountsDashboard.tsx
@@ -5,22 +5,17 @@ import printAda from '../../../helpers/printAda'
 import {State} from '../../../state'
 import {AdaIcon} from '../../common/svg'
 import Alert from '../../common/alert'
-import SendTransactionModal from './sendTransactionModal'
-import DelegationModal from './delegationModal'
-import ConfirmTransactionDialog from '../../../../frontend/components/pages/sendAda/confirmTransactionDialog'
 import AccountTile from './accountTile'
 import {AccountInfo, Lovelace} from '../../../../frontend/types'
 import Conversions from '../../common/conversions'
+import {hasStakingKey} from '../../../selectors'
 
 type DashboardProps = {
   accountsInfo: Array<AccountInfo>
   maxAccountIndex: number
   reloadWalletInfo: any
-  shouldShowSendTransactionModal: boolean
-  shouldShowDelegationModal: boolean
   totalWalletBalance: number
   totalRewardsBalance: number
-  shouldShowConfirmTransactionDialog: boolean
   conversionRates: any
 }
 
@@ -28,11 +23,8 @@ const AccountsDashboard = ({
   accountsInfo,
   maxAccountIndex,
   reloadWalletInfo,
-  shouldShowSendTransactionModal,
-  shouldShowDelegationModal,
   totalWalletBalance,
   totalRewardsBalance,
-  shouldShowConfirmTransactionDialog,
   conversionRates,
 }: DashboardProps) => {
   const InfoAlert = () => (
@@ -94,8 +86,6 @@ const AccountsDashboard = ({
 
   return (
     <Fragment>
-      {shouldShowSendTransactionModal && <SendTransactionModal />}
-      {shouldShowDelegationModal && <DelegationModal />}
       <div className="dashboard-column account">
         <div className="card account-aggregated">
           <div className="balance">
@@ -142,7 +132,9 @@ const AccountsDashboard = ({
                 <AccountTile
                   key={accountInfo.accountIndex}
                   accountIndex={accountInfo.accountIndex}
-                  ticker={accountInfo.shelleyAccountInfo.delegation.ticker}
+                  ticker={
+                    hasStakingKey(accountInfo) && accountInfo.shelleyAccountInfo.delegation.ticker
+                  }
                   availableBalance={accountInfo.balance}
                   rewardsBalance={accountInfo.shelleyBalances.rewardsAccountBalance}
                   shouldShowSaturatedBanner={
@@ -168,7 +160,6 @@ const AccountsDashboard = ({
           </div>
         </div>
       </div>
-      {shouldShowConfirmTransactionDialog && <ConfirmTransactionDialog />}
     </Fragment>
   )
 }
@@ -177,12 +168,9 @@ export default connect(
   (state: State) => ({
     accountsInfo: state.accountsInfo,
     maxAccountIndex: state.maxAccountIndex,
-    shouldShowSendTransactionModal: state.shouldShowSendTransactionModal,
-    shouldShowDelegationModal: state.shouldShowDelegationModal,
     activeAccountIndex: state.activeAccountIndex,
     totalRewardsBalance: state.totalRewardsBalance,
     totalWalletBalance: state.totalWalletBalance,
-    shouldShowConfirmTransactionDialog: state.shouldShowConfirmTransactionDialog,
     // TODO: refactor to get .data elsewhere
     conversionRates: state.conversionRates && state.conversionRates.data,
   }),

--- a/app/frontend/components/pages/dashboard/dashboardPage.tsx
+++ b/app/frontend/components/pages/dashboard/dashboardPage.tsx
@@ -8,6 +8,7 @@ import SendAdaPage from '../sendAda/sendAdaPage'
 import MultiAssetsPage from '../sendAda/multiAssetsPage'
 import MyAddresses from '../receiveAda/myAddresses'
 import DelegatePage from '../delegations/delegatePage'
+import DeregisterStakeKeyPage from '../delegations/deregisterStakeKey'
 import CurrentDelegationPage from '../delegations/currentDelegationPage'
 import StakingHistoryPage from '../delegations/stakingHistoryPage'
 import ShelleyBalances from '../delegations/shelleyBalances'
@@ -29,6 +30,9 @@ import {useViewport, isSmallerThanDesktop} from '../../common/viewPort'
 import {ScreenType} from '../../../types'
 import ReceiveRedirect from '../receiveAda/receiveRedirect'
 import {formatAccountIndex} from '../../../helpers/formatAccountIndex'
+import ConfirmTransactionDialog from '../sendAda/confirmTransactionDialog'
+import SendTransactionModal from '../accounts/sendTransactionModal'
+import DelegationModal from '../accounts/delegationModal'
 
 const StakingPage = ({screenType}: {screenType: ScreenType}) => {
   const subTabs = [SubTabs.DELEGATE_ADA, SubTabs.CURRENT_DELEGATION, SubTabs.STAKING_HISTORY]
@@ -53,6 +57,7 @@ const StakingPage = ({screenType}: {screenType: ScreenType}) => {
           <div className="dashboard-column">
             <DelegatePage />
             <CurrentDelegationPage />
+            <DeregisterStakeKeyPage />
           </div>
         </div>
       )}
@@ -174,7 +179,12 @@ const MobileSendAdaPage = () => (
 
 const SubPages: {[key in SubTabs]: any} = {
   [SubTabs.DELEGATE_ADA]: <DelegatePage />,
-  [SubTabs.CURRENT_DELEGATION]: <CurrentDelegationPage />,
+  [SubTabs.CURRENT_DELEGATION]: (
+    <Fragment>
+      <CurrentDelegationPage />
+      <DeregisterStakeKeyPage />
+    </Fragment>
+  ),
   [SubTabs.STAKING_HISTORY]: <StakingHistoryPage />,
   [SubTabs.SEND_ADA]: <MobileSendAdaPage />,
   [SubTabs.TRANSACTIONS]: <TransactionHistory />,
@@ -198,6 +208,9 @@ type Props = {
   shouldShowSaturatedBanner: boolean
   activeAccountIndex: number
   shouldShowExportOption: boolean
+  shouldShowConfirmTransactionDialog: boolean
+  shouldShowSendTransactionModal: boolean
+  shouldShowDelegationModal: boolean
 }
 
 const DashboardPage = ({
@@ -211,6 +224,9 @@ const DashboardPage = ({
   shouldShowSaturatedBanner,
   activeAccountIndex,
   shouldShowExportOption,
+  shouldShowConfirmTransactionDialog,
+  shouldShowSendTransactionModal,
+  shouldShowDelegationModal,
 }: Props) => {
   const screenType = useViewport()
 
@@ -226,6 +242,11 @@ const DashboardPage = ({
   return (
     <div className="page-wrapper">
       <ErrorModals />
+      {/* `SendTransactionModal` and `DelegationModal` should be before
+      `ConfirmTransactionDialog` */}
+      {shouldShowSendTransactionModal && <SendTransactionModal />}
+      {shouldShowDelegationModal && <DelegationModal />}
+      {shouldShowConfirmTransactionDialog && <ConfirmTransactionDialog />}
       {shouldShowWantedAddressesModal && <WantedAddressesModal />}
       {isShelleyCompatible && displayInfoModal && <InfoModal />}
       {shouldShowNonShelleyCompatibleDialog && <NotShelleyCompatibleDialog />}
@@ -287,6 +308,9 @@ export default connect(
     activeAccountIndex: state.activeAccountIndex,
     shouldShowExportOption: state.shouldShowExportOption,
     shouldShowWantedAddressesModal: state.shouldShowWantedAddressesModal,
+    shouldShowConfirmTransactionDialog: state.shouldShowConfirmTransactionDialog,
+    shouldShowSendTransactionModal: state.shouldShowSendTransactionModal,
+    shouldShowDelegationModal: state.shouldShowDelegationModal,
   }),
   actions
 )(DashboardPage)

--- a/app/frontend/components/pages/delegations/currentDelegationPage.tsx
+++ b/app/frontend/components/pages/delegations/currentDelegationPage.tsx
@@ -8,6 +8,7 @@ import {EpochDateTime} from '../common'
 import roundNumber from './../../../helpers/roundNumber'
 import {SATURATION_POINT} from '../../../wallet/constants'
 import {Lovelace} from '../../../types'
+import {useIsActiveAccountDelegating} from '../../../selectors'
 
 const SaturationInfo = (pool) => {
   if (pool.liveStake == null) return <Fragment />
@@ -29,10 +30,11 @@ const CurrentDelegationPage = ({
   nearestReward,
   currentDelegationReward,
 }) => {
+  const isDelegating = useIsActiveAccountDelegating()
   return (
     <div className="current-delegation card">
       <h2 className="card-title small-margin">Current Delegation</h2>
-      {Object.keys(pool).length ? (
+      {isDelegating ? (
         <div>
           <div className="current-delegation-wrapper">
             <div className="current-delegation-name">

--- a/app/frontend/components/pages/delegations/delegatePage.tsx
+++ b/app/frontend/components/pages/delegations/delegatePage.tsx
@@ -5,7 +5,6 @@ import tooltip from '../../common/tooltip'
 import printAda from '../../../helpers/printAda'
 import {AdaIcon} from '../../common/svg'
 import {getTranslation} from '../../../translations'
-import ConfirmTransactionDialog from '../../pages/sendAda/confirmTransactionDialog'
 import {getSourceAccountInfo, State} from '../../../state'
 import Accordion from '../../common/accordion'
 import {Lovelace, PoolRecommendation, Stakepool} from '../../../types'
@@ -52,7 +51,6 @@ interface Props {
   calculatingDelegationFee: boolean
   delegationValidationError: any
   isShelleyCompatible: boolean
-  shouldShowConfirmTransactionDialog: boolean
   txSuccessTab: string
   gettingPoolInfo: boolean
   poolRecommendation: PoolRecommendation
@@ -70,7 +68,6 @@ const Delegate = ({
   calculatingDelegationFee,
   delegationValidationError,
   isShelleyCompatible,
-  shouldShowConfirmTransactionDialog,
   txSuccessTab,
   gettingPoolInfo,
   poolRecommendation,
@@ -134,7 +131,6 @@ const Delegate = ({
           ),
         ]}
       </div>
-      {shouldShowConfirmTransactionDialog && <ConfirmTransactionDialog isDelegation />}
     </Fragment>
   )
 
@@ -169,7 +165,6 @@ export default connect(
     calculatingDelegationFee: state.calculatingDelegationFee,
     delegationFee: state.shelleyDelegation.delegationFee,
     delegationValidationError: state.delegationValidationError,
-    shouldShowConfirmTransactionDialog: state.shouldShowConfirmTransactionDialog,
     txSuccessTab: state.txSuccessTab,
     gettingPoolInfo: state.gettingPoolInfo,
     isShelleyCompatible: state.isShelleyCompatible,

--- a/app/frontend/components/pages/delegations/deregisterStakeKey.tsx
+++ b/app/frontend/components/pages/delegations/deregisterStakeKey.tsx
@@ -1,0 +1,25 @@
+import {h} from 'preact'
+import {useActions} from '../../../helpers/connect'
+import actions from '../../../actions'
+import {useIsActiveAccountDelegating} from '../../../selectors'
+
+const DeregisterStakeKeyPage = () => {
+  const {deregisterStakingKey} = useActions(actions)
+  const isDelegating = useIsActiveAccountDelegating()
+
+  if (!isDelegating) return null
+
+  return (
+    <div className="deregister-stake-key-card card">
+      <h2 className="card-title small-margin">Stake Key Deregistration</h2>
+      <p className="deregister-stake-key-card-disclaimer">
+        ...if you do not want to use this wallet anymore
+      </p>
+      <button className="button secondary cancel-delegation" onClick={() => deregisterStakingKey()}>
+        Deregister stake key
+      </button>
+    </div>
+  )
+}
+
+export default DeregisterStakeKeyPage

--- a/app/frontend/components/pages/delegations/stakingHistoryPage.tsx
+++ b/app/frontend/components/pages/delegations/stakingHistoryPage.tsx
@@ -169,11 +169,12 @@ const StakingHistoryObjectToItem = {
   [StakingHistoryItemType.REWARD_WITHDRAWAL]: (x: StakingHistoryObject) => (
     <RewardWithdrawalItem rewardWithdrawal={x as RewardWithdrawal} />
   ),
-  // Temporary disabled because of db-sync issue
-  // [StakingHistoryItemType.StakingKeyRegistration]: (x: StakingHistoryObject) => (
-  //   <StakingKeyRegistrationItem stakingKeyRegistration={x as StakingKeyRegistration} />
-  // ),
-  [StakingHistoryItemType.STAKING_KEY_REGISTRATION]: (x: StakingHistoryObject) => '',
+  [StakingHistoryItemType.STAKING_KEY_DEREGISTRATION]: (x: StakingHistoryObject) => (
+    <StakingKeyRegistrationItem stakingKeyRegistration={x as StakingKeyRegistration} />
+  ),
+  [StakingHistoryItemType.STAKING_KEY_REGISTRATION]: (x: StakingHistoryObject) => (
+    <StakingKeyRegistrationItem stakingKeyRegistration={x as StakingKeyRegistration} />
+  ),
 }
 
 class StakingHistoryPage extends Component<Props> {

--- a/app/frontend/components/pages/sendAda/sendAdaPage.tsx
+++ b/app/frontend/components/pages/sendAda/sendAdaPage.tsx
@@ -5,7 +5,6 @@ import actions from '../../../actions'
 import {getTranslation} from '../../../translations'
 import printAda from '../../../helpers/printAda'
 
-import ConfirmTransactionDialog from './confirmTransactionDialog'
 import Conversions from '../../common/conversions'
 import SearchableSelect from '../../common/searchableSelect'
 
@@ -52,7 +51,6 @@ interface Props {
   updateAddress: any
   updateAmount: (sendAmount: SendAmount) => void
   confirmTransaction: any
-  shouldShowConfirmTransactionDialog: any
   feeRecalculating: any
   sendMaxFunds: any
   conversionRates: any
@@ -105,7 +103,6 @@ const SendAdaPage = ({
   updateAddress,
   updateAmount,
   confirmTransaction,
-  shouldShowConfirmTransactionDialog,
   feeRecalculating,
   sendMaxFunds,
   conversionRates,
@@ -409,7 +406,6 @@ const SendAdaPage = ({
           />
         )}
       </div>
-      {shouldShowConfirmTransactionDialog && !isModal && <ConfirmTransactionDialog />}
     </div>
   )
 }
@@ -426,7 +422,6 @@ export default connect(
     sendAddress: state.sendAddress.fieldValue,
     sendAmountValidationError: state.sendAmountValidationError,
     sendAmount: state.sendAmount,
-    shouldShowConfirmTransactionDialog: state.shouldShowConfirmTransactionDialog,
     feeRecalculating: state.calculatingFee,
     conversionRates: state.conversionRates && state.conversionRates.data,
     sendTransactionSummary: state.sendTransactionSummary,

--- a/app/frontend/selectors.ts
+++ b/app/frontend/selectors.ts
@@ -1,0 +1,19 @@
+import {useSelector} from './helpers/connect'
+import {getActiveAccountInfo} from './state'
+import {AccountInfo} from './types'
+
+/*
+This file contains hooks shared accross multiple components which
+use global state to infer return values.
+Once "actions.ts" is divided into multiple files consider to also divide this file.
+*/
+
+export const useActiveAccount = () => useSelector((state) => getActiveAccountInfo(state))
+
+export const hasStakingKey = (account: AccountInfo) => account.shelleyAccountInfo.hasStakingKey
+
+export const useIsActiveAccountDelegating = (): boolean => {
+  const activeAccount = useActiveAccount()
+  const pool = activeAccount.shelleyAccountInfo.delegation
+  return hasStakingKey(activeAccount) && Object.keys(pool).length > 0
+}

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -154,6 +154,7 @@ export const enum TxType {
   DELEGATE,
   WITHDRAW,
   POOL_REG_OWNER,
+  DEREGISTER_STAKE_KEY,
 }
 
 export enum StakingHistoryItemType {
@@ -161,6 +162,7 @@ export enum StakingHistoryItemType {
   STAKING_REWARD,
   REWARD_WITHDRAWAL,
   STAKING_KEY_REGISTRATION,
+  STAKING_KEY_DEREGISTRATION,
 }
 
 export interface StakingHistoryObject {
@@ -239,12 +241,19 @@ export type PoolOwnerTxPlanArgs = {
   unsignedTxParsed: _UnsignedTxParsed
 }
 
+export type DeregisterStakingKeyTxPlanArgs = {
+  txType: TxType.DEREGISTER_STAKE_KEY
+  rewards: Lovelace
+  stakingAddress: Address
+}
+
 export type TxPlanArgs =
   | SendAdaTxPlanArgs
   | ConvertLegacyAdaTxPlanArgs
   | WithdrawRewardsTxPlanArgs
   | DelegateAdaTxPlanArgs
   | PoolOwnerTxPlanArgs
+  | DeregisterStakingKeyTxPlanArgs
 
 export type HostedPoolMetadata = {
   name: string
@@ -295,7 +304,12 @@ export type TransactionSummary = {
   type: TxType
   fee: Lovelace
   plan: TxPlan
-} & (SendTransactionSummary | WithdrawTransactionSummary | DelegateTransactionSummary)
+} & (
+  | SendTransactionSummary
+  | WithdrawTransactionSummary
+  | DelegateTransactionSummary
+  | DeregisterStakingKeyTransactionSummary
+)
 
 export type SendTransactionSummary = {
   type: TxType.SEND_ADA | TxType.CONVERT_LEGACY
@@ -303,6 +317,12 @@ export type SendTransactionSummary = {
   token: Token | null
   address: Address
   minimalLovelaceAmount: Lovelace
+}
+
+export type DeregisterStakingKeyTransactionSummary = {
+  type: TxType.DEREGISTER_STAKE_KEY
+  deposit: Lovelace
+  rewards: Lovelace
 }
 
 export type WithdrawTransactionSummary = {

--- a/app/frontend/wallet/blockchain-explorer.ts
+++ b/app/frontend/wallet/blockchain-explorer.ts
@@ -376,10 +376,13 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
       return rewardWithdrawal
     })
 
-    // Prepare staking key registration
+    // Prepare staking key registration/deregistration
     const parsedStakingKeyRegistrations = stakingKeyRegistrations.map((registration) => {
       const stakingKeyRegistration: StakingKeyRegistration = {
-        type: StakingHistoryItemType.STAKING_KEY_REGISTRATION,
+        type:
+          registration.action === 'registration'
+            ? StakingHistoryItemType.STAKING_KEY_REGISTRATION
+            : StakingHistoryItemType.STAKING_KEY_DEREGISTRATION,
         txHash: registration.txHash,
         epoch: registration.epochNo,
         dateTime: new Date(registration.time),

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -4322,3 +4322,68 @@ label.button.primary.disabled {
 .dashboard-tab:hover {
   cursor: pointer;
 }
+
+/* STAKE KEY DEREGISTER: (START) */
+.deregister-stake-key-card {
+  background: repeating-linear-gradient(
+    45deg,
+    #F7F7F7,
+    #F7F7F7 12px,
+    #FFFFFF 12px,
+    #FFFFFF 20px
+  );
+}
+
+.deregister-stake-key-card-disclaimer {
+  margin-bottom: 8px;
+  color: var(--color-grey);
+}
+
+.button.secondary.cancel-delegation {
+  position: relative;
+  padding-top: 0;
+  padding-bottom: 0;
+  padding-left: 40px;
+}
+
+.cancel-delegation::before {
+  background-image: url('../assets/alert_icon_danger.svg');
+  content: '';
+  position: absolute;
+  left: 8px;
+  top: 5px;
+  width: 20px;
+  height: 20px;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
+}
+
+.button.secondary.cancel-delegation:hover {
+  color: var(--color-red);
+}
+
+.review.deregister-staking-key {
+  grid-template-columns: 160px 1fr;
+  margin-left: 30px;
+  margin-bottom: 32px;
+}
+
+.review.deregister-staking-key .review-fee::before {
+  left: -220px;
+  width: 310px;
+}
+
+.checkbox.deregister-stake-key-check {
+  margin-bottom: 40px;
+}
+
+.modal-body .deregister-staking-key-dialog .alert {
+  margin-top: 0px;
+  margin-left: -22px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+  border: none;
+}
+
+/* STAKE KEY DEREGISTER: (END) */


### PR DESCRIPTION
* Add deregister stake key option
* Refactor modals to be only "centralized" in a single place (due to showing transaction modal from "advanced" tab, though it was finally decided not to be used from there, I still find the refactor useful)
* Texts & visuals of confirmation dialog are inspired by Yoroi
* I tried to divide it into more commits to make it easier to follow

Help wanted in: :pray: 
1. Are there some other dialogs that I might be not aware of and could get broken with this refactor? I tested "transfer/delegate" from accounts screen and those worked fine for me
