### PR TITLE
Disable tx creation while catalyst registration is being submitted

### DIFF
--- a/app/frontend/actions/transaction.ts
+++ b/app/frontend/actions/transaction.ts
@@ -244,8 +244,8 @@ export default (store: Store) => {
         error: e,
       })
       setState({
-        shouldShowTransactionErrorModal: true,
         shouldShowVotingDialog: false,
+        shouldShowTransactionErrorModal: true,
       })
 
       closeConfirmationDialog(state)
@@ -264,6 +264,7 @@ export default (store: Store) => {
         // TODO: refactor txSuccesTab!
         txSuccessTab: sendResponse && sendResponse.success ? getTxSuccessTabMapping(txTab) : '',
       })
+      stopLoadingAction(state)
     }
   }
 

--- a/app/frontend/components/common/modal.tsx
+++ b/app/frontend/components/common/modal.tsx
@@ -8,6 +8,7 @@ interface Props {
   bodyClass?: string
   title?: string
   showWarning?: boolean
+  closeOnClickOutside?: boolean
 }
 
 class Modal extends Component<Props, {}> {
@@ -19,10 +20,17 @@ class Modal extends Component<Props, {}> {
     document.body.classList.remove('no-scroll')
   }
 
-  render({children, onRequestClose, bodyClass = '', title = '', showWarning = false}) {
+  render({
+    children,
+    onRequestClose,
+    bodyClass = '',
+    title = '',
+    showWarning = false,
+    closeOnClickOutside = true,
+  }) {
     return (
       <div className="modal">
-        <div className="modal-overlay" onClick={onRequestClose} />
+        <div className="modal-overlay" onClick={closeOnClickOutside ? onRequestClose : null} />
         <div
           className={`modal-body ${bodyClass}`}
           onKeyDown={(e) => {

--- a/app/frontend/components/pages/sendAda/confirmTransactionDialog.tsx
+++ b/app/frontend/components/pages/sendAda/confirmTransactionDialog.tsx
@@ -419,7 +419,7 @@ const ConfirmTransactionDialog = () => {
 
   return (
     <div>
-      <Modal onRequestClose={cancelTransaction} title={modalTitle}>
+      <Modal onRequestClose={cancelTransaction} title={modalTitle} closeOnClickOutside={false}>
         {getModalBody()}
         {!hideDefaultSummary && (
           <ReviewBottom disabled={false} onSubmit={onSubmit} onCancel={cancelTransaction} />

--- a/app/frontend/components/pages/voting/transactionPage.tsx
+++ b/app/frontend/components/pages/voting/transactionPage.tsx
@@ -6,6 +6,7 @@ import Alert from '../../common/alert'
 import VotingDialogBottom from './votingDialogBottom'
 import styles from './voting.module.scss'
 import {WalletOperationStatusType} from '../dashboard/walletOperationStatus'
+import {shouldDisableSendingButton} from '../../../helpers/common'
 
 const TransactionPage = ({
   nextStep,
@@ -17,7 +18,7 @@ const TransactionPage = ({
   votingPublicKey: HexString
 }): h.JSX.Element => {
   const {registerVotingKey} = useActions(actions)
-  const {txSuccessTab} = useSelector((state) => ({
+  const {txSuccessTab, walletOperationStatusType} = useSelector((state) => ({
     txSuccessTab: state.txSuccessTab,
     walletOperationStatusType: state.walletOperationStatusType,
   }))
@@ -42,7 +43,9 @@ const TransactionPage = ({
       <div className={styles.reviewTransactionRow}>
         <button
           className="button primary"
-          disabled={txSuccessTab === 'voting'}
+          disabled={
+            txSuccessTab === 'voting' || shouldDisableSendingButton(walletOperationStatusType)
+          }
           onClick={submitHandler}
           data-cy="VotingReviewTransactionBtn"
         >

--- a/app/frontend/components/pages/voting/votingDialog.tsx
+++ b/app/frontend/components/pages/voting/votingDialog.tsx
@@ -133,6 +133,7 @@ const VotingDialog = (): h.JSX.Element => {
       bodyClass={styles.votingModal}
       title="Voting Registration"
       showWarning
+      closeOnClickOutside={false}
     >
       <ProgressBar stepNames={Object.values(REGISTRATION_STEP_NAMES)} activeStep={currentStep} />
       {renderStepPage(currentStep)}


### PR DESCRIPTION
As the submit tx UI has been updated to be non-blocking, we probably forgot to update the catalyst registration screen, which now shows to the user the "Confirm transaction" button as non-disabled while the previously confirmed tx is being submitted, which can lead to unpredictable behavior.

This PR is fixing the issue above and disables the button while the wallet is not ready to submit further txs

Other fixes:
* disable closing of the tx confirmation modal if user clicks outside by introducing a configurable property of the common modal element
* if user rejected the transaction while signing, UI got stuck on waiting for ledger - apparently `stopLoadingAction` call was missing in the "finally" block of the tx signing/submission handler

It can be tested with "odor match ..." mnemonic or on Ledger with abandon... mnemonic

Scenarios covered:
* clicking outside voting/tx confirmation modal no longer closes it
* if tx rejected on Ledger, error modal appears and "waiting for Ledger" disappears shortly thereafter
* "confirm transaction" no longer clickable while the transaction is being submitted

Known issue:
* probably not a big deal but the user can still close the modal/cancel the transaction from the UI and continue signing the transaction on Ledger and it gets submitted. We would have to be able to somehow abort the transaction or disable closing the modals while tx is being confirmed on hw wallet, but IMHO it's an overkill and I would expect a reasonable user to reject the transaction on the device as well