### PR TITLE
Divide actions part 1

### DIFF
--- a/app/frontend/actions/error.ts
+++ b/app/frontend/actions/error.ts
@@ -1,0 +1,29 @@
+import debugLog from '../helpers/debugLog'
+import captureBySentry from '../helpers/captureBySentry'
+import {Store, State} from '../state'
+
+export default ({setState}: Store) => {
+  const setError = (state: State, {errorName, error}: {errorName: string; error: any}) => {
+    if (error && error.name) {
+      debugLog(error)
+      captureBySentry(error)
+      setState({
+        [errorName]: {
+          code: error.name,
+          params: {
+            message: error.message,
+          },
+        },
+        error,
+      })
+    } else {
+      setState({
+        [errorName]: error,
+      })
+    }
+  }
+
+  return {
+    setError,
+  }
+}

--- a/app/frontend/actions/loading.ts
+++ b/app/frontend/actions/loading.ts
@@ -1,0 +1,22 @@
+import {Store, State} from '../state'
+
+export default ({setState}: Store) => {
+  const loadingAction = (state: State, message: string) => {
+    return setState({
+      loading: true,
+      loadingMessage: message,
+    })
+  }
+
+  const stopLoadingAction = (state: State) => {
+    return setState({
+      loading: false,
+      loadingMessage: undefined,
+    })
+  }
+
+  return {
+    loadingAction,
+    stopLoadingAction,
+  }
+}

