### PR TITLE
Handle "NotAllowedError: Failed to open the device." for Ledger in MacOS

### DIFF
--- a/app/frontend/errors/errorMessages.ts
+++ b/app/frontend/errors/errorMessages.ts
@@ -139,6 +139,8 @@ const internalErrorMessages: {[key in InternalErrorReason]: (params?: any) => st
     const errors = {
       'NotFoundError: The device was disconnected.': `${message} ${hwWalletTroubleshootingSuggestion}`,
       'AbortError: The transfer was cancelled.': `${message} ${hwWalletTroubleshootingSuggestion}`,
+      // happens sometimes for WebHID on MacOS
+      'NotAllowedError: Failed to open the device.': `${message} ${hwWalletTroubleshootingSuggestion}`,
       // an issue with CryptoToken extension allowing 2-step verification
       // https://askubuntu.com/questions/844090/what-is-cryptotokenextension-in-chromium-extensions
       "SyntaxError: Failed to execute 'postMessage' on 'Window': Invalid target origin 'chrome-extension://kmendfapggjehodndflmmgagdbamhnfd' in a call to 'postMessage'": `${message} ${hwWalletTroubleshootingSuggestion}`,

--- a/app/frontend/errors/errorsWithHelp.ts
+++ b/app/frontend/errors/errorsWithHelp.ts
@@ -7,6 +7,7 @@ const errorsWithHelp = new Set([
   'DisconnectedDeviceDuringOperation',
   'TransportWebUSBGestureRequired',
   'NotFoundError',
+  'NotAllowedError',
   'AbortError',
   'TransportError',
   'Error',


### PR DESCRIPTION
This error seems to happen for some MacOS users with Ledger (supposedly on webhid transport) and now they are getting a general error modal. This PR improves the UX to show them a proper troubleshooting suggestion