### PR TITLE
Fix change when registering pool and add tests

### DIFF
--- a/app/frontend/wallet/shelley/helpers/stakepoolRegistrationUtils.ts
+++ b/app/frontend/wallet/shelley/helpers/stakepoolRegistrationUtils.ts
@@ -107,7 +107,7 @@ const unsignedPoolTxToTxPlan = (unsignedTx: _UnsignedTxParsed, stakingAddress: A
   return {
     inputs: parseCliInputs(unsignedTx.inputs),
     outputs: parseCliOutputs(unsignedTx.outputs),
-    change: null,
+    change: [],
     certificates: parseCliCertificates(unsignedTx.certificates, stakingAddress),
     deposit: 0 as Lovelace,
     additionalLovelaceAmount: 0 as Lovelace,

--- a/app/frontend/wallet/shelley/transaction/computeTxPlan.ts
+++ b/app/frontend/wallet/shelley/transaction/computeTxPlan.ts
@@ -292,7 +292,7 @@ export const validateTxPlan = (txPlanResult: TxPlanResult): TxPlanResult => {
     minimalLovelaceAmount: additionalLovelaceAmount,
   }
 
-  const outputsWithChange = change ? [...outputs, ...change] : outputs
+  const outputsWithChange = [...outputs, ...change]
   if (
     outputsWithChange.some(({coins, tokenBundle}) => {
       coins > Number.MAX_SAFE_INTEGER ||

--- a/app/tests/src/common/pool-reg-tx-settings.js
+++ b/app/tests/src/common/pool-reg-tx-settings.js
@@ -1,0 +1,176 @@
+export const poolRegTxSettings = {
+  'regular pool registration': {
+    unsignedTxParsed: {
+      inputs: [
+        {
+          txHash: Buffer.from(
+            '3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7',
+            'hex'
+          ),
+          outputIndex: 0,
+        },
+      ],
+      outputs: [
+        {
+          address: Buffer.from(
+            '017cb05fce110fb999f01abb4f62bc455e217d4a51fde909fa9aea545443ac53c046cf6a42095e3c60310fa802771d0672f8fe2d1861138b09',
+            'hex'
+          ),
+          coins: BigInt(1),
+          tokenBundle: [],
+        },
+      ],
+      fee: BigInt(42),
+      ttl: 10n,
+      certificates: [
+        {
+          type: 3,
+          poolKeyHash: Buffer.from(
+            '13381d918ec0283ceeff60f7f4fc21e1540e053ccf8a77307a7a32ad',
+            'hex'
+          ),
+          vrfPubKeyHash: Buffer.from(
+            '07821cd344d7fd7e3ae5f2ed863218cb979ff1d59e50c4276bdc479b0d084450',
+            'hex'
+          ),
+          pledge: BigInt(50000000000),
+          cost: BigInt(340000000),
+          margin: {numerator: 3, denominator: 100},
+          rewardAddress: Buffer.from(
+            'e1794d9b3408c9fb67b950a48a0690f070f117e9978f7fc1d120fc58ad',
+            'hex'
+          ),
+          poolOwnersPubKeyHashes: [
+            Buffer.from('1d227aefa4b773149170885aadba30aab3127cc611ddbc4999def61c', 'hex'),
+            Buffer.from('794d9b3408c9fb67b950a48a0690f070f117e9978f7fc1d120fc58ad', 'hex'),
+          ],
+          relays: [
+            {
+              ipv4: Buffer.from('36e44b9a', 'hex'),
+              ipv6: null,
+              portNumber: 3000,
+              type: 0,
+            },
+            {
+              ipv4: Buffer.from('36e44b9b', 'hex'),
+              ipv6: Buffer.from('0178ff2483e3a2330a34c4a5e576c207', 'hex'),
+              portNumber: 3000,
+              type: 0,
+            },
+            {
+              dnsName: 'aaaa.bbbb.com',
+              portNumber: 3000,
+              type: 1,
+            },
+            {
+              dnsName: 'aaaa.bbbc.com',
+              type: 2,
+            },
+          ],
+          metadata: {
+            metadataUrl: 'https://www.vacuumlabs.com/sampleUrl.json',
+            metadataHash: Buffer.from(
+              'cdb714fd722c24aeb10c93dbb0ff03bd4783441cd5ba2a8b6f373390520535bb',
+              'hex'
+            ),
+          },
+        },
+      ],
+      withdrawals: [],
+      metaDataHash: null,
+      meta: null,
+      validityIntervalStart: null,
+    },
+    txPlanResult: {
+      txPlan: {
+        inputs: [
+          {
+            txHash: '3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7',
+            outputIndex: 0,
+            coins: null,
+            tokenBundle: null,
+            address: null,
+          },
+        ],
+        outputs: [
+          {
+            isChange: false,
+            address:
+              'addr1q97tqh7wzy8mnx0sr2a57c4ug40zzl222877jz06nt49g4zr43fuq3k0dfpqjh3uvqcsl2qzwuwsvuhclck3scgn3vys6wkj5d',
+            coins: 1,
+            tokenBundle: [],
+          },
+        ],
+        change: [],
+        certificates: [
+          {
+            type: 3,
+            stakingAddress: 'stake1uy9ggsc9qls4pu9qvyyacwnmr9tt0gzcdt5s0zj4au8qkqc65geks',
+            poolRegistrationParams: {
+              poolKeyHashHex: '13381d918ec0283ceeff60f7f4fc21e1540e053ccf8a77307a7a32ad',
+              vrfKeyHashHex: '07821cd344d7fd7e3ae5f2ed863218cb979ff1d59e50c4276bdc479b0d084450',
+              pledgeStr: '50000000000',
+              costStr: '340000000',
+              margin: {
+                numeratorStr: '3',
+                denominatorStr: '100',
+              },
+              rewardAccountHex: 'e1794d9b3408c9fb67b950a48a0690f070f117e9978f7fc1d120fc58ad',
+              poolOwners: [
+                {
+                  stakingKeyHashHex: '1d227aefa4b773149170885aadba30aab3127cc611ddbc4999def61c',
+                },
+                {
+                  stakingKeyHashHex: '794d9b3408c9fb67b950a48a0690f070f117e9978f7fc1d120fc58ad',
+                },
+              ],
+              relays: [
+                {
+                  type: 0,
+                  params: {
+                    portNumber: 3000,
+                    ipv4: '54.228.75.154',
+                    ipv6: null,
+                  },
+                },
+                {
+                  type: 0,
+                  params: {
+                    portNumber: 3000,
+                    ipv4: '54.228.75.155',
+                    ipv6: '24ff:7801:33a2:e383:a5c4:340a:07c2:76e5',
+                  },
+                },
+                {
+                  type: 1,
+                  params: {
+                    portNumber: 3000,
+                    dnsName: 'aaaa.bbbb.com',
+                  },
+                },
+                {
+                  type: 2,
+                  params: {
+                    dnsName: 'aaaa.bbbc.com',
+                  },
+                },
+              ],
+              metadata: {
+                metadataUrl: 'https://www.vacuumlabs.com/sampleUrl.json',
+                metadataHashHex: 'cdb714fd722c24aeb10c93dbb0ff03bd4783441cd5ba2a8b6f373390520535bb',
+              },
+            },
+          },
+        ],
+        deposit: 0,
+        additionalLovelaceAmount: 0,
+        fee: 42,
+        baseFee: 42,
+        withdrawals: [],
+        auxiliaryData: null,
+      },
+    },
+    ttl: 10,
+    txHash: 'bc678441767b195382f00f9f4c4bddc046f73e6116fa789035105ecddfdee949',
+  },
+}

--- a/app/tests/src/wallet/account.js
+++ b/app/tests/src/wallet/account.js
@@ -6,7 +6,9 @@ import BlockchainExplorer from '../../../frontend/wallet/blockchain-explorer'
 import ShelleyJsCryptoProvider from '../../../frontend/wallet/shelley/shelley-js-crypto-provider'
 import {ADALITE_CONFIG} from '../../../frontend/config'
 import {transactionSettings} from '../common/tx-settings'
+import {poolRegTxSettings} from '../common/pool-reg-tx-settings'
 import mockNetwork from '../common/mock'
+import {TxType} from '../../../frontend/types'
 
 const accounts = {}
 
@@ -94,12 +96,28 @@ describe('Tx plan', () => {
   )
 })
 
-describe('TxAux', () => {
-  Object.entries(transactionSettings).forEach(([name, setting]) =>
-    it(`should calculate the right tx hash for tx with ${name}`, async () => {
+describe('Tx plan', () => {
+  Object.entries(poolRegTxSettings).forEach(([name, setting]) =>
+    it(`should create the right tx plan for tx with ${name}`, async () => {
       const account = await accounts.ShelleyAccount0
-      const txHash = (await account.prepareTxAux(setting.txPlanResult.txPlan, setting.ttl)).getId()
-      assert.deepEqual(txHash, setting.txHash)
+      const txPlan = await account.getPoolRegistrationTxPlan({
+        txType: TxType.POOL_REG_OWNER,
+        unsignedTxParsed: setting.unsignedTxParsed,
+      })
+      assert.deepEqual(txPlan, setting.txPlanResult.txPlan)
     })
+  )
+})
+
+describe('TxAux', () => {
+  ;[...Object.entries(transactionSettings), ...Object.entries(poolRegTxSettings)].forEach(
+    ([name, setting]) =>
+      it(`should calculate the right tx hash for tx with ${name}`, async () => {
+        const account = await accounts.ShelleyAccount0
+        const txHash = (
+          await account.prepareTxAux(setting.txPlanResult.txPlan, setting.ttl)
+        ).getId()
+        assert.deepEqual(txHash, setting.txHash)
+      })
   )
 })


### PR DESCRIPTION
Motivation: 
- refactoring of tx plan computing and splitting change outputs introduces a bud in pool registration, change was assigned null instead of `[]`

Changes:
- fix bug with change
- add tests for pool registration so we don't forget to change plan-computing logic there as well

Fixes: 
 https://github.com/vacuumlabs/adalite/issues/1046