### PR TITLE
Remove balances from global state

### DIFF
--- a/app/frontend/components/pages/accounts/accountsDashboard.tsx
+++ b/app/frontend/components/pages/accounts/accountsDashboard.tsx
@@ -3,12 +3,16 @@ import {connect} from '../../../helpers/connect'
 import actions from '../../../actions'
 import printAda from '../../../helpers/printAda'
 import {State} from '../../../state'
+import {
+  totalWalletBalanceSelector,
+  totalRewardsBalanceSelector,
+  hasStakingKey,
+} from '../../../selectors'
 import {AdaIcon} from '../../common/svg'
 import Alert from '../../common/alert'
 import AccountTile from './accountTile'
 import {AccountInfo, Lovelace} from '../../../../frontend/types'
 import Conversions from '../../common/conversions'
-import {hasStakingKey} from '../../../selectors'
 
 type DashboardProps = {
   accountsInfo: Array<AccountInfo>
@@ -169,10 +173,10 @@ export default connect(
     accountsInfo: state.accountsInfo,
     maxAccountIndex: state.maxAccountIndex,
     activeAccountIndex: state.activeAccountIndex,
-    totalRewardsBalance: state.totalRewardsBalance,
-    totalWalletBalance: state.totalWalletBalance,
     // TODO: refactor to get .data elsewhere
     conversionRates: state.conversionRates && state.conversionRates.data,
+    totalWalletBalance: totalWalletBalanceSelector(state),
+    totalRewardsBalance: totalRewardsBalanceSelector(state),
   }),
   actions
 )(AccountsDashboard)

--- a/app/frontend/components/pages/dashboard/dashboardPage.tsx
+++ b/app/frontend/components/pages/dashboard/dashboardPage.tsx
@@ -28,6 +28,7 @@ import {useState} from 'preact/hooks'
 import {SubTabs, MainTabs} from '../../../constants'
 import {useViewport, isSmallerThanDesktop} from '../../common/viewPort'
 import {ScreenType} from '../../../types'
+import {shouldShowPremiumBannerSelector} from '../../../selectors'
 import ReceiveRedirect from '../receiveAda/receiveRedirect'
 import {formatAccountIndex} from '../../../helpers/formatAccountIndex'
 import ConfirmTransactionDialog from '../sendAda/confirmTransactionDialog'
@@ -303,7 +304,7 @@ export default connect(
     displayInfoModal: state.displayInfoModal,
     isShelleyCompatible: state.isShelleyCompatible,
     shouldShowNonShelleyCompatibleDialog: state.shouldShowNonShelleyCompatibleDialog,
-    shouldShowPremiumBanner: state.shouldShowPremiumBanner,
+    shouldShowPremiumBanner: shouldShowPremiumBannerSelector(state),
     shouldShowSaturatedBanner: state.shouldShowSaturatedBanner,
     activeAccountIndex: state.activeAccountIndex,
     shouldShowExportOption: state.shouldShowExportOption,

--- a/app/frontend/components/pages/delegations/delegatePage.tsx
+++ b/app/frontend/components/pages/delegations/delegatePage.tsx
@@ -8,6 +8,7 @@ import {getTranslation} from '../../../translations'
 import {getSourceAccountInfo, State} from '../../../state'
 import Accordion from '../../common/accordion'
 import {Lovelace, PoolRecommendation, Stakepool} from '../../../types'
+import {isBigDelegatorSelector} from '../../../selectors'
 import {StakePoolInfo} from './stakePoolInfo'
 import DelegateInput from './delegateInput'
 
@@ -170,7 +171,7 @@ export default connect(
     isShelleyCompatible: state.isShelleyCompatible,
     poolRecommendation: getSourceAccountInfo(state).poolRecommendation,
     pool: getSourceAccountInfo(state).shelleyAccountInfo.delegation,
-    isBigDelegator: state.isBigDelegator,
+    isBigDelegator: isBigDelegatorSelector(state),
   }),
   actions
 )(Delegate)

--- a/app/frontend/selectors.ts
+++ b/app/frontend/selectors.ts
@@ -1,16 +1,39 @@
+import {State, getActiveAccountInfo} from './state'
+import {BIG_DELEGATOR_THRESHOLD, PREMIUM_MEMBER_BALANCE_TRESHOLD} from './wallet/constants'
 import {useSelector} from './helpers/connect'
-import {getActiveAccountInfo} from './state'
 import {AccountInfo} from './types'
 
 /*
-This file contains hooks shared accross multiple components which
+This file contains hooks/selectors shared accross multiple components which
 use global state to infer return values.
 Once "actions.ts" is divided into multiple files consider to also divide this file.
 */
 
-export const useActiveAccount = () => useSelector((state) => getActiveAccountInfo(state))
+export const totalWalletBalanceSelector = (state: State): number =>
+  state.accountsInfo.reduce((a, {balance}) => balance + a, 0)
 
