### PR TITLE
Refactor IP extraction to account for firewall

### DIFF
--- a/server/helpers/getRequestIp.js
+++ b/server/helpers/getRequestIp.js
@@ -1,0 +1,12 @@
+function getRequestIp(req) {
+  // 'x-forwarded-for' due to internal heroku routing
+  const forwardedFor = req.headers['x-forwarded-for']
+
+  // the "x-forwarded-for" header can contain multiple IPs
+  // see https://serverfault.com/questions/846489/can-x-forwarded-for-contain-multiple-ips
+  const forwardedForClientIp = forwardedFor ? forwardedFor.split(',')[0] : null
+
+  return forwardedForClientIp || req.connection.remoteAddress
+}
+
+module.exports = getRequestIp

--- a/server/helpers/getRequestIp.js
+++ b/server/helpers/getRequestIp.js
@@ -6,6 +6,9 @@ function getRequestIp(req) {
   // see https://serverfault.com/questions/846489/can-x-forwarded-for-contain-multiple-ips
   const forwardedForClientIp = forwardedFor ? forwardedFor.split(',')[0] : null
 
+  // eslint-disable-next-line no-console
+  console.log(forwardedForClientIp) // temporary logging for the sake of testing in prod
+
   return forwardedForClientIp || req.connection.remoteAddress
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -11,6 +11,7 @@ const errorHandler = require('./middlewares/errorHandler')
 let app = express()
 const Sentry = require('@sentry/node')
 const dropSensitiveEventData = require('./helpers/dropSensitiveEventData')
+const getRequestIp = require('./helpers/getRequestIp')
 
 const isProd = process.env.NODE_ENV === 'production'
 
@@ -56,7 +57,7 @@ if (backendConfig.REDIS_URL) {
 if (backendConfig.ADALITE_IP_BLACKLIST.length > 0) {
   app.use(
     ipfilter(backendConfig.ADALITE_IP_BLACKLIST, {
-      detectIp: (req) => req.headers['x-forwarded-for'] || req.connection.remoteAddress,
+      detectIp: (req) => getRequestIp(req),
       mode: 'deny',
       logLevel: 'deny', // logs "Access denied to IP address: <ip>" for denied IPs
     })

--- a/server/middlewares/statsGoogleAnalytics.js
+++ b/server/middlewares/statsGoogleAnalytics.js
@@ -5,6 +5,7 @@ const ua = require('universal-analytics')
 const {backendConfig} = require('../helpers/loadConfig')
 const {captureException} = require('@sentry/node')
 const {isSameOrigin, tokenMatches} = require('../helpers/checkOrigin')
+const getRequestIp = require('../helpers/getRequestIp')
 
 const knownIps = new Set()
 
@@ -44,8 +45,7 @@ const trackEvent = async ({category, action, label, value, path, originTestSucce
 }
 
 const trackVisits = async (req, res, next) => {
-  // 'x-forwarded-for' due to internal heroku routing
-  const ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress
+  const ip = getRequestIp(req)
   const mydevice = device(req.headers['user-agent'])
 
   if (!knownIps.has(ip) && !mydevice.is('bot')) {

--- a/server/middlewares/statsRedis.js
+++ b/server/middlewares/statsRedis.js
@@ -6,6 +6,7 @@ const {parseTxBodyOutAmount, parseTxBodyTotalAmount} = require('../helpers/parse
 const {captureException} = require('@sentry/node')
 const {isSameOrigin, tokenMatches} = require('../helpers/checkOrigin')
 const {backendConfig} = require('../helpers/loadConfig')
+const getRequestIp = require('../helpers/getRequestIp')
 
 const knownIps = new Set()
 
@@ -24,8 +25,7 @@ const incrCountersBy = (key, value) => {
 }
 
 const trackVisits = (req, res, next) => {
-  // 'x-forwarded-for' due to internal heroku routing
-  const ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress
+  const ip = getRequestIp(req)
 
   const mydevice = device(req.headers['user-agent'])
 


### PR DESCRIPTION
Since we setup an application firewall, it appends its IPs to the "fwd" header, skewing our metrics based around IP addresses. This PR fixes the call to take only the first IP (the on of the client itself) from the respective header

More context: https://serverfault.com/questions/846489/can-x-forwarded-for-contain-multiple-ips

Testing: included temporary logging to see in logs if ips are being extracted properly once deployed, is to be reverted afterwards