### PR TITLE
Separate CircleCI into separate jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,9 @@ jobs:
       - image: circleci/node:11.10-browsers
     working_directory: ~/repo
     steps:
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "yarn.lock" }}-{{ checksum "app/yarn.lock"}}
       - checkout
       - run: yarn eslint
 
@@ -55,6 +58,9 @@ jobs:
       - image: circleci/node:11.10-browsers
     working_directory: ~/repo
     steps:
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "yarn.lock" }}-{{ checksum "app/yarn.lock"}}
       - checkout
       - run: yarn test-chrome-headless
 
@@ -63,6 +69,10 @@ workflows:
   build:
     jobs:
       - build
-      - lint
       - audit
-      - test
+      - lint:
+        requires:
+          - build
+      - test:
+        requires:
+          - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,10 +47,10 @@ jobs:
       - image: circleci/node:11.10-browsers
     working_directory: ~/repo
     steps:
+      - checkout
       - restore_cache:
           keys:
             - v1-dependencies-{{ checksum "yarn.lock" }}-{{ checksum "app/yarn.lock"}}
-      - checkout
       - run: yarn eslint
 
   test:
@@ -58,15 +58,15 @@ jobs:
       - image: circleci/node:11.10-browsers
     working_directory: ~/repo
     steps:
+      - checkout
       - restore_cache:
           keys:
             - v1-dependencies-{{ checksum "yarn.lock" }}-{{ checksum "app/yarn.lock"}}
-      - checkout
       - run: yarn test-chrome-headless
 
 workflows:
   version: 2
-  build-and-test:
+  build:
     jobs:
       - build
       - audit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
       - image: circleci/node:11.10-browsers
     working_directory: ~/repo
     steps:
+      - checkout
       - run: yarn audit
       - run: cd app && yarn audit && cd ../
   
@@ -46,6 +47,7 @@ jobs:
       - image: circleci/node:11.10-browsers
     working_directory: ~/repo
     steps:
+      - checkout
       - run: yarn eslint
 
   test:
@@ -53,6 +55,7 @@ jobs:
       - image: circleci/node:11.10-browsers
     working_directory: ~/repo
     steps:
+      - checkout
       - run: yarn test-chrome-headless
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,8 +71,8 @@ workflows:
       - build
       - audit
       - lint:
-        requires:
-          - build
+          requires:
+            - build
       - test:
-        requires:
-          - build
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
 
 workflows:
   version: 2
-  build:
+  build-and-test:
     jobs:
       - build
       - audit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,15 +27,39 @@ jobs:
       - run: cp .env.example .env
       - run: yarn install
       - run: cd app && yarn install && cd ../
-      - run: yarn audit
-      - run: cd app && yarn audit && cd ../
-
       - save_cache:
           paths:
             - node_modules
             - app/node_modules
           key: v1-dependencies-{{ checksum "yarn.lock" }}-{{ checksum "app/yarn.lock"}}
 
-      # run tests!
+  audit:
+    docker:
+      - image: circleci/node:11.10-browsers
+    working_directory: ~/repo
+    steps:
+      - run: yarn audit
+      - run: cd app && yarn audit && cd ../
+  
+  lint:
+    docker:
+      - image: circleci/node:11.10-browsers
+    working_directory: ~/repo
+    steps:
       - run: yarn eslint
+
+  test:
+    docker:
+      - image: circleci/node:11.10-browsers
+    working_directory: ~/repo
+    steps:
       - run: yarn test-chrome-headless
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build
+      - lint
+      - audit
+      - test

--- a/app/frontend/actions/error.ts
+++ b/app/frontend/actions/error.ts
@@ -1,0 +1,29 @@
+import debugLog from '../helpers/debugLog'
+import captureBySentry from '../helpers/captureBySentry'
+import {Store, State} from '../state'
+
+export default ({setState}: Store) => {
+  const setError = (state: State, {errorName, error}: {errorName: string; error: any}) => {
+    if (error && error.name) {
+      debugLog(error)
+      captureBySentry(error)
+      setState({
+        [errorName]: {
+          code: error.name,
+          params: {
+            message: error.message,
+          },
+        },
+        error,
+      })
+    } else {
+      setState({
+        [errorName]: error,
+      })
+    }
+  }
+
+  return {
+    setError,
+  }
+}

