### PR TITLE
Bulk export gradually more public keys

### DIFF
--- a/app/frontend/errors/unexpectedErrorReason.ts
+++ b/app/frontend/errors/unexpectedErrorReason.ts
@@ -3,6 +3,7 @@ export enum UnexpectedErrorReason {
   ParamsValidationError = 'ParamsValidationError',
   InvalidCertificateType = 'InvalidCertificateType',
   AccountExplorationError = 'AccountExplorationError',
+  BulkExportCreationError = 'BulkExportCreationError',
   InvalidTxPlanType = 'InvalidTxPlanType',
   InvalidRelayType = 'InvalidRelayType',
   CannotConstructTxPlan = 'CannotConstructTxPlan',

--- a/app/frontend/wallet/constants.ts
+++ b/app/frontend/wallet/constants.ts
@@ -116,6 +116,6 @@ export const TREZOR_ERRORS = {
   [CryptoProviderFeature.POOL_OWNER]: InternalErrorReason.TrezorPoolRegNotSupported,
 }
 
-export const MAX_ACCOUNT_INDEX = 30
+export const MAX_ACCOUNT_INDEX = 29
 
-export const MAX_BULK_EXPORT_AMOUNT = 5
+export const EXPORTED_PATHS_SLICE_SIZE = 5

--- a/app/frontend/wallet/constants.ts
+++ b/app/frontend/wallet/constants.ts
@@ -116,6 +116,4 @@ export const TREZOR_ERRORS = {
   [CryptoProviderFeature.POOL_OWNER]: InternalErrorReason.TrezorPoolRegNotSupported,
 }
 
-export const MAX_ACCOUNT_INDEX = 29
-
-export const EXPORTED_PATHS_SLICE_SIZE = 5
+export const MAX_ACCOUNT_INDEX = 30

--- a/app/frontend/wallet/helpers/CachedDeriveXpubFactory.ts
+++ b/app/frontend/wallet/helpers/CachedDeriveXpubFactory.ts
@@ -1,5 +1,5 @@
 import indexIsHardened from './indexIsHardened'
-import {HARDENED_THRESHOLD, MAX_BULK_EXPORT_AMOUNT} from './../constants'
+import {HARDENED_THRESHOLD, EXPORTED_PATHS_SLICE_SIZE} from './../constants'
 import {derivePublic as deriveChildXpub} from 'cardano-crypto.js'
 import {isShelleyPath} from '../../wallet/shelley/helpers/addresses'
 import {BIP32Path} from '../../types'
@@ -17,9 +17,9 @@ function CachedDeriveXpubFactory(derivationScheme, shouldExportPubKeyBulk, deriv
         absDerivationPath.length === 0 || indexIsHardened(absDerivationPath.slice(-1)[0])
 
       /*
-      * we create pubKeyBulk only if the derivation path is from shelley era
-      * since there should be only one byron account exported in the fist shelley pubKey bulk
-      */
+       * we create pubKeyBulk only if the derivation path is from shelley era
+       * since there should be only one byron account exported in the fist shelley pubKey bulk
+       */
 
       if (deriveHardened) {
         const derivationPaths =
@@ -34,10 +34,10 @@ function CachedDeriveXpubFactory(derivationScheme, shouldExportPubKeyBulk, deriv
     }
 
     /*
-    * we await the derivation of the key so in case the derivation fails
-    * the key is not added to the cache
-    * this approach depends on the key derivation happening sychronously
-    */
+     * we await the derivation of the key so in case the derivation fails
+     * the key is not added to the cache
+     * this approach depends on the key derivation happening sychronously
+     */
 
     return derivedXpubs[memoKey]
   }
@@ -48,30 +48,42 @@ function CachedDeriveXpubFactory(derivationScheme, shouldExportPubKeyBulk, deriv
     return deriveChildXpub(parentXpub, lastIndex, derivationScheme.ed25519Mode)
   }
 
+  function getExportedBulkSize(currentAccountSlice: number) {
+    if (currentAccountSlice === 0) {
+      return 5
+    }
+    if (currentAccountSlice === 1) {
+      return 10
+    }
+    return 15
+  }
+
   function createPathBulk(derivationPath: BIP32Path): BIP32Path[] {
     const paths: BIP32Path[] = []
     const accountIndex = derivationPath[2] - HARDENED_THRESHOLD
-    const currentAccountPage = Math.floor(accountIndex / MAX_BULK_EXPORT_AMOUNT)
+    const currentAccountSlice = Math.floor(accountIndex / EXPORTED_PATHS_SLICE_SIZE)
+    const exportedBulkSize = getExportedBulkSize(currentAccountSlice)
 
-    for (let i = 0; i < MAX_BULK_EXPORT_AMOUNT; i += 1) {
-      const nextAccountIndex = currentAccountPage * MAX_BULK_EXPORT_AMOUNT + i + HARDENED_THRESHOLD
+    for (let i = 0; i < exportedBulkSize; i += 1) {
+      const nextAccountIndex =
+        currentAccountSlice * EXPORTED_PATHS_SLICE_SIZE + i + HARDENED_THRESHOLD
       const nextAccountPath = [...derivationPath.slice(0, -1), nextAccountIndex]
       paths.push(nextAccountPath)
     }
 
     /*
-    * in case of the account 0 we append also the byron path
-    * since during byron era only the first account was used
-    */
+     * in case of the account 0 we append also the byron path
+     * since during byron era only the first account was used
+     */
     if (accountIndex === 0 && !paths.includes(BYRON_V2_PATH)) paths.push(BYRON_V2_PATH)
 
     return paths
   }
 
   /*
-  * on top of the original deriveXpubHardenedFn this is priming
-  * the cache of derived keys to minimize the number of prompts on hardware wallets
-  */
+   * on top of the original deriveXpubHardenedFn this is priming
+   * the cache of derived keys to minimize the number of prompts on hardware wallets
+   */
   async function _deriveXpubsHardenedFn(derivationPaths: BIP32Path[]): Promise<any> {
     const xPubBulk = await deriveXpubsHardenedFn(derivationPaths)
     const _derivedXpubs = {}


### PR DESCRIPTION
Motivation: 
 - for wallets that have a lot of account ist more convenient to export public key by batches bigger than 5

Changes: 
 - public keys are exported in batches of 5, 10, 20, 20.... (from 20 the batch stays the same, exporting more than 20 key from ledger takes a bit too long)