### PR TITLE
Bump ledgerjs to support pool registration with ledger app 2.4.1

### DIFF
--- a/app/frontend/wallet/shelley/shelley-ledger-crypto-provider.ts
+++ b/app/frontend/wallet/shelley/shelley-ledger-crypto-provider.ts
@@ -361,6 +361,18 @@ const ShelleyLedgerCryptoProvider = async ({
       type: LedgerTypes.CertificateType.STAKE_POOL_REGISTRATION,
       params: {
         ...poolRegistrationParams,
+        poolKey: {
+          type: LedgerTypes.PoolKeyType.THIRD_PARTY,
+          params: {
+            keyHashHex: poolRegistrationParams.poolKeyHashHex,
+          },
+        },
+        rewardAccount: {
+          type: LedgerTypes.PoolRewardAccountType.THIRD_PARTY,
+          params: {
+            rewardAccountHex: poolRegistrationParams.rewardAccountHex,
+          },
+        },
         poolOwners,
         margin,
         pledge: poolRegistrationParams.pledgeStr,

--- a/app/package.json
+++ b/app/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/vacuumlabs/adalite#readme",
   "scripts": {},
   "dependencies": {
-    "@cardano-foundation/ledgerjs-hw-app-cardano": "3.1.0",
+    "@cardano-foundation/ledgerjs-hw-app-cardano": "^3.2.1",
     "@ledgerhq/hw-transport": "^5.51.1",
     "@ledgerhq/hw-transport-u2f": "^5.36.0-deprecated",
     "@ledgerhq/hw-transport-webhid": "^5.51.1",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -38,10 +38,10 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@cardano-foundation/ledgerjs-hw-app-cardano@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@cardano-foundation/ledgerjs-hw-app-cardano/-/ledgerjs-hw-app-cardano-3.1.0.tgz#7b27501a0001cb31cfc3c59ac9398bd6596c0648"
-  integrity sha512-vzO1o1ebmuYoKPhjpo+1ANaBORmrqFz5bmyFpuEkinBK3OM1URJYFNSj8nOXg070XM587wUT2uihPv8BFQxgJg==
+"@cardano-foundation/ledgerjs-hw-app-cardano@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@cardano-foundation/ledgerjs-hw-app-cardano/-/ledgerjs-hw-app-cardano-3.2.1.tgz#7c7539003eb9b60da33600715b03ac529738fe4b"
+  integrity sha512-qdYeXWDzHE6zEaQeajrKvop9D9mzGDta3OdzlYkFvjiMM0lr/VBLIkhPOd5t6I2vv/LnkhAY8izziVa+my+ifA==
   dependencies:
     "@ledgerhq/hw-transport" "^5.12.0"
     "@types/ledgerhq__hw-transport" "^4.21.3"


### PR DESCRIPTION
Tested pool registration with Ledger Cardano app 2.4.1 and 2.3.2 - both work fine. Current master is failing for the newer version as it has an outdated version of ledgerjs

Tested tx submission/delegation as well and work as expected too