### PR TITLE
Force updated version of ssri recursive dependency

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -51,6 +51,7 @@
     "sinon": "^7.3.2"
   },
   "resolutions": {
+    "ssri": ">=8.0.1",
     "serialize-javascript": "^3.1.0",
     "minimist": "^1.2.2"
   }

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3081,6 +3081,13 @@ minimist@0.0.8, minimist@^1.2.0, minimist@^1.2.2, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
+minipass@^3.1.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.3.tgz#7d42ff1f39635482e15f9cdb53184deebd5815fd"
+  integrity sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==
+  dependencies:
+    yallist "^4.0.0"
+
 mississippi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/mississippi/-/mississippi-2.0.0.tgz#3442a508fafc28500486feea99409676e4ee5a6f"
@@ -4156,12 +4163,12 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
-ssri@^5.2.4:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/ssri/-/ssri-5.3.0.tgz#ba3872c9c6d33a0704a7d71ff045e5ec48999d06"
-  integrity sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==
+ssri@>=8.0.1, ssri@^5.2.4:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-8.0.1.tgz#638e4e439e2ffbd2cd289776d5ca457c4f51a2af"
+  integrity sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==
   dependencies:
-    safe-buffer "^5.1.1"
+    minipass "^3.1.1"
 
 static-extend@^0.1.1:
   version "0.1.2"


### PR DESCRIPTION
Motivation: We need to update to ssri >= 8.0.1 as reported by dependabot but it is a recursive dependency of webpack which is currently at version 4 and the latest minor version of webpack 4 (https://www.npmjs.com/package/webpack/v/4.46.0) uses ssri ^6.0.1 which is not enough and doesn't allow an automatic update of the dependency.

The suggested solution is to force ssri 8.0.1 over the previously used version 5.3.0, from the changelog: https://github.com/npm/ssri/blob/latest/CHANGELOG.md it seems that only new calls/bugfixes/error throwing behavior has been added, so as long as anything during compilation/runtime doesn't crash it should be fine.

However, we should consider updating to webpack version 5, which seems to make sense alongside the introduction of hot reloading which would require significant modifications of the current webpack config anyway