### PR TITLE
Transactions refactor part 1

### DIFF
--- a/app/frontend/components/pages/delegations/delegatePage.tsx
+++ b/app/frontend/components/pages/delegations/delegatePage.tsx
@@ -7,7 +7,7 @@ import {AdaIcon} from '../../common/svg'
 import {getTranslation} from '../../../translations'
 import {getSourceAccountInfo, State} from '../../../state'
 import Accordion from '../../common/accordion'
-import {Lovelace, PoolRecommendation, Stakepool} from '../../../types'
+import {Lovelace, PoolRecommendation, Stakepool, TxType} from '../../../types'
 import {isBigDelegatorSelector} from '../../../selectors'
 import {StakePoolInfo} from './stakePoolInfo'
 import DelegateInput from './delegateInput'
@@ -59,7 +59,7 @@ interface Props {
   isBigDelegator: boolean
   withAccordion: boolean
   title: string
-  confirmTransaction: (txConfirmType) => Promise<void>
+  confirmTransactionOld: (txConfirmType) => Promise<void>
   selectAdaliteStakepool: () => void
 }
 
@@ -76,7 +76,7 @@ const Delegate = ({
   isBigDelegator,
   withAccordion,
   title,
-  confirmTransaction,
+  confirmTransactionOld,
 }: Props): h.JSX.Element => {
   /*
   REFACTOR (calculateFee):
@@ -85,7 +85,7 @@ const Delegate = ({
   */
 
   const delegationHandler = async (): Promise<void> => {
-    await confirmTransaction('delegate')
+    await confirmTransactionOld(TxType.DELEGATE)
   }
 
   const validationError = !!delegationValidationError || !stakePool || !!stakePool.validationError

--- a/app/frontend/components/pages/delegations/deregisterStakeKey.tsx
+++ b/app/frontend/components/pages/delegations/deregisterStakeKey.tsx
@@ -1,16 +1,10 @@
 import {h} from 'preact'
-import {useActions, useSelector} from '../../../helpers/connect'
+import {useActions} from '../../../helpers/connect'
 import actions from '../../../actions'
 import {useIsActiveAccountDelegating} from '../../../selectors'
 
 const DeregisterStakeKeyPage = () => {
   const {deregisterStakingKey} = useActions(actions)
-
-  /*
-  REFACTOR (calculateFee):
-  After "calculateFee" refactor "calculatingDelegationFee" should be removed.
-  */
-  const calculatingDelegationFee = useSelector((state) => state.calculatingDelegationFee)
   const isDelegating = useIsActiveAccountDelegating()
 
   if (!isDelegating) return null
@@ -21,11 +15,7 @@ const DeregisterStakeKeyPage = () => {
       <p className="deregister-stake-key-card-disclaimer">
         ...if you do not want to use this wallet anymore
       </p>
-      <button
-        className="button secondary cancel-delegation"
-        disabled={calculatingDelegationFee}
-        onClick={() => deregisterStakingKey()}
-      >
+      <button className="button secondary cancel-delegation" onClick={() => deregisterStakingKey()}>
         Deregister stake key
       </button>
     </div>

--- a/app/frontend/components/pages/sendAda/confirmTransactionDialog.tsx
+++ b/app/frontend/components/pages/sendAda/confirmTransactionDialog.tsx
@@ -254,12 +254,26 @@ const ConvertFundsReview = ({
 }
 
 const ConfirmTransactionDialog = () => {
-  const {rawTransactionOpen, transactionSummary, txConfirmType} = useSelector((state) => ({
+  const {
+    rawTransactionOpen,
+    transactionSummary,
+    txConfirmType,
+    isCrossAccount,
+    cachedTransactionSummaries,
+    sendAddress,
+    sourceAccountIndex,
+  } = useSelector((state) => ({
     transactionSummary: state.sendTransactionSummary,
     rawTransactionOpen: state.rawTransactionOpen,
     txConfirmType: state.txConfirmType,
+    isCrossAccount: state.isCrossAccount,
+    cachedTransactionSummaries: state.cachedTransactionSummaries,
+    sendAddress: state.sendAddress.fieldValue,
+    sourceAccountIndex: state.sourceAccountIndex,
   }))
   const {setRawTransactionOpen, submitTransaction, cancelTransaction} = useActions(actions)
+
+  const hideDefaultSummary = txConfirmType === TxType.DEREGISTER_STAKE_KEY
 
   const titleMap: {[key in TxType]: string} = {
     [TxType.DELEGATE]: 'Delegation review',
@@ -268,51 +282,65 @@ const ConfirmTransactionDialog = () => {
     [TxType.WITHDRAW]: 'Rewards withdrawal review',
     [TxType.POOL_REG_OWNER]: '',
     [TxType.DEREGISTER_STAKE_KEY]: 'Deregister stake key',
-    // crossAccount: 'Transaction between accounts review',
   }
-  const hideDefaultSummary = transactionSummary.type === TxType.DEREGISTER_STAKE_KEY
-  // TODO: refactor, remove txConfirmType
+
+  const onSubmit = () => {
+    // refactored cases
+    if ([TxType.DEREGISTER_STAKE_KEY].includes(txConfirmType)) {
+      return submitTransaction({
+        sendAddress,
+        sourceAccountIndex,
+        txSummary: cachedTransactionSummaries[TxType.DEREGISTER_STAKE_KEY],
+      })
+    }
+    // to be refactored cases
+    return submitTransaction({sendAddress, sourceAccountIndex, txSummary: transactionSummary})
+  }
+
+  // Refactor: tmp util till all transactions types use "cachedTransactionSummaries"
+  const getModalBody = () => {
+    // Refactored cases:
+    if (txConfirmType === TxType.DEREGISTER_STAKE_KEY) {
+      return (
+        <DeregisterStakeKeyReview
+          transactionSummary={cachedTransactionSummaries[TxType.DEREGISTER_STAKE_KEY]}
+          onSubmit={onSubmit}
+          onCancel={cancelTransaction}
+        />
+      )
+    }
+    // To be refactored cases:
+    if (transactionSummary.type === TxType.CONVERT_LEGACY) {
+      return <ConvertFundsReview transactionSummary={transactionSummary} />
+    }
+    if (transactionSummary.type === TxType.WITHDRAW) {
+      return <WithdrawReview transactionSummary={transactionSummary} />
+    }
+    if (transactionSummary.type === TxType.DELEGATE) {
+      return <DelegateReview transactionSummary={transactionSummary} />
+    }
+    if (transactionSummary.type === TxType.SEND_ADA) {
+      return (
+        <SendAdaReview
+          transactionSummary={transactionSummary}
+          shouldShowAddressVerification={isCrossAccount}
+        />
+      )
+    }
+    return null
+  }
+
   return (
     <div>
       <Modal
         onRequestClose={cancelTransaction}
         title={
-          txConfirmType === 'crossAccount'
-            ? 'Transaction between accounts review'
-            : titleMap[transactionSummary.type]
+          isCrossAccount ? 'Transaction between accounts review' : titleMap[transactionSummary.type]
         }
       >
-        {transactionSummary.type === TxType.CONVERT_LEGACY && (
-          <ConvertFundsReview transactionSummary={transactionSummary} />
-        )}
-        {transactionSummary.type === TxType.WITHDRAW && (
-          <WithdrawReview transactionSummary={transactionSummary} />
-        )}
-
-        {transactionSummary.type === TxType.DELEGATE && (
-          <DelegateReview transactionSummary={transactionSummary} />
-        )}
-
-        {transactionSummary.type === TxType.DEREGISTER_STAKE_KEY && (
-          <DeregisterStakeKeyReview
-            transactionSummary={transactionSummary}
-            onSubmit={submitTransaction}
-            onCancel={cancelTransaction}
-          />
-        )}
-
-        {transactionSummary.type === TxType.SEND_ADA && (
-          <SendAdaReview
-            transactionSummary={transactionSummary}
-            shouldShowAddressVerification={txConfirmType === 'crossAccount'}
-          />
-        )}
+        {getModalBody()}
         {!hideDefaultSummary && (
-          <ReviewBottom
-            disabled={false}
-            onSubmit={submitTransaction}
-            onCancel={cancelTransaction}
-          />
+          <ReviewBottom disabled={false} onSubmit={onSubmit} onCancel={cancelTransaction} />
         )}
         <a href="#" className="send-raw" onClick={() => setRawTransactionOpen(true)}>
           Raw unsigned transaction

--- a/app/frontend/components/pages/sendAda/sendAdaPage.tsx
+++ b/app/frontend/components/pages/sendAda/sendAdaPage.tsx
@@ -18,6 +18,7 @@ import {
   SendTransactionSummary,
   Token,
   TransactionSummary,
+  TxType,
 } from '../../../types'
 import {AdaIcon} from '../../common/svg'
 import {parseCoins} from '../../../../frontend/helpers/validators'
@@ -50,7 +51,7 @@ interface Props {
   sendAmountValidationError: any
   updateAddress: any
   updateAmount: (sendAmount: SendAmount) => void
-  confirmTransaction: any
+  confirmTransactionOld: any
   feeRecalculating: any
   sendMaxFunds: any
   conversionRates: any
@@ -102,7 +103,7 @@ const SendAdaPage = ({
   sendAmountValidationError,
   updateAddress,
   updateAmount,
-  confirmTransaction,
+  confirmTransactionOld,
   feeRecalculating,
   sendMaxFunds,
   conversionRates,
@@ -171,7 +172,7 @@ const SendAdaPage = ({
   }, [adaAsset, dropdownAssetItems, sendAmount])
 
   const submitHandler = async () => {
-    await confirmTransaction('send')
+    await confirmTransactionOld(TxType.SEND_ADA)
   }
 
   const searchPredicate = useCallback(

--- a/app/frontend/state.ts
+++ b/app/frontend/state.ts
@@ -10,6 +10,10 @@ import {
   PoolRegTransactionSummary,
   SendAmount,
   TransactionSummary,
+  SendTransactionSummary,
+  WithdrawTransactionSummary,
+  DelegateTransactionSummary,
+  DeregisterStakingKeyTransactionSummary,
   TxType,
 } from './types'
 
@@ -80,11 +84,24 @@ export interface State {
 
   // transaction
   sendTransactionSummary: TransactionSummary
+
+  // Note: This allows for multiple transaction summaries by TxType, to avoid race-conditions
+  // when calculating transaction summaries for more TxTypes at the same time.
+  // Note that this still does not allow for multiple cached transaction summaries from
+  // the same TxType, however, this should not be use-case for us in the near future.
+  cachedTransactionSummaries: {
+    [TxType.CONVERT_LEGACY]?: TransactionSummary & SendTransactionSummary
+    [TxType.SEND_ADA]?: TransactionSummary & SendTransactionSummary
+    [TxType.WITHDRAW]?: TransactionSummary & WithdrawTransactionSummary
+    [TxType.DELEGATE]?: TransactionSummary & DelegateTransactionSummary
+    [TxType.DEREGISTER_STAKE_KEY]?: TransactionSummary & DeregisterStakingKeyTransactionSummary
+  }
   rawTransactionOpen: boolean
   rawTransaction: string
   transactionFee?: any
   sendResponse: any // TODO
-  txConfirmType: string
+  txConfirmType?: TxType
+  isCrossAccount: boolean
   txSuccessTab: string
   transactionSubmissionError?: any
   shouldShowConfirmTransactionDialog?: boolean
@@ -192,11 +209,12 @@ const initialState: State = {
     fee: 0 as Lovelace,
     plan: null,
   },
+  cachedTransactionSummaries: {},
   rawTransactionOpen: false,
   rawTransaction: '',
   transactionFee: 0,
   sendResponse: {},
-  txConfirmType: '',
+  isCrossAccount: false,
   txSuccessTab: '',
   keepConfirmationDialogOpen: false,
 


### PR DESCRIPTION
This one is aimed to fix race-conditions when calculating multiple TxPlans at once. Now we should have one TxPlan per TxType and it should be determined by `txConfirmType` when confirming the transaction.
We discussed that we do not expect multiple TxPlans for on TxType so I did not consider this scenario.

Among that, I tried to make chosen action parameters more explicit. Also, I postfixed parts that I did not refactor with **"Old"**, what do you think about that?

The refactor of "connect" related to "sendAdaPage" and "delegate" is handled in a https://github.com/vacuumlabs/adalite/pull/915 so I did not incorporate it here, though it would help to ensure better types.

Ideally I would prefer to drop this "txPlan" info from global state altogether, but this would require a lot extra changes, so maybe this could be changed in the future. In ideal scenarios I would prefer style like this:

// e.g. sendAdaPage (very simplified)
// but idea is that we do not really need global state, that is more difficult to reason about (race conditions, reset in right time, etc) for that
```
const [txPlan, setTxPlan] = useState(...)
const [formData, setFormData] = useState(...)
// good router would help here
const [showSubmit, setShowSubmit] = useState(...)

useEffect(() => {
   setTxPlan(calculateTxPlan(formData))  
}, [reasonable deps])

const onSubmit = () => {
  showSubmit(true)
}

// and "Confirm" handled similarly

return (
  {!showSubmit && (
    <Form {...formData} />
    <button label="Send ADA" />
  )}
  {showSubmit && <SubmitTransactionModal {...{txPlan, formData}} />}
)

```
