### PR TITLE
Fix Tx syncing issues and provide better feedback to the user on network congestion

### DIFF
--- a/app/frontend/actions/common.ts
+++ b/app/frontend/actions/common.ts
@@ -1,4 +1,4 @@
-import {State, Store} from '../state'
+import {getActiveAccountInfo, State, Store} from '../state'
 import {getWallet} from './wallet'
 import {
   AssetFamily,
@@ -48,10 +48,11 @@ export default (store: Store) => {
 
   const prepareTxPlan = async (args: TxPlanArgs): Promise<TxPlanResult> => {
     const state = getState()
+    const utxos = getActiveAccountInfo(state).utxos
     try {
       return await getWallet()
         .getAccount(state.sourceAccountIndex)
-        .getTxPlan(args)
+        .getTxPlan(args, utxos)
     } catch (e) {
       // TODO: refactor setErrorState to check all errors if there unexpected
       if (

--- a/app/frontend/actions/send.ts
+++ b/app/frontend/actions/send.ts
@@ -1,4 +1,4 @@
-import {Store, State, getSourceAccountInfo} from '../state'
+import {Store, State, getSourceAccountInfo, getActiveAccountInfo} from '../state'
 import {getWallet} from './wallet'
 import errorActions from './error'
 import commonActions from './common'
@@ -191,7 +191,12 @@ export default (store: Store) => {
     try {
       const maxAmounts = await getWallet()
         .getAccount(state.sourceAccountIndex)
-        .getMaxSendableAmount(state.sendAddress.fieldValue as Address, state.sendAmount, decimals)
+        .getMaxSendableAmount(
+          getActiveAccountInfo(state).utxos,
+          state.sendAddress.fieldValue as Address,
+          state.sendAmount,
+          decimals
+        )
       validateAndSetMaxFunds(state, maxAmounts)
     } catch (e) {
       setState({

--- a/app/frontend/actions/transaction.ts
+++ b/app/frontend/actions/transaction.ts
@@ -1,4 +1,4 @@
-import {Store, State, getSourceAccountInfo} from '../state'
+import {Store, State, getSourceAccountInfo, getActiveAccountInfo} from '../state'
 import {getWallet} from './wallet'
 import reloadWalletActions from './reloadWallet'
 import loadingActions from './loading'
@@ -280,7 +280,7 @@ export default (store: Store) => {
     const sendAmount = await getWallet()
       .getAccount(state.sourceAccountIndex)
       // TODO: we should pass something more sensible
-      .getMaxNonStakingAmount(address, {
+      .getMaxNonStakingAmount(getActiveAccountInfo(state).utxos, address, {
         assetFamily: AssetFamily.ADA,
         fieldValue: '',
         coins: 0 as Lovelace,

--- a/app/frontend/errors/errorMessages.ts
+++ b/app/frontend/errors/errorMessages.ts
@@ -58,6 +58,8 @@ const internalErrorMessages: {[key in InternalErrorReason]: (params?: any) => st
     `TransactionNotFoundInBlockchainAfterSubmission: 
     Transaction ${txHash ||
       ''} not found in blockchain after being submitted. The transaction may or may not have succeeded, check again later please.`,
+  [InternalErrorReason.TransactionSubmissionTimedOut]: () =>
+    'Transaction submission timed out, the blockchain is likely congested. It may take up to an hour for the transaction to appear on the blockchain, if it was successful.',
   [InternalErrorReason.TxSerializationError]: ({message}) => `TxSerializationError: ${message}`,
 
   [InternalErrorReason.TrezorSignTxError]: ({message}) => `TrezorSignTxError: ${message}`,

--- a/app/frontend/errors/internalErrorReason.ts
+++ b/app/frontend/errors/internalErrorReason.ts
@@ -21,6 +21,7 @@ export enum InternalErrorReason {
   TransactionRejectedByNetwork = 'TransactionRejectedByNetwork',
   TransactionRejectedWhileSigning = 'TransactionRejectedWhileSigning',
   TransactionNotFoundInBlockchainAfterSubmission = 'TransactionNotFoundInBlockchainAfterSubmission',
+  TransactionSubmissionTimedOut = 'TransactionSubmissionTimedOut',
   TxSerializationError = 'TxSerializationError',
   TrezorSignTxError = 'TrezorSignTxError',
   TrezorError = 'TrezorError',

--- a/app/frontend/state.ts
+++ b/app/frontend/state.ts
@@ -228,6 +228,7 @@ const initialState: State = {
       },
       stakingXpub: null,
       stakingAddress: null,
+      utxos: [],
       balance: 0,
       tokenBalance: [],
       shelleyBalances: {

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -1,6 +1,6 @@
 import {TxSigned, TxAux, CborizedCliWitness} from './wallet/shelley/types'
 import {CaTxEntry, NextRewardDetail, RewardType, TokenObject} from './wallet/backend-types'
-import {Network, WalletName} from './wallet/types'
+import {Network, UTxO, WalletName} from './wallet/types'
 import {TxPlan} from './wallet/shelley/transaction'
 import {_UnsignedTxParsed} from './helpers/cliParser/types'
 
@@ -151,6 +151,7 @@ export type AccountInfo = {
   stakingXpub: _XPubKey
   stakingAddress: Address
   balance: number
+  utxos: Array<UTxO>
   tokenBalance: TokenBundle
   shelleyBalances: {
     stakingBalance?: number

--- a/app/frontend/wallet/constants.ts
+++ b/app/frontend/wallet/constants.ts
@@ -46,7 +46,7 @@ export const NETWORKS: {[key: string]: Network} = {
   },
 }
 
-export const DEFAULT_TTL_SLOTS = 3600
+export const DEFAULT_TTL_SLOTS = 3600 // 1 hour
 
 export const DELAY_AFTER_TOO_MANY_REQUESTS = 2000
 

--- a/app/frontend/wallet/helpers/request.ts
+++ b/app/frontend/wallet/helpers/request.ts
@@ -3,7 +3,13 @@ import {throwIfEpochBoundary} from '../../helpers/epochBoundaryUtils'
 import sleep from '../../helpers/sleep'
 import {DELAY_AFTER_TOO_MANY_REQUESTS} from '../constants'
 
-const request = async function request(url, method = 'GET', body = null, headers = {}) {
+const request = async function request(
+  url,
+  method = 'GET',
+  body = null,
+  headers = {},
+  callback: (response: Response) => void = null
+) {
   let requestParams = {
     method,
     headers,
@@ -23,6 +29,8 @@ const request = async function request(url, method = 'GET', body = null, headers
       message: `No response from ${method} ${url}`,
     })
   }
+
+  callback && callback(response)
 
   if (response.status === 429) {
     await sleep(DELAY_AFTER_TOO_MANY_REQUESTS)

--- a/app/tests/src/actions/wallet-actions.js
+++ b/app/tests/src/actions/wallet-actions.js
@@ -57,6 +57,7 @@ it('Should properly load shelley wallet', async () => {
   mockNet.mockPoolRecommendation()
   mockNet.mockPoolRecommendation()
   mockNet.mockTokenRegistry()
+  mockNet.mockUtxoEndpoint()
 
   await action.loadWallet(state, {
     cryptoProviderType: CryptoProviderType.WALLET_SECRET,

--- a/app/tests/src/common/mock.js
+++ b/app/tests/src/common/mock.js
@@ -159,7 +159,7 @@ const mock = (ADALITE_CONFIG) => {
       response: {
         status: 200,
         body: {
-          Left: 'Transaction rejected by network',
+          Left: 'Transaction network error',
         },
         sendAsJson: true,
       },

--- a/app/tests/src/common/tx-settings.js
+++ b/app/tests/src/common/tx-settings.js
@@ -20,6 +20,17 @@ const inputTokens = [
   },
 ]
 
+const utxos = [
+  {
+    txHash: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+    address:
+      'addr1q8eakg39wqlye7lzyfmh900s2luc99zf7x9vs839pn4srjs2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsjv0zk3',
+    coins: 10000000,
+    tokenBundle: inputTokens,
+    outputIndex: 1,
+  },
+]
+
 const transactionSettings = {
   sendAda: {
     args: {
@@ -29,6 +40,7 @@ const transactionSettings = {
       sendAmount: {assetFamily: AssetFamily.ADA, fieldValue: `${1.5}`, coins: 1500000},
       txType: TxType.SEND_ADA,
     },
+    utxos,
     txPlanResult: {
       success: true,
       txPlan: {
@@ -94,6 +106,7 @@ const transactionSettings = {
       },
       txType: TxType.SEND_ADA,
     },
+    utxos,
     txPlanResult: {
       success: true,
       txPlan: {
@@ -173,6 +186,7 @@ const transactionSettings = {
       stakingAddress: 'stake1uy9ggsc9qls4pu9qvyyacwnmr9tt0gzcdt5s0zj4au8qkqc65geks',
       txType: TxType.DELEGATE,
     },
+    utxos,
     txPlanResult: {
       success: true,
       txPlan: {
@@ -231,6 +245,7 @@ const transactionSettings = {
       txType: TxType.WITHDRAW,
       stakingAddress: 'stake1uy9ggsc9qls4pu9qvyyacwnmr9tt0gzcdt5s0zj4au8qkqc65geks',
     },
+    utxos,
     txPlanResult: {
       success: true,
       txPlan: {
@@ -286,6 +301,7 @@ const transactionSettings = {
       stakingAddress: 'stake1uy9ggsc9qls4pu9qvyyacwnmr9tt0gzcdt5s0zj4au8qkqc65geks',
       nonce: BigInt(25000000),
     },
+    utxos,
     txPlanResult: {
       success: true,
       txPlan: {

--- a/app/tests/src/wallet/account/account.js
+++ b/app/tests/src/wallet/account/account.js
@@ -87,7 +87,7 @@ describe('Tx plan', () => {
   Object.entries(transactionSettings).forEach(([name, setting]) =>
     it(`should create the right tx plan for tx with ${name}`, async () => {
       const account = await accounts.ShelleyAccount0
-      const txPlanResult = await account.getTxPlan({...setting.args})
+      const txPlanResult = await account.getTxPlan({...setting.args}, setting.utxos)
       assert.deepEqual(txPlanResult, setting.txPlanResult)
     })
   )

--- a/app/tests/src/wallet/account/utxo-settings.js
+++ b/app/tests/src/wallet/account/utxo-settings.js
@@ -75,6 +75,6 @@ export const utxoSettings = {
       txType: TxType.SEND_ADA,
     },
     availableUtxos: [utxos.adaOnly, utxos.withTokens2, utxos.legacy, utxos.withTokens1],
-    selectedUtxos: [utxos.withTokens1, utxos.legacy, utxos.adaOnly, utxos.withTokens2],
+    selectedUtxos: [utxos.legacy, utxos.adaOnly, utxos.withTokens1, utxos.withTokens2],
   },
 }

--- a/server/mocking.js
+++ b/server/mocking.js
@@ -27,7 +27,7 @@ module.exports = function(app, env) {
         Right: {txHash},
       })
       : res.json({
-        Left: 'Transaction rejected by network',
+        Left: 'Transaction network error',
       })
   })
 

--- a/server/poolInfoGetter.js
+++ b/server/poolInfoGetter.js
@@ -19,6 +19,8 @@ module.exports = function(app, env) {
           ...a,
         })
       }
+
+      return res.json({})
     } catch (err) {
       return res.json({})
     }

--- a/server/transactionSubmitter.js
+++ b/server/transactionSubmitter.js
@@ -33,6 +33,7 @@ module.exports = function(app, env) {
           },
         }
       )
+
       if (response.status === 200) {
         return res.json({
           Right: {txHash},
@@ -56,7 +57,7 @@ module.exports = function(app, env) {
       }
 
       return res.json({
-        Left: `Transaction rejected by network - ${errorMessage}`,
+        Left: `Transaction network error - ${errorMessage}`,
         statusCode: response.status,
       })
     } catch (err) {


### PR DESCRIPTION
This PR solves first 4 issues described in https://github.com/vacuumlabs/adalite/issues/1168

The first issue is also described in https://github.com/vacuumlabs/adalite/issues/1165

Notes:
1) UTxO sync with wallet reload
    - Removed UTxos fetching on tx plan construction.
    - Utxos are now part of the account state.
    - Balance and history visible in the UI are consistent with data that are used for constructing a tx plan.
    - Before it was possible to create and submit successfully a transaction from a misleading wallet state (outdated balance and tx history).
2) Sort UTxOs to ensure determinism
    - So it's not possible to successfully submit 2 transaction with the same user input from 1 state
      - that is sending another transaction before the previous one is submitted to the blockchain
      - now UTxOs used in inputs should collide and 2nd one should fail
    - It's still possible to successfully send 2 transaction when they are disjunctive (eg. ADA transaction + Token transaction)
3) Set lower TTL
4) Give more descriptive feedback to the user on a gateway timeout - this happens when the network is congested
    - To test a gateway timeout, change server endpoint `'/api/txs/submit'` of `transactionSubmitter` to return 504 as a error code:

```return res.status(504).send('Gateway timed out')```
Issue was that transaction can be successfully submitted, but the request to server times out on the side of Heroku