### PR TITLE
Refactor tx plan computation into recursive

### DIFF
--- a/app/frontend/actions/common.ts
+++ b/app/frontend/actions/common.ts
@@ -64,6 +64,7 @@ export default (store: Store) => {
         success: false,
         estimatedFee: 0 as Lovelace,
         minimalLovelaceAmount: 0 as Lovelace,
+        deposit: 0 as Lovelace,
         error: {code: e.name},
       }
     }

--- a/app/frontend/actions/delegate.ts
+++ b/app/frontend/actions/delegate.ts
@@ -83,10 +83,14 @@ export default (store: Store) => {
         calculatingDelegationFee: false,
         txSuccessTab: newState.txSuccessTab === 'send' ? newState.txSuccessTab : '',
       })
+      setError(state, {
+        errorName: 'delegationValidationError',
+        error: null,
+      })
     } else {
       // REFACTOR: (Untyped errors)
       const validationError =
-        delegationPlanValidator(balance, 0 as Lovelace, txPlanResult.estimatedFee) ||
+        delegationPlanValidator(balance, txPlanResult.deposit, txPlanResult.estimatedFee) ||
         txPlanResult.error
       setError(state, {
         errorName: 'delegationValidationError',

--- a/app/frontend/wallet/account.ts
+++ b/app/frontend/wallet/account.ts
@@ -21,12 +21,7 @@ import {
   getStakingXpub,
 } from './shelley/shelley-address-provider'
 
-import {
-  selectMinimalTxPlan,
-  isUtxoProfitable,
-  TxPlan,
-  TxPlanResult,
-} from './shelley/shelley-transaction-planner'
+import {selectMinimalTxPlan, TxPlan, TxPlanResult} from './shelley/shelley-transaction-planner'
 import shuffleArray from './helpers/shuffleArray'
 import {MaxAmountCalculator} from './max-amount-calculator'
 import {
@@ -275,7 +270,7 @@ const Account = ({
 
   async function getMaxSendableAmount(address: Address, sendAmount: SendAmount) {
     // TODO: why do we need hasDonation?
-    const utxos = (await getUtxos()).filter(isUtxoProfitable)
+    const utxos = await getUtxos()
     return _getMaxSendableAmount(utxos, address, sendAmount)
   }
 

--- a/app/frontend/wallet/shelley/helpers/stakepoolRegistrationUtils.ts
+++ b/app/frontend/wallet/shelley/helpers/stakepoolRegistrationUtils.ts
@@ -112,6 +112,7 @@ const unsignedPoolTxToTxPlan = (unsignedTx: _UnsignedTxParsed, stakingAddress: A
     deposit: 0 as Lovelace,
     additionalLovelaceAmount: 0 as Lovelace,
     fee: parseCliFee(unsignedTx.fee) as Lovelace,
+    baseFee: parseCliFee(unsignedTx.fee) as Lovelace,
     withdrawals: parseCliWithdrawals(unsignedTx.withdrawals, stakingAddress),
   }
 }

--- a/app/tests/src/common/tx-settings.js
+++ b/app/tests/src/common/tx-settings.js
@@ -61,6 +61,7 @@ const transactionSettings = {
         certificates: [],
         deposit: 0,
         fee: 174850,
+        baseFee: 174850,
         additionalLovelaceAmount: 0,
         withdrawals: [],
       },
@@ -137,6 +138,7 @@ const transactionSettings = {
         certificates: [],
         deposit: 0,
         fee: 176871,
+        baseFee: 176871,
         additionalLovelaceAmount: 1481480,
         withdrawals: [],
       },
@@ -185,6 +187,7 @@ const transactionSettings = {
         ],
         deposit: 2000000,
         fee: 187989,
+        baseFee: 187989,
         additionalLovelaceAmount: 0,
         withdrawals: [],
       },
@@ -222,6 +225,7 @@ const transactionSettings = {
         certificates: [],
         deposit: 0,
         fee: 179156,
+        baseFee: 179156,
         additionalLovelaceAmount: 0,
         withdrawals: [
           {

--- a/app/tests/src/index.js
+++ b/app/tests/src/index.js
@@ -31,4 +31,7 @@ describe('AdaLite Test Suite', () => {
   describe('Token bundle', () => {
     require('./tokenBundle')
   })
+  describe('Transaction planning', () => {
+    require('./transaction-planner')
+  })
 })

--- a/app/tests/src/transaction-planner.js
+++ b/app/tests/src/transaction-planner.js
@@ -1,0 +1,65 @@
+import assert from 'assert'
+import {selectMinimalTxPlan} from '../../frontend/wallet/shelley/shelley-transaction-planner'
+import {AssetFamily, TxType} from '../..//frontend/types'
+
+const utxos = {
+  utxo1: {
+    txHash: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+    address:
+      'addr1q8eakg39wqlye7lzyfmh900s2luc99zf7x9vs839pn4srjs2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsjv0zk3',
+    coins: 1000000,
+    outputIndex: 1,
+    tokenBundle: [],
+  },
+  utxo2: {
+    txHash: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+    address:
+      'addr1q8eakg39wqlye7lzyfmh900s2luc99zf7x9vs839pn4srjs2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsjv0zk3',
+    coins: 2000000,
+    outputIndex: 0,
+    tokenBundle: [],
+  },
+}
+
+const successPlanFixtures = {
+  'not add fee to change': {
+    args: {
+      address:
+        'addr1qjag9rgwe04haycr283datdrjv3mlttalc2waz34xcct0g4uvf6gdg3dpwrsne4uqng3y47ugp2pp5dvuq0jqlperwj83r4pwxvwuxsgds90s0',
+      coins: 1500000,
+      sendAmount: {assetFamily: AssetFamily.ADA, fieldValue: `${1.5}`, coins: 1500000},
+      txType: TxType.SEND_ADA,
+    },
+    changeAddress:
+      'addr1q8eakg39wqlye7lzyfmh900s2luc99zf7x9vs839pn4srjs2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsjv0zk3',
+    utxos: [utxos.utxo2, utxos.utxo1],
+    fee: 178541,
+  },
+  'add fee to change': {
+    args: {
+      address:
+        'addr1qjag9rgwe04haycr283datdrjv3mlttalc2waz34xcct0g4uvf6gdg3dpwrsne4uqng3y47ugp2pp5dvuq0jqlperwj83r4pwxvwuxsgds90s0',
+      coins: 1500000,
+      sendAmount: {assetFamily: AssetFamily.ADA, fieldValue: `${1.5}`, coins: 1500000},
+      txType: TxType.SEND_ADA,
+    },
+    changeAddress:
+      'addr1q8eakg39wqlye7lzyfmh900s2luc99zf7x9vs839pn4srjs2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsjv0zk3',
+    utxos: [utxos.utxo2],
+    fee: 500000,
+  },
+}
+
+describe('Succesful transaction plans', () => {
+  Object.entries(successPlanFixtures).forEach(([name, setting]) =>
+    it(`should ${name}`, () => {
+      const {utxos, changeAddress, fee, args} = setting
+      const txPlanResult = selectMinimalTxPlan(utxos, changeAddress, args)
+      if (txPlanResult.success === true) {
+        assert.equal(txPlanResult.txPlan.fee, fee)
+      } else {
+        assert(false, 'Transaction plan is not succesful')
+      }
+    })
+  )
+})


### PR DESCRIPTION
Previously:
- tx plan computation was in a really ugly for cycle
- in case wallet has for example a two utxos 2 ADA and 5 ADA, there was a 50% chance that the 2 ADA utxo gets to the tx plan computation first and if user wanted to send 1.1 ADA, 0.9 would be added to the fee (since its too small for change output) 
- if a wallet didn't have registered staking key, and had less then amount 2ADA balance, no error was shown

Changes: 
 - tx plan computation refactored into recursion
 - we try to add the change to the fee only if the plan computation with all utxos failed
 - error is shown didn't have registered staking key, and had less then amount 2ADA balance