### PR TITLE
Break out CI config into seperate jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,20 @@
-# Orb 'cypress-io/cypress@1' resolved to 'cypress-io/cypress@1.27.0'
-version: 2
-jobs:
-  build:
-    docker:
-      - image: circleci/node:14.16-browsers
-    working_directory: ~/repo
+version: 2.1
+
+defaults: &defaults
+  docker:
+    - image: circleci/node:14.16-browsers
+  working_directory: ~/repo
+
+commands:
+  setup:
     steps:
       - checkout
-
-      # Download and cache dependencies
       - restore_cache:
           keys:
             - dependencies-{{ checksum "yarn.lock" }}-{{ checksum "app/yarn.lock"}}
-
       - run: cp .env.example .env
       - run: yarn install
       - run: cd app && yarn install && cd ../
-      - run: yarn audit
-      - run: cd app && yarn audit && cd ../
-
       - save_cache:
           paths:
             - node_modules
@@ -26,9 +22,30 @@ jobs:
             - ../.cache/Cypress
           key: dependencies-{{ checksum "yarn.lock" }}-{{ checksum "app/yarn.lock"}}
 
-      # run tests!
+jobs:
+  audit:
+    <<: *defaults
+    steps:
+      - setup
+      - run: yarn audit
+      - run: cd app && yarn audit && cd ../
+  
+  lint:
+    <<: *defaults
+    steps:
+      - setup
       - run: yarn eslint
+
+  test_unit:
+    <<: *defaults
+    steps:
+      - setup
       - run: yarn test-chrome-headless
+  
+  test_integration:
+    <<: *defaults
+    steps:
+      - setup
       - run:
           name: Build the app so that server can be started
           command: cd app && yarn build && cd ../
@@ -50,4 +67,8 @@ workflows:
   version: 2
   workflow:
     jobs:
-      - build
+      - audit
+      - lint
+      - test_unit
+      - test_integration
+


### PR DESCRIPTION
Based on https://github.com/vacuumlabs/adalite/pull/921

Motivation:
* allow for parallel execution of otherwise independent jobs in the pipeline

Changes respective to https://github.com/vacuumlabs/adalite/pull/921 :
* incorporate Cypress tests
* move restoring of cache/dependencies setup to a reusable command (source: https://preventdirectaccess.com/reuse-steps-circleci/), avoid reliance on cache in individual jobs so they are runnable locally
* extract default setup (docker image) into a "defaults" anchor" (source: https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/)

Jobs now run in parallel, check CI logs in PR

closes: #919 