### PR TITLE
Enforce non-caching of the initial landing page HTML

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -96,6 +96,14 @@ app.get('*', (req, res) => {
   // which doesn't seem worth it at the moment. The frontend bundle changes most often and the
   // rest of assets (css mostly) is several tens of kB combined anyway.
   const appVersionQueryParam = encodeURIComponent(backendConfig.ADALITE_APP_VERSION)
+
+  // Don't cache this page to ensure users always have the latest js/css loaded
+  // inspired by https://github.com/helmetjs/nocache/blob/main/index.ts
+  res.setHeader('Surrogate-Control', 'no-store')
+  res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate')
+  res.setHeader('Pragma', 'no-cache')
+  res.setHeader('Expires', '0')
+
   return res.status(200).send(`
       <!doctype html>
       <html>


### PR DESCRIPTION
Motivation: Make sure users request the latest HTML of the initial page which in turn loads the latest js/css assets, otherwise, after releasing the app some users may still keep the cached versions of the assets, resulting in seeing an outdated version of the website

Inspired by https://stackoverflow.com/a/53240717/2657249

Testing: checked that the respective header is set when fetching the page and the main HTML appears to no longer be cached, even after repeated refreshing