--- a/app/frontend/actions/wallet.ts
+++ b/app/frontend/actions/wallet.ts
@@ -1,0 +1,208 @@
+import {NETWORKS, WANTED_DELEGATOR_STAKING_ADDRESSES} from '../wallet/constants'
+import {CryptoProviderType} from '../wallet/types'
+import ShelleyCryptoProviderFactory from '../wallet/shelley/shelley-crypto-provider-factory'
+import {ShelleyWallet} from '../wallet/shelley-wallet'
+import mnemonicToWalletSecretDef from '../wallet/helpers/mnemonicToWalletSecretDef'
+
+import debugLog from '../helpers/debugLog'
+import getConversionRates from '../helpers/getConversionRates'
+
+import {ADALITE_CONFIG} from '../config'
+import {AccountInfo, Lovelace, AssetFamily, AuthMethodType} from '../types'
+import {initialState} from '../store'
+import {State, Store} from '../state'
+import errorActions from './error'
+import loadingActions from './loading'
+
+// TODO: (refactor), this should not call "setState" as it is not action
+const fetchConversionRates = async (conversionRates, setState) => {
+  try {
+    setState({
+      conversionRates: await conversionRates,
+    })
+  } catch (e) {
+    debugLog('Could not fetch conversion rates.')
+    setState({
+      conversionRates: null,
+    })
+  }
+}
+
+const accountsIncludeStakingAddresses = (
+  accountsInfo: Array<AccountInfo>,
+  soughtAddresses: Array<string>
+): boolean => {
+  const stakingAddresses = accountsInfo.map((accountInfo) => accountInfo.stakingAddress)
+  return stakingAddresses.some((address) => soughtAddresses.includes(address))
+}
+
+// TODO: we may be able to remove this, kept for backwards compatibility
+const getShouldShowSaturatedBanner = (accountsInfo: Array<AccountInfo>) =>
+  accountsInfo.some(({poolRecommendation}) => poolRecommendation.shouldShowSaturatedBanner)
+
+type Wallet = ReturnType<typeof ShelleyWallet>
+let wallet: Wallet
+export const setWallet = (w: Wallet) => {
+  wallet = w
+}
+export const getWallet = (): Wallet => wallet
+
+export default (store: Store) => {
+  const {loadingAction} = loadingActions(store)
+  const {setError} = errorActions(store)
+  const {setState} = store
+
+  const loadWallet = async (
+    state: State,
+    {
+      cryptoProviderType,
+      walletSecretDef,
+      forceWebUsb,
+      shouldExportPubKeyBulk,
+    }: {
+      cryptoProviderType: CryptoProviderType
+      walletSecretDef: any
+      forceWebUsb: boolean
+      shouldExportPubKeyBulk: boolean
+    }
+  ) => {
+    loadingAction(state, 'Loading wallet data...')
+    setState({walletLoadingError: undefined})
+    const isShelleyCompatible = !(walletSecretDef && walletSecretDef.derivationScheme.type === 'v1')
+    const config = {...ADALITE_CONFIG, isShelleyCompatible, shouldExportPubKeyBulk}
+    try {
+      const cryptoProvider = await ShelleyCryptoProviderFactory.getCryptoProvider(
+        cryptoProviderType,
+        {
+          walletSecretDef,
+          network: NETWORKS[ADALITE_CONFIG.ADALITE_NETWORK],
+          config,
+          forceWebUsb, // TODO: into config
+        }
+      )
+
+      setWallet(
+        await ShelleyWallet({
+          config,
+          cryptoProvider,
+        })
+      )
+
+      const validStakepoolDataProvider = await wallet.getStakepoolDataProvider()
+      const accountsInfo = await wallet.getAccountsInfo(validStakepoolDataProvider)
+      const shouldShowSaturatedBanner = getShouldShowSaturatedBanner(accountsInfo)
+
+      const conversionRatesPromise = getConversionRates(state)
+      const usingHwWallet = wallet.isHwWallet()
+      const maxAccountIndex = wallet.getMaxAccountIndex()
+      const shouldShowWantedAddressesModal = accountsIncludeStakingAddresses(
+        accountsInfo,
+        WANTED_DELEGATOR_STAKING_ADDRESSES
+      )
+      const hwWalletName = usingHwWallet ? wallet.getWalletName() : undefined
+      if (usingHwWallet) loadingAction(state, `Waiting for ${hwWalletName}...`)
+      const demoRootSecret = (
+        await mnemonicToWalletSecretDef(ADALITE_CONFIG.ADALITE_DEMO_WALLET_MNEMONIC)
+      ).rootSecret
+      const isDemoWallet = walletSecretDef && walletSecretDef.rootSecret.equals(demoRootSecret)
+      const autoLogin = state.autoLogin
+      setState({
+        validStakepoolDataProvider,
+        accountsInfo,
+        maxAccountIndex,
+        shouldShowSaturatedBanner,
+        walletIsLoaded: true,
+        loading: false,
+        mnemonicAuthForm: {
+          mnemonicInputValue: '',
+          mnemonicInputError: null,
+          formIsValid: false,
+        },
+        usingHwWallet,
+        hwWalletName,
+        isDemoWallet,
+        shouldShowDemoWalletWarningDialog: isDemoWallet && !autoLogin,
+        shouldShowNonShelleyCompatibleDialog: !isShelleyCompatible,
+        shouldShowWantedAddressesModal,
+        shouldShowGenerateMnemonicDialog: false,
+        shouldShowAddressVerification: usingHwWallet,
+        // send form
+        sendAmount: {assetFamily: AssetFamily.ADA, fieldValue: '', coins: 0 as Lovelace},
+        sendAddress: {fieldValue: ''},
+        sendResponse: '',
+        // shelley
+        isShelleyCompatible,
+      })
+      await fetchConversionRates(conversionRatesPromise, setState)
+    } catch (e) {
+      setState({
+        loading: false,
+      })
+      setError(state, {errorName: 'walletLoadingError', error: e})
+      setState({
+        shouldShowWalletLoadingErrorModal: true,
+      })
+      return false
+    }
+    return true
+  }
+
+  const reloadWalletInfo = async (state: State) => {
+    loadingAction(state, 'Reloading wallet info...')
+    try {
+      const accountsInfo = await wallet.getAccountsInfo(state.validStakepoolDataProvider)
+      const conversionRates = getConversionRates(state)
+
+      // timeout setting loading state, so that loading shows even if everything was cached
+      setTimeout(() => setState({loading: false}), 500)
+      setState({
+        accountsInfo,
+        shouldShowSaturatedBanner: getShouldShowSaturatedBanner(accountsInfo),
+      })
+      await fetchConversionRates(conversionRates, setState)
+    } catch (e) {
+      setState({
+        loading: false,
+      })
+      setError(state, {errorName: 'walletLoadingError', error: e})
+      setState({
+        shouldShowWalletLoadingErrorModal: true,
+      })
+    }
+  }
+
+  const loadDemoWallet = (state: State) => {
+    setState({
+      mnemonicAuthForm: {
+        mnemonicInputValue: ADALITE_CONFIG.ADALITE_DEMO_WALLET_MNEMONIC,
+        mnemonicInputError: null,
+        formIsValid: true,
+      },
+      walletLoadingError: undefined,
+      shouldShowWalletLoadingErrorModal: false,
+      authMethod: AuthMethodType.MNEMONIC,
+      shouldShowExportOption: true,
+    })
+  }
+
+  const logout = (state: State) => {
+    setWallet(null)
+    setState(
+      {
+        ...initialState,
+        displayWelcome: false,
+        autoLogin: false,
+      },
+      // @ts-ignore (we don't have types for forced state overwrite)
+      true
+    ) // force overwriting the state
+    window.history.pushState({}, '/', '/')
+  }
+
+  return {
+    loadWallet,
+    reloadWalletInfo,
+    loadDemoWallet,
+    logout,
+  }
+}

--- a/app/frontend/state.ts
+++ b/app/frontend/state.ts
@@ -272,6 +272,7 @@ const initialState: State = {
 }
 export type SetStateFn = (newState: Partial<State>) => void
 export type GetStateFn = () => State
+export type Store = {getState: GetStateFn; setState: SetStateFn}
 
 export const getSourceAccountInfo = (state: State) => state.accountsInfo[state.sourceAccountIndex]
 export const getActiveAccountInfo = (state: State) => state.accountsInfo[state.activeAccountIndex]


### PR DESCRIPTION
Idea for the future is:

-> have multiple "Actions" files
-> later move "actions.ts" into "actions" folder and rename it to "index.ts"
-> if there would be some cyclic-dependencies, extract such "functions/actions" into "actions/common.ts"
-> make all "actions" receive "state" as first object
-> avoid using "setState" outside the "actions"
-> actions can use other actions if not causing cycling deps, e.g. wallet uses "loading/error" actions
-> actions should receive "state" object as first param and optional params object as second param (e.g. error case)

I wanted to avoid more changes in this PR not to grow to big.

**Please pay attention to**
I removed "config/extra" params from loading/error as I believe this is "hacky" pattern and those actions/functions should not have such responsibility.
**Global wallet** object is exposed via `getWallet`.

I ADVISE to review by commits, should be easier to follow.