--- a/app/frontend/actions/loading.ts
+++ b/app/frontend/actions/loading.ts
@@ -1,0 +1,22 @@
+import {Store, State} from '../state'
+
+export default ({setState}: Store) => {
+  const loadingAction = (state: State, message: string) => {
+    return setState({
+      loading: true,
+      loadingMessage: message,
+    })
+  }
+
+  const stopLoadingAction = (state: State) => {
+    return setState({
+      loading: false,
+      loadingMessage: undefined,
+    })
+  }
+
+  return {
+    loadingAction,
+    stopLoadingAction,
+  }
+}

--- a/app/frontend/actions/wallet.ts
+++ b/app/frontend/actions/wallet.ts
@@ -1,0 +1,208 @@
+import {NETWORKS, WANTED_DELEGATOR_STAKING_ADDRESSES} from '../wallet/constants'
+import {CryptoProviderType} from '../wallet/types'
+import ShelleyCryptoProviderFactory from '../wallet/shelley/shelley-crypto-provider-factory'
+import {ShelleyWallet} from '../wallet/shelley-wallet'
+import mnemonicToWalletSecretDef from '../wallet/helpers/mnemonicToWalletSecretDef'
+
+import debugLog from '../helpers/debugLog'
+import getConversionRates from '../helpers/getConversionRates'
+
+import {ADALITE_CONFIG} from '../config'
+import {AccountInfo, Lovelace, AssetFamily, AuthMethodType} from '../types'
+import {initialState} from '../store'
+import {State, Store} from '../state'
+import errorActions from './error'
+import loadingActions from './loading'
+
+// TODO: (refactor), this should not call "setState" as it is not action
+const fetchConversionRates = async (conversionRates, setState) => {
+  try {
+    setState({
+      conversionRates: await conversionRates,
+    })
+  } catch (e) {
+    debugLog('Could not fetch conversion rates.')
+    setState({
+      conversionRates: null,
+    })
+  }
+}
+
+const accountsIncludeStakingAddresses = (
+  accountsInfo: Array<AccountInfo>,
+  soughtAddresses: Array<string>
+): boolean => {
+  const stakingAddresses = accountsInfo.map((accountInfo) => accountInfo.stakingAddress)
+  return stakingAddresses.some((address) => soughtAddresses.includes(address))
+}
+
+// TODO: we may be able to remove this, kept for backwards compatibility
+const getShouldShowSaturatedBanner = (accountsInfo: Array<AccountInfo>) =>
+  accountsInfo.some(({poolRecommendation}) => poolRecommendation.shouldShowSaturatedBanner)
+
+type Wallet = ReturnType<typeof ShelleyWallet>
+let wallet: Wallet
+export const setWallet = (w: Wallet) => {
+  wallet = w
+}
+export const getWallet = (): Wallet => wallet
+
+export default (store: Store) => {
+  const {loadingAction} = loadingActions(store)
+  const {setError} = errorActions(store)
+  const {setState} = store
+
+  const loadWallet = async (
+    state: State,
+    {
+      cryptoProviderType,
+      walletSecretDef,
+      forceWebUsb,
+      shouldExportPubKeyBulk,
+    }: {
+      cryptoProviderType: CryptoProviderType
+      walletSecretDef: any
+      forceWebUsb: boolean
+      shouldExportPubKeyBulk: boolean
+    }
+  ) => {
+    loadingAction(state, 'Loading wallet data...')
+    setState({walletLoadingError: undefined})
+    const isShelleyCompatible = !(walletSecretDef && walletSecretDef.derivationScheme.type === 'v1')
+    const config = {...ADALITE_CONFIG, isShelleyCompatible, shouldExportPubKeyBulk}
+    try {
+      const cryptoProvider = await ShelleyCryptoProviderFactory.getCryptoProvider(
+        cryptoProviderType,
+        {
+          walletSecretDef,
+          network: NETWORKS[ADALITE_CONFIG.ADALITE_NETWORK],
+          config,
+          forceWebUsb, // TODO: into config
+        }
+      )
+
+      setWallet(
+        await ShelleyWallet({
+          config,
+          cryptoProvider,
+        })
+      )
+
+      const validStakepoolDataProvider = await wallet.getStakepoolDataProvider()
+      const accountsInfo = await wallet.getAccountsInfo(validStakepoolDataProvider)
+      const shouldShowSaturatedBanner = getShouldShowSaturatedBanner(accountsInfo)
+
+      const conversionRatesPromise = getConversionRates(state)
+      const usingHwWallet = wallet.isHwWallet()
+      const maxAccountIndex = wallet.getMaxAccountIndex()
+      const shouldShowWantedAddressesModal = accountsIncludeStakingAddresses(
+        accountsInfo,
+        WANTED_DELEGATOR_STAKING_ADDRESSES
+      )
+      const hwWalletName = usingHwWallet ? wallet.getWalletName() : undefined
+      if (usingHwWallet) loadingAction(state, `Waiting for ${hwWalletName}...`)
+      const demoRootSecret = (
+        await mnemonicToWalletSecretDef(ADALITE_CONFIG.ADALITE_DEMO_WALLET_MNEMONIC)
+      ).rootSecret
+      const isDemoWallet = walletSecretDef && walletSecretDef.rootSecret.equals(demoRootSecret)
+      const autoLogin = state.autoLogin
+      setState({
+        validStakepoolDataProvider,
+        accountsInfo,
+        maxAccountIndex,
+        shouldShowSaturatedBanner,
+        walletIsLoaded: true,
+        loading: false,
+        mnemonicAuthForm: {
+          mnemonicInputValue: '',
+          mnemonicInputError: null,
+          formIsValid: false,
+        },
+        usingHwWallet,
+        hwWalletName,
+        isDemoWallet,
+        shouldShowDemoWalletWarningDialog: isDemoWallet && !autoLogin,
+        shouldShowNonShelleyCompatibleDialog: !isShelleyCompatible,
+        shouldShowWantedAddressesModal,
+        shouldShowGenerateMnemonicDialog: false,
+        shouldShowAddressVerification: usingHwWallet,
+        // send form
+        sendAmount: {assetFamily: AssetFamily.ADA, fieldValue: '', coins: 0 as Lovelace},
+        sendAddress: {fieldValue: ''},
+        sendResponse: '',
+        // shelley
+        isShelleyCompatible,
+      })
+      await fetchConversionRates(conversionRatesPromise, setState)
+    } catch (e) {
+      setState({
+        loading: false,
+      })
+      setError(state, {errorName: 'walletLoadingError', error: e})
+      setState({
+        shouldShowWalletLoadingErrorModal: true,
+      })
+      return false
+    }
+    return true
+  }
+
+  const reloadWalletInfo = async (state: State) => {
+    loadingAction(state, 'Reloading wallet info...')
+    try {
+      const accountsInfo = await wallet.getAccountsInfo(state.validStakepoolDataProvider)
+      const conversionRates = getConversionRates(state)
+
+      // timeout setting loading state, so that loading shows even if everything was cached
+      setTimeout(() => setState({loading: false}), 500)
+      setState({
+        accountsInfo,
+        shouldShowSaturatedBanner: getShouldShowSaturatedBanner(accountsInfo),
+      })
+      await fetchConversionRates(conversionRates, setState)
+    } catch (e) {
+      setState({
+        loading: false,
+      })
+      setError(state, {errorName: 'walletLoadingError', error: e})
+      setState({
+        shouldShowWalletLoadingErrorModal: true,
+      })
+    }
+  }
+
+  const loadDemoWallet = (state: State) => {
+    setState({
+      mnemonicAuthForm: {
+        mnemonicInputValue: ADALITE_CONFIG.ADALITE_DEMO_WALLET_MNEMONIC,
+        mnemonicInputError: null,
+        formIsValid: true,
+      },
+      walletLoadingError: undefined,
+      shouldShowWalletLoadingErrorModal: false,
+      authMethod: AuthMethodType.MNEMONIC,
+      shouldShowExportOption: true,
+    })
+  }
+
+  const logout = (state: State) => {
+    setWallet(null)
+    setState(
+      {
+        ...initialState,
+        displayWelcome: false,
+        autoLogin: false,
+      },
+      // @ts-ignore (we don't have types for forced state overwrite)
+      true
+    ) // force overwriting the state
+    window.history.pushState({}, '/', '/')
+  }
+
+  return {
+    loadWallet,
+    reloadWalletInfo,
+    loadDemoWallet,
+    logout,
+  }
+}

--- a/app/frontend/state.ts
+++ b/app/frontend/state.ts
@@ -272,6 +272,7 @@ const initialState: State = {
 }
 export type SetStateFn = (newState: Partial<State>) => void
 export type GetStateFn = () => State
+export type Store = {getState: GetStateFn; setState: SetStateFn}
 
 export const getSourceAccountInfo = (state: State) => state.accountsInfo[state.sourceAccountIndex]
 export const getActiveAccountInfo = (state: State) => state.accountsInfo[state.activeAccountIndex]


### PR DESCRIPTION
Related to https://github.com/vacuumlabs/adalite/issues/919

- Broke out single job into four separate jobs (`build`, `audit`, `test`, `lint`)
- `build` job fans out to `test` and `lint` and restores install in build from cache
- `audit` runs in parallel to `build` and fails on the first yarn audit that errors