### PR TITLE
Refactor caching of transaction plans

### DIFF
--- a/app/frontend/actions/common.ts
+++ b/app/frontend/actions/common.ts
@@ -18,6 +18,7 @@ export default (store: Store) => {
 
   const resetTransactionSummary = (state: State) => {
     setState({
+      // Refactor: remove when `setTransactionSummaryOld` will not exist
       sendTransactionSummary: {
         // TODO: we should reset this to null
         type: TxType.SEND_ADA,
@@ -28,6 +29,8 @@ export default (store: Store) => {
         fee: 0 as Lovelace,
         plan: null,
       },
+      // TODO: this can be smarter, dummy reset for now
+      cachedTransactionSummaries: {},
     })
   }
 
@@ -66,7 +69,8 @@ export default (store: Store) => {
     }
   }
 
-  const setTransactionSummary = (
+  // Refactor: remove once not used
+  const setTransactionSummaryOld = (
     plan: TxPlan,
     transactionSummary:
       | SendTransactionSummary
@@ -83,6 +87,33 @@ export default (store: Store) => {
     })
   }
 
+  // Refactor: remove once not used
+  const setTransactionSummary = (
+    state: State,
+    {
+      plan,
+      transactionSummary,
+    }: {
+      plan: TxPlan
+      transactionSummary:
+        | SendTransactionSummary
+        | WithdrawTransactionSummary
+        | DelegateTransactionSummary
+        | DeregisterStakingKeyTransactionSummary
+    }
+  ) => {
+    setState({
+      cachedTransactionSummaries: {
+        ...state.cachedTransactionSummaries,
+        [transactionSummary.type]: {
+          ...transactionSummary,
+          fee: plan.fee,
+          plan,
+        },
+      },
+    })
+  }
+
   const resetAccountIndexes = (state: State) => {
     setState({
       targetAccountIndex: state.activeAccountIndex,
@@ -95,6 +126,7 @@ export default (store: Store) => {
     resetSendFormFields,
     prepareTxPlan,
     setTransactionSummary,
+    setTransactionSummaryOld,
     resetAccountIndexes,
   }
 }

--- a/app/frontend/actions/delegate.ts
+++ b/app/frontend/actions/delegate.ts
@@ -9,7 +9,7 @@ import {delegationPlanValidator} from '../helpers/validators'
 export default (store: Store) => {
   const {setState, getState} = store
   const {setError} = errorActions(store)
-  const {prepareTxPlan, setTransactionSummary} = commonActions(store)
+  const {prepareTxPlan, setTransactionSummaryOld} = commonActions(store)
 
   const hasPoolIdentifiersChanged = (state: State) => {
     const {shelleyDelegation: newShelleyDelegation} = getState()
@@ -78,7 +78,7 @@ export default (store: Store) => {
         deposit: txPlanResult.txPlan.deposit,
         stakePool: newState.shelleyDelegation?.selectedPool,
       }
-      setTransactionSummary(txPlanResult.txPlan, delegationTransactionSummary)
+      setTransactionSummaryOld(txPlanResult.txPlan, delegationTransactionSummary)
       setState({
         calculatingDelegationFee: false,
         txSuccessTab: newState.txSuccessTab === 'send' ? newState.txSuccessTab : '',

--- a/app/frontend/actions/poolOwner.ts
+++ b/app/frontend/actions/poolOwner.ts
@@ -155,8 +155,12 @@ export default (store: Store) => {
         rewards,
       } as DeregisterStakingKeyTransactionSummary
 
-      setTransactionSummary(txPlanResult.txPlan, summary)
-      await confirmTransaction(getState(), 'deregisterStakeKey')
+      setTransactionSummary(getState(), {plan: txPlanResult.txPlan, transactionSummary: summary})
+      await confirmTransaction(getState(), {
+        sourceAccountIndex: sourceAccount.accountIndex,
+        txPlan: txPlanResult.txPlan,
+        txConfirmType: TxType.DEREGISTER_STAKE_KEY,
+      })
     } else {
       // Handled the same way as for withdrawal
       const withdrawalValidationError =

--- a/app/frontend/actions/send.ts
+++ b/app/frontend/actions/send.ts
@@ -14,7 +14,7 @@ import debounceEvent from '../helpers/debounceEvent'
 export default (store: Store) => {
   const {setState, getState} = store
   const {setError} = errorActions(store)
-  const {resetTransactionSummary, setTransactionSummary, prepareTxPlan} = commonActions(store)
+  const {resetTransactionSummary, setTransactionSummaryOld, prepareTxPlan} = commonActions(store)
 
   const validateSendForm = (state: State) => {
     setError(state, {
@@ -105,7 +105,7 @@ export default (store: Store) => {
         token,
         minimalLovelaceAmount: txPlanResult.txPlan.additionalLovelaceAmount,
       }
-      setTransactionSummary(txPlanResult.txPlan, sendTransactionSummary)
+      setTransactionSummaryOld(txPlanResult.txPlan, sendTransactionSummary)
       setState({
         calculatingFee: false,
         txSuccessTab: '',

--- a/app/frontend/components/pages/delegations/delegatePage.tsx
+++ b/app/frontend/components/pages/delegations/delegatePage.tsx
@@ -13,6 +13,7 @@ import {StakePoolInfo} from './stakePoolInfo'
 import DelegateInput from './delegateInput'
 import {ADALITE_CONFIG} from '../../../../frontend/config'
 import {StakepoolDataProvider} from '../../../../frontend/helpers/dataProviders/types'
+import {TxType} from '../../../types'
 
 const CalculatingFee = (): h.JSX.Element => (
   <div className="validation-message send">Calculating fee...</div>
@@ -134,7 +135,7 @@ const Delegate = ({withAccordion, title}: Props): h.JSX.Element => {
     isBigDelegator: isBigDelegatorSelector(state),
     validStakepoolDataProvider: state.validStakepoolDataProvider,
   }))
-  const {confirmTransaction, updateStakePoolIdentifier, resetStakePoolIndentifier} = useActions(
+  const {confirmTransactionOld, updateStakePoolIdentifier, resetStakePoolIndentifier} = useActions(
     actions
   )
   const handleOnStopTyping = useHandleOnStopTyping()
@@ -184,7 +185,7 @@ const Delegate = ({withAccordion, title}: Props): h.JSX.Element => {
   }, [currentDelegation, handleInputValidation, poolRecommendation])
 
   const delegationHandler = async (): Promise<void> => {
-    await confirmTransaction('delegate')
+    await confirmTransactionOld(TxType.DELEGATE)
   }
 
   const validationError = !!delegationValidationError || !!error || !stakePool

--- a/app/frontend/components/pages/delegations/deregisterStakeKey.tsx
+++ b/app/frontend/components/pages/delegations/deregisterStakeKey.tsx
@@ -1,16 +1,10 @@
 import {h} from 'preact'
-import {useActions, useSelector} from '../../../helpers/connect'
+import {useActions} from '../../../helpers/connect'
 import actions from '../../../actions'
 import {useIsActiveAccountDelegating} from '../../../selectors'
 
 const DeregisterStakeKeyPage = () => {
   const {deregisterStakingKey} = useActions(actions)
-
-  /*
-  REFACTOR (calculateFee):
-  After "calculateFee" refactor "calculatingDelegationFee" should be removed.
-  */
-  const calculatingDelegationFee = useSelector((state) => state.calculatingDelegationFee)
   const isDelegating = useIsActiveAccountDelegating()
 
   if (!isDelegating) return null
@@ -21,11 +15,7 @@ const DeregisterStakeKeyPage = () => {
       <p className="deregister-stake-key-card-disclaimer">
         ...if you do not want to use this wallet anymore
       </p>
-      <button
-        className="button secondary cancel-delegation"
-        disabled={calculatingDelegationFee}
-        onClick={() => deregisterStakingKey()}
-      >
+      <button className="button secondary cancel-delegation" onClick={() => deregisterStakingKey()}>
         Deregister stake key
       </button>
     </div>

--- a/app/frontend/components/pages/sendAda/sendAdaPage.tsx
+++ b/app/frontend/components/pages/sendAda/sendAdaPage.tsx
@@ -17,6 +17,7 @@ import {
   SendTransactionSummary,
   Token,
   TransactionSummary,
+  TxType,
 } from '../../../types'
 import {AdaIcon} from '../../common/svg'
 import {parseCoins} from '../../../../frontend/helpers/validators'
@@ -135,7 +136,7 @@ const SendAdaPage = ({
   const {
     updateAddress,
     updateAmount,
-    confirmTransaction,
+    confirmTransactionOld,
     sendMaxFunds,
     setSourceAccount,
     setTargetAccount,
@@ -196,7 +197,7 @@ const SendAdaPage = ({
   }, [adaAsset, dropdownAssetItems, sendAmount])
 
   const submitHandler = async () => {
-    await confirmTransaction('send')
+    await confirmTransactionOld(TxType.SEND_ADA)
   }
 
   const searchPredicate = useCallback(

--- a/app/frontend/state.ts
+++ b/app/frontend/state.ts
@@ -12,6 +12,7 @@ import {
   SendAmount,
   Stakepool,
   TransactionSummary,
+  CachedTransactionSummaries,
   TxType,
 } from './types'
 
@@ -79,10 +80,12 @@ export interface State {
 
   // transaction
   sendTransactionSummary: TransactionSummary
+  cachedTransactionSummaries: CachedTransactionSummaries
   rawTransactionOpen: boolean
   rawTransaction: string
   transactionFee?: any
-  txConfirmType: string
+  txConfirmType?: TxType
+  isCrossAccount: boolean
   txSuccessTab: string
   transactionSubmissionError?: any
   shouldShowConfirmTransactionDialog?: boolean
@@ -186,10 +189,11 @@ const initialState: State = {
     fee: 0 as Lovelace,
     plan: null,
   },
+  cachedTransactionSummaries: {},
   rawTransactionOpen: false,
   rawTransaction: '',
   transactionFee: 0,
-  txConfirmType: '',
+  isCrossAccount: false,
   txSuccessTab: '',
   keepConfirmationDialogOpen: false,
 

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -256,6 +256,18 @@ export type DeregisterStakingKeyTxPlanArgs = {
   stakingAddress: Address
 }
 
+// Note: This allows for multiple transaction summaries by TxType, to avoid race-conditions
+// when calculating transaction summaries for more TxTypes at the same time.
+// Note that this still does not allow for multiple cached transaction summaries from
+// the same TxType, however, this should not be use-case for us in the near future.
+export type CachedTransactionSummaries = {
+  [TxType.CONVERT_LEGACY]?: TransactionSummary & SendTransactionSummary
+  [TxType.SEND_ADA]?: TransactionSummary & SendTransactionSummary
+  [TxType.WITHDRAW]?: TransactionSummary & WithdrawTransactionSummary
+  [TxType.DELEGATE]?: TransactionSummary & DelegateTransactionSummary
+  [TxType.DEREGISTER_STAKE_KEY]?: TransactionSummary & DeregisterStakingKeyTransactionSummary
+}
+
 export type TxPlanArgs =
   | SendAdaTxPlanArgs
   | ConvertLegacyAdaTxPlanArgs


### PR DESCRIPTION
* cache txPlan per TxType to avoid race-conditions
* require explicit params for "confirm" and "submitTransaction"
* keep backward functionality ("old" prefixes) for parts that were
not updated yet
* remove unnecessary race-condition check from deregister staking screen

This one is copy of https://github.com/vacuumlabs/adalite/pull/917, but due to changes in `actions.ts` it was easier to create new PR. I will close original PR and delete its branch once this is merged.