### PR TITLE
Check max utxo size also for change

### DIFF
--- a/app/frontend/wallet/shelley/shelley-transaction-planner.ts
+++ b/app/frontend/wallet/shelley/shelley-transaction-planner.ts
@@ -384,7 +384,11 @@ const validateTxPlan = (txPlanResult: TxPlanResult): TxPlanResult => {
     }
   }
 
-  if (outputs.some((output) => encode(cborizeSingleTxOutput(output)).length > MAX_TX_OUTPUT_SIZE)) {
+  if (
+    outputsWithChange.some(
+      (output) => encode(cborizeSingleTxOutput(output)).length > MAX_TX_OUTPUT_SIZE
+    )
+  ) {
     return {
       ...noTxPlan,
       error: {code: InternalErrorReason.OutputTooBig},


### PR DESCRIPTION
Motivation: 
 - previously we were checking only outputs without change for max utxo size :facepalm: 

Changes: 
 - we check also change for max utxo size

Gotcha: 
- ideally we would create multiple outputs for transactions containing too many tokens but that would require significantly more work, I suggest we address it separately, since this anyway effect small minority of users.