### PR TITLE
Optimize token registry metadata processing

### DIFF
--- a/app/frontend/actions/wallet.ts
+++ b/app/frontend/actions/wallet.ts
@@ -47,12 +47,12 @@ export default (store: Store) => {
 
   const loadAsyncWalletData = async (): Promise<void> => {
     const asyncFetchAndUpdate = async <T extends Partial<State>>(
-      fetch: () => Promise<T>,
+      fetchFn: () => Promise<T>,
       fallbackValue: T,
       debugMessage: string = null
     ): Promise<void> => {
       try {
-        setState(await fetch())
+        setState(await fetchFn())
       } catch (e) {
         debugMessage ?? debugLog(debugMessage)
         setState(fallbackValue)

--- a/app/frontend/helpers/getConversionRates.ts
+++ b/app/frontend/helpers/getConversionRates.ts
@@ -1,6 +1,8 @@
+import {State} from '../state'
+import {ConvectionRates} from '../types'
 import request from '../wallet/helpers/request'
 
-async function getConversionRates(state) {
+async function getConversionRates(state: State): Promise<ConvectionRates> {
   let conversionRates = state.conversionRates
   const maxConversionRatesAge = 1000 * 60 * 5
 
@@ -13,7 +15,8 @@ async function getConversionRates(state) {
 
   return conversionRates
 }
-async function fetchConversionRates() {
+
+async function fetchConversionRates(): Promise<ConvectionRates['data']> {
   return await request('https://min-api.cryptocompare.com/data/price?fsym=ADA&tsyms=USD,EUR').catch(
     (e) => null
   )

--- a/app/frontend/helpers/getConversionRates.ts
+++ b/app/frontend/helpers/getConversionRates.ts
@@ -1,8 +1,8 @@
 import {State} from '../state'
-import {ConvectionRates} from '../types'
+import {ConversionRates} from '../types'
 import request from '../wallet/helpers/request'
 
-async function getConversionRates(state: State): Promise<ConvectionRates> {
+async function getConversionRates(state: State): Promise<ConversionRates> {
   let conversionRates = state.conversionRates
   const maxConversionRatesAge = 1000 * 60 * 5
 
@@ -16,7 +16,7 @@ async function getConversionRates(state: State): Promise<ConvectionRates> {
   return conversionRates
 }
 
-async function fetchConversionRates(): Promise<ConvectionRates['data']> {
+async function fetchConversionRates(): Promise<ConversionRates['data']> {
   return await request('https://min-api.cryptocompare.com/data/price?fsym=ADA&tsyms=USD,EUR').catch(
     (e) => null
   )

--- a/app/frontend/state.ts
+++ b/app/frontend/state.ts
@@ -17,6 +17,7 @@ import {
   WalletOperationStatusType,
   RegisteredTokenMetadata,
   TokenRegistrySubject,
+  ConvectionRates,
 } from './types'
 
 export interface State {
@@ -34,7 +35,7 @@ export interface State {
   error?: any
   activeMainTab: MainTabs
   shouldShowContactFormModal?: boolean
-  conversionRates?: {data: {USD: number; EUR: number}}
+  conversionRates?: ConvectionRates
 
   // cache
   displayWelcome: boolean

--- a/app/frontend/state.ts
+++ b/app/frontend/state.ts
@@ -17,7 +17,7 @@ import {
   WalletOperationStatusType,
   RegisteredTokenMetadata,
   TokenRegistrySubject,
-  ConvectionRates,
+  ConversionRates,
 } from './types'
 
 export interface State {
@@ -35,7 +35,7 @@ export interface State {
   error?: any
   activeMainTab: MainTabs
   shouldShowContactFormModal?: boolean
-  conversionRates?: ConvectionRates
+  conversionRates?: ConversionRates
 
   // cache
   displayWelcome: boolean

--- a/app/frontend/tokenRegistry/tokenRegistry.ts
+++ b/app/frontend/tokenRegistry/tokenRegistry.ts
@@ -3,6 +3,8 @@ import {RegisteredTokenMetadata, Token, TokenRegistrySubject} from '../types'
 import cacheResults from '../helpers/cacheResults'
 import {SuccessResponse, TokenMetadata, TokenMetadataResponse} from '../wallet/backend-types'
 
+const MAX_REQUEST_SIZE = 2000
+
 export const createTokenRegistrySubject = (
   policyId: string,
   assetName: string
@@ -22,6 +24,12 @@ export class TokenRegistry {
   private readonly _fetchTokensMetadata = async (
     subjects: string[]
   ): Promise<TokenMetadataResponse> => {
+    if (subjects.length > MAX_REQUEST_SIZE) {
+      return Promise.resolve({Left: 'Request over max limit'})
+    }
+    if (subjects.length === 0) {
+      return Promise.resolve({Right: []})
+    }
     const requestBody = {subjects}
     try {
       return await request(this.url, 'POST', JSON.stringify(requestBody), {

--- a/app/frontend/tokenRegistry/tokenRegistry.ts
+++ b/app/frontend/tokenRegistry/tokenRegistry.ts
@@ -3,7 +3,7 @@ import {RegisteredTokenMetadata, Token, TokenRegistrySubject} from '../types'
 import cacheResults from '../helpers/cacheResults'
 import {SuccessResponse, TokenMetadata, TokenMetadataResponse} from '../wallet/backend-types'
 
-const MAX_REQUEST_SIZE = 2000
+const MAX_SUBJECTS_COUNT = 2000
 
 export const createTokenRegistrySubject = (
   policyId: string,
@@ -24,7 +24,7 @@ export class TokenRegistry {
   private readonly _fetchTokensMetadata = async (
     subjects: string[]
   ): Promise<TokenMetadataResponse> => {
-    if (subjects.length > MAX_REQUEST_SIZE) {
+    if (subjects.length > MAX_SUBJECTS_COUNT) {
       return Promise.resolve({Left: 'Request over max limit'})
     }
     if (subjects.length === 0) {

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -415,3 +415,11 @@ export type WalletOperationStatusType =
   | 'txSuccess'
   | 'txFailed'
   | 'reloadFailed'
+
+export type ConvectionRates = {
+  data: {
+    USD: number
+    EUR: number
+  }
+  timestamp: number
+}

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -416,7 +416,7 @@ export type WalletOperationStatusType =
   | 'txFailed'
   | 'reloadFailed'
 
-export type ConvectionRates = {
+export type ConversionRates = {
   data: {
     USD: number
     EUR: number

--- a/server/helpers/cache.js
+++ b/server/helpers/cache.js
@@ -1,0 +1,38 @@
+const TIMEOUT = 24 * 60 * 60 * 1000 // 1 day
+const PRUNE_RATIO = 0.1
+
+class Cache {
+  constructor(limit, maxAge = TIMEOUT) {
+    this.limit = limit
+    this.maxAge = maxAge
+    this.cache = {}
+    this.size = 0
+  }
+
+  get(key) {
+    if (key in this.cache && this.cache[key].timestamp + this.maxAge > Date.now()) {
+      return this.cache[key].data
+    }
+    return undefined
+  }
+
+  set(key, value) {
+    if (this.get(key) === undefined) this.size++
+    this.cache[key] = {
+      timestamp: Date.now(),
+      data: value,
+    }
+    if (this.size > this.limit) this.prune()
+  }
+
+  prune() {
+    const pruneSize = Math.round(PRUNE_RATIO * this.limit)
+    Object.entries(this.cache)
+      .sort((a, b) => a[1].timestamp - b[1].timestamp)
+      .slice(0, pruneSize)
+      .forEach(([key, value]) => delete this.cache[key])
+    this.size -= pruneSize
+  }
+}
+
+module.exports = Cache

--- a/server/helpers/chunk.js
+++ b/server/helpers/chunk.js
@@ -1,0 +1,18 @@
+/**
+ * Returns an array with arrays of the given size.
+ *
+ * @param array {Array} Array to split
+ * @param size {Integer} Size of every group
+ */
+const chunk = (array, size) => {
+  const results = []
+  const mutableArray = [...array] // splice modifies array, we want to prevent mutating input array
+
+  while (mutableArray.length) {
+    results.push(mutableArray.splice(0, size))
+  }
+
+  return results
+}
+
+module.exports = chunk

--- a/server/tokenRegistryProxy.js
+++ b/server/tokenRegistryProxy.js
@@ -5,6 +5,7 @@ const chunk = require('./helpers/chunk')
 const Cache = require('./helpers/cache')
 
 const REQUEST_CHUNK_SIZE = 100
+const MAX_REQUEST_SIZE = 2000
 
 const cache = (() => {
   // We expect far more tokens to not be in token registry, we keep that information in nullCache
@@ -34,6 +35,14 @@ module.exports = function(app, env) {
   app.post('/api/bulk/tokens/metadata', async (req, res) => {
     try {
       const subjects = req.body.subjects
+
+      if (subjects.length > MAX_REQUEST_SIZE) {
+        return res.json({
+          statusCode: 400,
+          Left: 'Request over max limit',
+        })
+      }
+
       // Retrieve subjects that are cached form cache and determine
       // which subjects need to be fetched from remote
       const {cached: cachedTokensMetadata, toFetch} = subjects.reduce(

--- a/server/tokenRegistryProxy.js
+++ b/server/tokenRegistryProxy.js
@@ -1,29 +1,86 @@
 require('isomorphic-fetch')
 const Sentry = require('@sentry/node')
 const {backendConfig} = require('./helpers/loadConfig')
-const cacheResults = require('./helpers/cacheResults')
+const chunk = require('./helpers/chunk')
+const Cache = require('./helpers/cache')
 
-const CACHE_TIMEOUT = 24 * 60 * 60 * 1000 // 1 day
+const REQUEST_CHUNK_SIZE = 100
 
-const cachedFetch = cacheResults(CACHE_TIMEOUT)(async (url) => {
-  const response = await fetch(url)
-  if (response.status === 200) {
-    return response.json()
-  } else {
-    return null
+const cache = (() => {
+  // We expect far more tokens to not be in token registry, we keep that information in nullCache
+  // Keeping it separate helps us to not prune cached information about tokens that have real
+  // metadata in token registry
+  const cache = new Cache(1000)
+  const nullCache = new Cache(100000)
+
+  const get = (key) => {
+    const value = cache.get(key)
+    if (value === undefined) return nullCache.get(key)
+    return value
   }
-})
+
+  const set = (key, value) => {
+    if (value === null) {
+      nullCache.set(key, value)
+    } else {
+      cache.set(key, value)
+    }
+  }
+
+  return {get, set}
+})()
 
 module.exports = function(app, env) {
   app.post('/api/bulk/tokens/metadata', async (req, res) => {
     try {
-      const responses = await Promise.all(
-        req.body.subjects.map((subject) =>
-          cachedFetch(`${backendConfig.ADALITE_TOKEN_REGISTRY_URL}/metadata/${subject}`)
-        )
+      const subjects = req.body.subjects
+      // Retrieve subjects that are cached form cache and determine
+      // which subjects need to be fetched from remote
+      const {cached: cachedTokensMetadata, toFetch} = subjects.reduce(
+        (acc, subject) => {
+          const cachedValue = cache.get(subject)
+          if (cachedValue === undefined) {
+            acc.toFetch.push(subject)
+          } else {
+            if (cachedValue !== null) acc.cached.push(cachedValue)
+          }
+          return acc
+        },
+        {cached: [], toFetch: []}
       )
 
-      const tokensMetadata = await Promise.all(responses.filter((e) => e !== null))
+      // Fetch subjects from remote that are not present in cache
+      const responses = (
+        await Promise.all(
+          (
+            await Promise.all(
+              chunk(toFetch, REQUEST_CHUNK_SIZE).map((subjects) =>
+                fetch(`${backendConfig.ADALITE_TOKEN_REGISTRY_URL}/metadata/query`, {
+                  method: 'POST',
+                  headers: {'Content-Type': 'application/json'},
+                  body: JSON.stringify({subjects}),
+                })
+              )
+            )
+          ).flatMap((response) =>
+            response.status === 200 ? response.json() : Promise.resolve(null)
+          )
+        )
+      )
+        .filter((e) => e !== null)
+        .flatMap((response) => response?.subjects)
+
+      // Cache entries with metadata
+      responses.forEach((tokenMetadata) => cache.set(tokenMetadata.subject, tokenMetadata))
+
+      // Cache entries with no metadata
+      const diff = (arr1, arr2) => arr1.filter((x) => !arr2.includes(x))
+      diff(
+        toFetch,
+        responses.map((response) => response.subject)
+      ).forEach((entry) => cache.set(entry, null))
+
+      const tokensMetadata = [...cachedTokensMetadata, ...responses]
 
       return res.json({
         Right: tokensMetadata,


### PR DESCRIPTION
Changes
- Load token metadata in non-blocking matter. After wallet is loaded we would show tokens without linked metadata until the request fetches data from remote service and then update UI accordingly.
- Change request to token registry to bulk request.
  - Maximum amount of tokens per request arbitrarily set to 100.
- Cache entries on level of token metadata, instead of functions calls.
- Set maximum limit for wallet for which we support token metadata, currently set arbitrary to 2000.