### PR TITLE
Remove shouldShowExportOption from global state

### DIFF
--- a/app/frontend/actions.ts
+++ b/app/frontend/actions.ts
@@ -64,12 +64,8 @@ export default (store: Store) => {
   } = walletActions(store)
   const {setState, getState} = store
 
-  const setAuthMethod = (state: State, option: AuthMethodType): void => {
-    setState({
-      authMethod: option,
-      shouldShowExportOption:
-        option === AuthMethodType.MNEMONIC || option === AuthMethodType.KEY_FILE,
-    })
+  const setAuthMethod = (state: State, authMethod: AuthMethodType): void => {
+    setState({authMethod})
   }
 
   const closeDemoWalletWarningDialog = (state) => {

--- a/app/frontend/actions/wallet.ts
+++ b/app/frontend/actions/wallet.ts
@@ -168,7 +168,6 @@ export default (store: Store) => {
       walletLoadingError: undefined,
       shouldShowWalletLoadingErrorModal: false,
       authMethod: AuthMethodType.MNEMONIC,
-      shouldShowExportOption: true,
     })
   }
 

--- a/app/frontend/components/pages/dashboard/dashboardPage.tsx
+++ b/app/frontend/components/pages/dashboard/dashboardPage.tsx
@@ -27,7 +27,7 @@ import {useState} from 'preact/hooks'
 import {SubTabs, MainTabs} from '../../../constants'
 import {useViewport, isSmallerThanDesktop} from '../../common/viewPort'
 import {ScreenType} from '../../../types'
-import {shouldShowPremiumBannerSelector} from '../../../selectors'
+import {shouldShowExportOptionSelector, shouldShowPremiumBannerSelector} from '../../../selectors'
 import ReceiveRedirect from '../receiveAda/receiveRedirect'
 import {formatAccountIndex} from '../../../helpers/formatAccountIndex'
 import ConfirmTransactionDialog from '../sendAda/confirmTransactionDialog'
@@ -309,7 +309,7 @@ export default connect(
     shouldShowPremiumBanner: shouldShowPremiumBannerSelector(state),
     shouldShowSaturatedBanner: state.shouldShowSaturatedBanner,
     activeAccountIndex: state.activeAccountIndex,
-    shouldShowExportOption: state.shouldShowExportOption,
+    shouldShowExportOption: shouldShowExportOptionSelector(state),
     shouldShowConfirmTransactionDialog: state.shouldShowConfirmTransactionDialog,
     shouldShowSendTransactionModal: state.shouldShowSendTransactionModal,
     shouldShowDelegationModal: state.shouldShowDelegationModal,

--- a/app/frontend/selectors.ts
+++ b/app/frontend/selectors.ts
@@ -1,7 +1,7 @@
 import {State, getActiveAccountInfo} from './state'
 import {BIG_DELEGATOR_THRESHOLD, PREMIUM_MEMBER_BALANCE_TRESHOLD} from './wallet/constants'
 import {useSelector} from './helpers/connect'
-import {AccountInfo} from './types'
+import {AccountInfo, AuthMethodType} from './types'
 
 /*
 This file contains hooks/selectors shared accross multiple components which
@@ -23,6 +23,11 @@ export const isBigDelegatorSelector = (state: State): boolean => {
 export const shouldShowPremiumBannerSelector = (state: State): boolean => {
   const totalWalletBalance = totalWalletBalanceSelector(state)
   return !state.seenPremiumBanner && PREMIUM_MEMBER_BALANCE_TRESHOLD < totalWalletBalance
+}
+
+export const shouldShowExportOptionSelector = (state: State): boolean => {
+  const {authMethod} = state
+  return authMethod === AuthMethodType.MNEMONIC || authMethod === AuthMethodType.KEY_FILE
 }
 
 /*

--- a/app/frontend/state.ts
+++ b/app/frontend/state.ts
@@ -28,7 +28,6 @@ export interface State {
   error?: any
   activeMainTab: MainTabs
   shouldShowContactFormModal?: boolean
-  shouldShowExportOption?: boolean
   conversionRates?: {data: {USD: number; EUR: number}}
 
   // cache


### PR DESCRIPTION
A mini PR which removes shouldShowExportOption. I'd continue with other keys but then I remembered I was meant to refactor just the "form" global state