### PR TITLE
Avoid redirect for review apps

### DIFF
--- a/server/helpers/loadConfig.js
+++ b/server/helpers/loadConfig.js
@@ -73,7 +73,8 @@ const {
   PORT,
   REDIS_URL,
   ADALITE_ENABLE_DEBUGGING,
-  ADALITE_SERVER_URL,
+  HEROKU_APP_NAME,
+  HEROKU_IS_REVIEW_APP,
   ADALITE_BLOCKCHAIN_EXPLORER_URL,
   ADALITE_DEFAULT_ADDRESS_COUNT,
   ADALITE_GAP_LIMIT,
@@ -101,6 +102,19 @@ const {
   ADALITE_ENABLE_TREZOR,
   ADALITE_ENABLE_LEDGER,
 } = process.env
+
+let {ADALITE_SERVER_URL} = process.env
+if (HEROKU_IS_REVIEW_APP) {
+  /*
+  `HEROKU_IS_REVIEW_APP` is redundant, as checking for `HEROKU_APP_NAME` should be
+  sufficient. But as according to https://devcenter.heroku.com/articles/github-integration-review-apps#injected-environment-variables
+  this functionality is prone to change, prefer more "explicit" solution.
+  */
+  if (!HEROKU_APP_NAME) throw new Error('HEROKU_APP_NAME is empty!')
+  ADALITE_SERVER_URL = `https://${HEROKU_APP_NAME}.herokuapp.com`
+  // eslint-disable-next-line no-console
+  console.log(`Using ${ADALITE_SERVER_URL} as ADALITE_SERVER_URL`)
+}
 
 const ADALITE_BACKEND_TOKEN = process.env.ADALITE_BACKEND_TOKEN || undefined
 
@@ -165,6 +179,7 @@ const backendConfig = {
   ADALITE_GA_TRACKING_ID,
   ADALITE_MAILCHIMP_API_KEY,
   ADALITE_MAILCHIMP_LIST_ID,
+  HEROKU_IS_REVIEW_APP,
   ADALITE_IP_BLACKLIST: ADALITE_IP_BLACKLIST
     ? ADALITE_IP_BLACKLIST.replace(/ /g, '').split(',')
     : [],

--- a/server/middlewares/redirectToBaseUrl.js
+++ b/server/middlewares/redirectToBaseUrl.js
@@ -1,6 +1,8 @@
+const {backendConfig} = require('../helpers/loadConfig')
+
 module.exports = (req, res, next) => {
-  if (`${req.protocol}://${req.get('host')}` !== process.env.ADALITE_SERVER_URL) {
-    res.redirect(301, `${process.env.ADALITE_SERVER_URL}${req.originalUrl}`)
+  if (`${req.protocol}://${req.get('host')}` !== backendConfig.ADALITE_SERVER_URL) {
+    res.redirect(301, `${backendConfig.ADALITE_SERVER_URL}${req.originalUrl}`)
   } else {
     next()
   }

--- a/server/middlewares/statsGoogleAnalytics.js
+++ b/server/middlewares/statsGoogleAnalytics.js
@@ -64,7 +64,7 @@ const trackTxSubmissions = mung.jsonAsync(async (body, req, res) => {
   if (req.originalUrl === '/api/txs/submit' && req.method === 'POST') {
     const tokenMatched = tokenMatches(req.get('token'))
     const txSubmissionType =
-      tokenMatched && isSameOrigin(req.get('origin'), process.env.ADALITE_SERVER_URL)
+      tokenMatched && isSameOrigin(req.get('origin'), backendConfig.ADALITE_SERVER_URL)
         ? 'txSubmissions'
         : 'otherTxSubmissions'
     const txSubmissionSuccess = body.Right ? 'successful' : 'unsuccessful'

--- a/server/middlewares/statsRedis.js
+++ b/server/middlewares/statsRedis.js
@@ -5,6 +5,7 @@ const mung = require('express-mung')
 const {parseTxBodyOutAmount, parseTxBodyTotalAmount} = require('../helpers/parseTxBody')
 const {captureException} = require('@sentry/node')
 const {isSameOrigin, tokenMatches} = require('../helpers/checkOrigin')
+const {backendConfig} = require('../helpers/loadConfig')
 
 const knownIps = new Set()
 
@@ -40,7 +41,7 @@ const trackTxSubmissions = mung.json((body, req, res) => {
   if (req.originalUrl === '/api/txs/submit' && req.method === 'POST') {
     const txSubmissionType =
       tokenMatches(req.get('token')) &&
-      isSameOrigin(req.get('origin'), process.env.ADALITE_SERVER_URL)
+      isSameOrigin(req.get('origin'), backendConfig.ADALITE_SERVER_URL)
         ? 'txSubmissions'
         : 'otherTxSubmissions'
     const txSubmissionSuccess = body.Right ? 'successful' : 'unsuccessful'

--- a/server/transactionSubmitter.js
+++ b/server/transactionSubmitter.js
@@ -1,6 +1,7 @@
 require('isomorphic-fetch')
 const Sentry = require('@sentry/node')
 const {isSameOrigin, tokenMatches} = require('./helpers/checkOrigin')
+const {backendConfig} = require('./helpers/loadConfig')
 
 module.exports = function(app, env) {
   // eslint-disable-next-line consistent-return
@@ -47,7 +48,7 @@ module.exports = function(app, env) {
 
       if (
         tokenMatches(req.get('token')) &&
-        isSameOrigin(req.get('origin'), process.env.ADALITE_SERVER_URL)
+        isSameOrigin(req.get('origin'), backendConfig.ADALITE_SERVER_URL)
       ) {
         Sentry.captureException(new Error('TransactionSubmissionFailed'), {
           contexts: [{...JSON.parse(errorMessage)}],


### PR DESCRIPTION
* After this is merged, all newly created PRs will have automatically created environments
* If you want to use it for already opened PR, then rebase & reopen them

For testnet CORS were allowed for `https://adalite-*.herokuapp.com`.
