### PR TITLE
Fix counting number of distinct assetNames

### DIFF
--- a/app/tests/src/index.js
+++ b/app/tests/src/index.js
@@ -28,7 +28,7 @@ describe('AdaLite Test Suite', () => {
   describe('Account', () => {
     require('./wallet/account')
   })
-  describe('Token formater', () => {
-    require('./common/tokenFormater')
+  describe('Token bundle', () => {
+    require('./tokenBundle')
   })
 })

--- a/app/tests/src/tokenBundle.js
+++ b/app/tests/src/tokenBundle.js
@@ -1,5 +1,6 @@
 import assert from 'assert'
-import {orderTokenBundle} from '../../../frontend/wallet/helpers/tokenFormater'
+import {orderTokenBundle} from '../../frontend/wallet/helpers/tokenFormater'
+import {computeMinUTxOLovelaceAmount} from '../../frontend/wallet/shelley/shelley-transaction-planner'
 
 describe('Token sorting', () => {
   it('should sort tokenBundle by policyId canonically', () => {
@@ -78,3 +79,32 @@ describe('Token sorting', () => {
     assert.deepEqual(sortedTokenBundle, orderTokenBundle(tokenBundle))
   })
 })
+
+describe('Min ada calculation', () => {
+  it('should calculate min ADA value for empty tokens', () => {
+    assert.deepEqual(1000000, computeMinUTxOLovelaceAmount([]))
+  })
+  it('should calculate min ADA value for multiple assets under one policy', () => {
+    const tokenBundle = [
+      {policyId: 'ca37dd6b151b6a1d023ecbd22d7e881d814b0c58a3a3148b42b865a0', assetName: '000000000000', quantity: 1},
+      {policyId: 'ca37dd6b151b6a1d023ecbd22d7e881d814b0c58a3a3148b42b865a0', assetName: '', quantity: 1},
+    ]
+    assert.deepEqual(1629628, computeMinUTxOLovelaceAmount(tokenBundle))
+  })
+  it('should calculate min ADA value for multiple assets under multiple policies', () => {
+    const tokenBundle = [
+      {policyId: 'ca37dd6b151b6a1d023ecbd22d7e881d814b0c58a3a3148b42b865a0', assetName: '000000000000', quantity: 1},
+      {policyId: '6b8d07d69639e9413dd637a1a815a7323c69c86abbafb66dbfdb1aa7', assetName: '111111111111', quantity: 1},
+    ]
+    assert.deepEqual(1666665, computeMinUTxOLovelaceAmount(tokenBundle))
+  })
+  it('should calculate min ADA value for multiple assets under multiple policies with same assetName', () => {
+    const tokenBundle = [
+      {policyId: 'ca37dd6b151b6a1d023ecbd22d7e881d814b0c58a3a3148b42b865a0', assetName: '000000000000', quantity: 1},
+      {policyId: '6b8d07d69639e9413dd637a1a815a7323c69c86abbafb66dbfdb1aa7', assetName: '000000000000', quantity: 1},
+    ]
+    assert.deepEqual(1666665, computeMinUTxOLovelaceAmount(tokenBundle))
+  })
+})
+
+


### PR DESCRIPTION
I realized that in case there are same assetNames under a different policyId, the function for calculating min ada for output would consider only one unique assetName, which is true but since they are under different policyId they cause the output to be bigger. For this reason we need to calculate unique number of (policyId, assetName) pairs intead.