-export const hasStakingKey = (account: AccountInfo) => account.shelleyAccountInfo.hasStakingKey
+export const totalRewardsBalanceSelector = (state: State): number =>
+  state.accountsInfo.reduce((a, {shelleyBalances}) => shelleyBalances.rewardsAccountBalance + a, 0)
+
+export const isBigDelegatorSelector = (state: State): boolean => {
+  const totalWalletBalance = totalWalletBalanceSelector(state)
+  return totalWalletBalance > BIG_DELEGATOR_THRESHOLD
+}
+
+export const shouldShowPremiumBannerSelector = (state: State): boolean => {
+  const totalWalletBalance = totalWalletBalanceSelector(state)
+  return !state.seenPremiumBanner && PREMIUM_MEMBER_BALANCE_TRESHOLD < totalWalletBalance
+}
+
+/*
+TODO: decide where to keep such hooks & utils which are not really "selectors".
+As we are "in-the-middle-of-refactor", it is kept there.
+*/
+export const useActiveAccount = (): AccountInfo =>
+  useSelector((state) => getActiveAccountInfo(state))
+
+export const hasStakingKey = (account: AccountInfo): boolean =>
+  account.shelleyAccountInfo.hasStakingKey
 
 export const useIsActiveAccountDelegating = (): boolean => {
   const activeAccount = useActiveAccount()

--- a/app/frontend/state.ts
+++ b/app/frontend/state.ts
@@ -34,7 +34,7 @@ export interface State {
   displayWelcome: boolean
   shouldShowStakingBanner: boolean
   displayInfoModal: boolean
-  shouldShowPremiumBanner?: boolean
+  seenPremiumBanner: boolean
   shouldShowWantedAddressesModal: boolean
 
   // login / logout
@@ -48,7 +48,6 @@ export interface State {
   walletLoadingError?: any
   shouldShowWalletLoadingErrorModal?: boolean
   usingHwWallet?: boolean
-  isBigDelegator: boolean
   shouldShowSaturatedBanner?: boolean
   mnemonicAuthForm: {
     mnemonicInputValue: string
@@ -115,8 +114,6 @@ export interface State {
   sourceAccountIndex: number
   activeAccountIndex: number
   targetAccountIndex: number
-  totalWalletBalance: number
-  totalRewardsBalance: number
 
   shouldShowSendTransactionModal: boolean
   shouldShowDelegationModal: boolean
@@ -150,9 +147,7 @@ const initialState: State = {
   shouldShowStakingBanner: !(
     window.localStorage.getItem(localStorageVars.STAKING_BANNER) === 'true'
   ),
-  shouldShowPremiumBanner: !(
-    window.localStorage.getItem(localStorageVars.PREMIUM_BANNER) === 'true'
-  ),
+  seenPremiumBanner: window.localStorage.getItem(localStorageVars.PREMIUM_BANNER) === 'true',
   shouldShowWantedAddressesModal: false,
   displayInfoModal: !(window.localStorage.getItem(localStorageVars.INFO_MODAL) === 'true'),
 
@@ -167,7 +162,6 @@ const initialState: State = {
   walletIsLoaded: false,
   isShelleyCompatible: true,
   shouldShowNonShelleyCompatibleDialog: false,
-  isBigDelegator: false,
   mnemonicAuthForm: {
     mnemonicInputValue: '',
     mnemonicInputError: null,
@@ -272,8 +266,6 @@ const initialState: State = {
   sourceAccountIndex: 0,
   activeAccountIndex: 0,
   targetAccountIndex: 0,
-  totalWalletBalance: 0,
-  totalRewardsBalance: 0,
 
   shouldShowSendTransactionModal: false,
   shouldShowDelegationModal: false,


### PR DESCRIPTION
**Keys removed from global state**
-> totalWalletBalance
-> totalRewardsBalance

Due to the above refactor those further changes were needed:
-> `isBigDelegator` key was removed and  selector introduced
-> `shouldShowPremiumBanner` was reworked

**shouldShowPremiumBanner**
-> localStorage key renamed to `seenPremiumBanner` as otherwise initial value of `shouldShowPremiumBanner`
is misleading (it could be `true` even though we later override it `false` due to not enough funds)
-> by naming it `seenPremiumBanner` it only focuses on whether the user saw it, and whether to display banner
is decided by the selector

**other notes**
* no "memoization" as for now selectors do not perform any "complex" computations
* what do you think about "selector" postfix? Do you find it redundant or like that it is explicit?
* For easier review, I skipped exchanging `connect` for `useActions | useSelector` for now (I can then push it as a second commit)

Please share your ideas about those changes and whether you have some other tips how to make this refactor more meaningful. I then plan to remove other "redundant" keys in a similar fashion.
