### PR TITLE
Cache backend for cypress and lower sleep time for tx submit mock

### DIFF
--- a/app/cypress/tsconfig.json
+++ b/app/cypress/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["es5", "dom"],
+    "target": "es2019",
+    "lib": ["es2019", "dom"],
     "types": ["cypress", "@testing-library/cypress"]
   },
   "include": ["**/*.ts"]

--- a/server/mocking.js
+++ b/server/mocking.js
@@ -18,7 +18,7 @@ module.exports = function(app, env) {
       })
     }
 
-    await sleep(5000)
+    await sleep(100)
 
     const success = process.env.ADALITE_MOCK_TX_SUBMISSION_SUCCESS === 'true'
 
@@ -46,7 +46,7 @@ module.exports = function(app, env) {
       }
     }
 
-    await sleep(1000)
+    await sleep(100)
 
     return res.json(response)
   })
@@ -62,7 +62,7 @@ module.exports = function(app, env) {
       })
     }
 
-    await sleep(600)
+    await sleep(100)
 
     return res.json({
       Right: 'Successfuly subscribed',


### PR DESCRIPTION
- Implements rather a very simple caching of request for cypress,
(open to suggestions on the hash function or the approach)
the alternative would be to create create a separate command that runs the tests and creates fixtures for the tests, tho this would require a bit more work and I doubt it would speed the testing process up.
- Lowers the sleep time when mocking requests. 

Improved integration tests duration, previously ~4:30 now ~3:00 

Gotcha: 
- let me know if the previous sleep durations had some special purpose other than mimicking the real response time, if we still consider this useful I can create a .env variable on which would the sleep time depend, and set it to 0 for cypres. IMO we dont need the mimicking of real response time anywhere.