### PR TITLE
Refactoring README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,8 @@ Some notes on how to implement new coin into Trezor can be found here: https://g
 Hot reloading is not working well with components that use `connect`. The project is leading towards removal of `connect` and its
 replacement by `useSelector` so eventually this issue should be solved.
 The issue you can experience with `connect` is that components would stop receiving state updates and you therefore need to reload the app.
+
+## Refactoring
+
+As all projects also this one would appreciate some refactoring love. To save some time on identifying potential source for refactoring
+see [refactoring-proposal](https://docs.google.com/document/d/1rlEI2KvzVmWMgITuK86YEN_WVjH8h6fJH9EvZN9Isko/edit?usp=sharing).


### PR DESCRIPTION
@refi93 @ppershing please see the doc this PR refers to.

About "css-modules": I plan to configure this once https://github.com/vacuumlabs/adalite/pull/958 is merged and introduce some demo usage. After that, this could be done in incremental batches.

About "Use “cachedTransactionSummaries” for all action types". I discussed with @xdzurman and @PeterBenc that it would be worth it to finish this one, so we will try to allocate time for that in the near future.