### PR TITLE
Invalidate browser cache after new version release

### DIFF
--- a/app/public/js/init.js
+++ b/app/public/js/init.js
@@ -50,9 +50,18 @@ function playsNice(cb) {
 function loadScript(success) {
   if (success) {
     // if everything goes well, load the main script
+    const appVersion = JSON.parse(document.body.attributes['data-config'].textContent).ADALITE_APP_VERSION
+    const appVersionQueryParam = encodeURIComponent(appVersion)
+
     const mainScriptTag = document.createElement('script')
     mainScriptTag.type = 'text/javascript'
-    mainScriptTag.src = 'js/frontend.bundle.js'
+
+    // This fix to invalidate browser cache with appVersionQueryParam after app deploy is not ideal
+    // because it invalidates even files that didn't really change.
+    // A proper fix would require reworking the index HTML and to be assembled by webpack
+    // which doesn't seem worth it at the moment. The frontend bundle changes most often and the
+    // rest of assets (css mostly) is several tens of kB combined anyway.
+    mainScriptTag.src = `js/frontend.bundle.js?v=${appVersionQueryParam}`
     mainScriptTag.setAttribute('defer', '')
     document.getElementsByTagName('head')[0].appendChild(mainScriptTag)
   } else {

--- a/server/helpers/loadConfig.js
+++ b/server/helpers/loadConfig.js
@@ -183,6 +183,7 @@ const frontendConfig = {
 const backendConfig = {
   PORT,
   REDIS_URL,
+  ADALITE_APP_VERSION: appVersion,
   ADALITE_STATS_PWD,
   ADALITE_TREZOR_CONNECT_URL,
   ADALITE_ENABLE_SERVER_MOCKING_MODE,

--- a/server/index.js
+++ b/server/index.js
@@ -89,6 +89,13 @@ require('./poolInfoGetter')(app)
 
 app.get('*', (req, res) => {
   const serverUrl = backendConfig.ADALITE_SERVER_URL
+
+  // This fix to invalidate browser cache with appVersionQueryParam after app deploy is not ideal
+  // because it invalidates even files that didn't really change.
+  // A proper fix would require reworking the index HTML and to be assembled by webpack
+  // which doesn't seem worth it at the moment. The frontend bundle changes most often and the
+  // rest of assets (css mostly) is several tens of kB combined anyway.
+  const appVersionQueryParam = encodeURIComponent(backendConfig.ADALITE_APP_VERSION)
   return res.status(200).send(`
       <!doctype html>
       <html>
@@ -115,15 +122,19 @@ app.get('*', (req, res) => {
           <meta property="og:description" content="Free open-source web-browser Cardano wallet with Trezor and Ledger Nano S and Nano X support">
           <meta property="og:image" content="${serverUrl}/assets/og-image.png">
 
-          <script src="js/init.js"></script>
-          <link rel="stylesheet" type="text/css" href="css/styles.css">
-          <link rel="stylesheet" type="text/css" href="css/0-767px.css">
-          <link rel="stylesheet" type="text/css" href="css/0-1366px.css">
-          <link rel="stylesheet" type="text/css" href="css/767-1366px.css">
-          <link rel="stylesheet" type="text/css" href="css/768-1024px.css">
-          <link rel="stylesheet" type="text/css" href="css/1024-1112px.css">
+          <script src="js/init.js?v=${appVersionQueryParam}"></script>
+          <link rel="stylesheet" type="text/css" href="css/styles.css?v=${appVersionQueryParam}">
+          <link rel="stylesheet" type="text/css" href="css/0-767px.css?v=${appVersionQueryParam}">
+          <link rel="stylesheet" type="text/css" href="css/0-1366px.css?v=${appVersionQueryParam}">
+          <link rel="stylesheet" type="text/css" href="css/767-1366px.css?v=${appVersionQueryParam}">
+          <link rel="stylesheet" type="text/css" href="css/768-1024px.css?v=${appVersionQueryParam}">
+          <link rel="stylesheet" type="text/css" href="css/1024-1112px.css?v=${appVersionQueryParam}">
           <link rel="icon" type="image/ico" href="assets/favicon.ico">
-          ${isProd ? '<link rel="stylesheet" type="text/css" href="css/modules.css">' : ''}
+          ${
+  isProd
+    ? `<link rel="stylesheet" type="text/css" href="css/modules.css?v=${appVersionQueryParam}">`
+    : ''
+}
           ${
   backendConfig.ADALITE_TREZOR_CONNECT_URL
     ? `<script src="${backendConfig.ADALITE_TREZOR_CONNECT_URL}"></script>`


### PR DESCRIPTION
Ensures that users get latest js as soon as we make a new release of the app. A bit hacky, but given the effort it would take to rework serving the initial page (injecting the content hashes into HTML, meaning it would have to be done by webpack or keep it in expresses but with even uglier hacks) I think it's a reasonable workaround and at least I tried to clarify the rationale with comments