### PR TITLE
Disable trezor on mobile devices

### DIFF
--- a/app/frontend/components/pages/login/hardwareAuth.tsx
+++ b/app/frontend/components/pages/login/hardwareAuth.tsx
@@ -7,6 +7,7 @@ import {useActions} from '../../../helpers/connect'
 import actions from '../../../actions'
 import {useState, useCallback} from 'preact/hooks'
 import {localStorageVars} from '../../../localStorage'
+import {isMobileOnly} from 'react-device-detect'
 
 const LoadByHardwareWalletSection = () => {
   const {loadWallet} = useActions(actions)
@@ -46,11 +47,12 @@ const LoadByHardwareWalletSection = () => {
             dangerouslySetInnerHTML={{__html: '&nbsp;'}}
           />
           <button
-            disabled={!ADALITE_CONFIG.ADALITE_ENABLE_TREZOR}
+            disabled={!ADALITE_CONFIG.ADALITE_ENABLE_TREZOR || isMobileOnly}
             {...tooltip(
               'Support for Trezor is temporarily disabled',
               !ADALITE_CONFIG.ADALITE_ENABLE_TREZOR
             )}
+            {...tooltip('Not supported on mobile devices', isMobileOnly)}
             className="button primary trezor thin-data-balloon"
             onClick={() =>
               loadWallet({

--- a/app/frontend/wallet/shelley/shelley-ledger-crypto-provider.ts
+++ b/app/frontend/wallet/shelley/shelley-ledger-crypto-provider.ts
@@ -12,7 +12,7 @@ import {
   cborizeTxAuxiliaryVotingData,
   ShelleyTxAux,
 } from './shelley-transaction'
-import * as platform from 'platform'
+import {isWindows, isOpera} from 'react-device-detect'
 import {hasRequiredVersion} from './helpers/version-check'
 import {LEDGER_VERSIONS, LEDGER_ERRORS} from '../constants'
 import {captureMessage} from '@sentry/browser'
@@ -66,7 +66,7 @@ import assertUnreachable from '../../helpers/assertUnreachable'
 
 const isWebUsbSupported = async (): Promise<boolean> => {
   const isSupported = await LedgerTransportWebUsb.isSupported()
-  return isSupported && platform.os.family !== 'Windows' && platform.name !== 'Opera'
+  return isSupported && !isWindows && !isOpera
 }
 
 const isWebHidSupported = async (): Promise<boolean> => {

--- a/app/package.json
+++ b/app/package.json
@@ -31,8 +31,8 @@
     "chacha": "^2.1.0",
     "lodash": "^4.17.21",
     "pbkdf2": "^3.1.2",
-    "platform": "^1.3.6",
     "preact": "^10.5.11",
+    "react-device-detect": "^1.17.0",
     "trezor-connect": "^8.1.26"
   },
   "devDependencies": {

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2029,11 +2029,6 @@ pify@^2.2.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
   integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
 
-platform@^1.3.6:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
-  integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
-
 preact@^10.5.11:
   version "10.5.11"
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.11.tgz#2c8a431f16613e442901068175771806cf1cc0f6"
@@ -2108,6 +2103,13 @@ randombytes@^2.0.1:
   integrity sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==
   dependencies:
     safe-buffer "^5.1.0"
+
+react-device-detect@^1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/react-device-detect/-/react-device-detect-1.17.0.tgz#a00b4fd6880cebfab3fd8a42a79dc0290cdddca9"
+  integrity sha512-bBblIStwpHmoS281JFIVqeimcN3LhpoP5YKDWzxQdBIUP8S2xPvHDgizLDhUq2ScguLfVPmwfF5y268EEQR60w==
+  dependencies:
+    ua-parser-js "^0.7.24"
 
 react-is@^17.0.1:
   version "17.0.1"
@@ -2483,6 +2485,11 @@ u2f-api@0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/u2f-api/-/u2f-api-0.2.7.tgz#17bf196b242f6bf72353d9858e6a7566cc192720"
   integrity sha512-fqLNg8vpvLOD5J/z4B6wpPg4Lvowz1nJ9xdHcCzdUPKcFE/qNCceV2gNZxSJd5vhAZemHr/K/hbzVA0zxB5mkg==
+
+ua-parser-js@^0.7.24:
+  version "0.7.28"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"
+  integrity sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==
 
 unbox-primitive@^1.0.0:
   version "1.0.1"

--- a/webpack.build.config.js
+++ b/webpack.build.config.js
@@ -131,6 +131,7 @@ module.exports = {
       'unistore': `${__dirname}/app/frontend/libs/unistore`,
       'file-saver': `${__dirname}/app/frontend/libs/file-saver`,
       'qrious': `${__dirname}/app/frontend/libs/qrious`,
+      'react': 'preact/compat',
     },
     extensions: ['.tsx', '.ts', '.js', '.wasm'],
   },

--- a/webpack.test.config.js
+++ b/webpack.test.config.js
@@ -23,5 +23,8 @@ module.exports = {
   },
   resolve: {
     extensions: ['.tsx', '.ts', '.js'],
+    alias: {
+      react: 'preact/compat',
+    },
   },
 }


### PR DESCRIPTION
Changes: 
 - one fix in webpack related to this issue https://github.com/preactjs/preact/issues/1334
 - remove `platform` lib, it seems its no longer maintained and it didn't offer the API we need
 - add `react-device-detect-lib` as a better replacement
 
 Fixes: #1010