### PR TITLE
Hotfix epoch boundary error catching

### DIFF
--- a/app/frontend/actions/common.ts
+++ b/app/frontend/actions/common.ts
@@ -56,6 +56,7 @@ export default (store: Store) => {
       if (
         e.name !== InternalErrorReason.NetworkError &&
         e.name !== InternalErrorReason.ServerError &&
+        e.name !== InternalErrorReason.EpochBoundaryUnderway &&
         e.name !== InternalErrorReason.TxTooBig &&
         e.name !== InternalErrorReason.OutputTooBig
       ) {

--- a/server/transactionSubmitter.js
+++ b/server/transactionSubmitter.js
@@ -51,7 +51,7 @@ module.exports = function(app, env) {
         isSameOrigin(req.get('origin'), backendConfig.ADALITE_SERVER_URL)
       ) {
         Sentry.captureException(new Error('TransactionSubmissionFailed'), {
-          contexts: [{...JSON.parse(errorMessage)}],
+          contexts: [{errorMessage}],
         })
       }
 


### PR DESCRIPTION
Gotcha: we should really do the second part of the error handling refactor, I recommend we do this in a separate issue and have this merged as soon as possible to avoid more sentry errors.

Fixes:

1. Sometimes the error returned by the server is not a JSON but a HTML which then caused error response parsing to fail with `Unexpected token < in JSON at position 0` - for the sake of error logging we may as well pass the response directly to sentry
2. If a user happened to be logged into adalite during an epoch boundary and trying to compute a tx plan, they would get a sentry modal instead of a standard error modal - the custom EpochBoundaryUnderway error was missing from the logic that catches "known" exceptions to display a proper error modal