### PR TITLE
Fix "path is undefined" error when transferring between accounts

### DIFF
--- a/app/frontend/actions/common.ts
+++ b/app/frontend/actions/common.ts
@@ -1,4 +1,4 @@
-import {getActiveAccountInfo, State, Store} from '../state'
+import {getSourceAccountInfo, State, Store} from '../state'
 import {getWallet} from './wallet'
 import {
   AssetFamily,
@@ -48,8 +48,9 @@ export default (store: Store) => {
 
   const prepareTxPlan = async (args: TxPlanArgs): Promise<TxPlanResult> => {
     const state = getState()
-    const utxos = getActiveAccountInfo(state).utxos
     try {
+      const utxos = getSourceAccountInfo(state).utxos
+
       return await getWallet()
         .getAccount(state.sourceAccountIndex)
         .getTxPlan(args, utxos)

--- a/app/frontend/actions/send.ts
+++ b/app/frontend/actions/send.ts
@@ -1,4 +1,4 @@
-import {Store, State, getSourceAccountInfo, getActiveAccountInfo} from '../state'
+import {Store, State, getSourceAccountInfo} from '../state'
 import {getWallet} from './wallet'
 import errorActions from './error'
 import commonActions from './common'
@@ -192,7 +192,7 @@ export default (store: Store) => {
       const maxAmounts = await getWallet()
         .getAccount(state.sourceAccountIndex)
         .getMaxSendableAmount(
-          getActiveAccountInfo(state).utxos,
+          getSourceAccountInfo(state).utxos,
           state.sendAddress.fieldValue as Address,
           state.sendAmount,
           decimals

--- a/app/frontend/actions/transaction.ts
+++ b/app/frontend/actions/transaction.ts
@@ -1,4 +1,4 @@
-import {Store, State, getSourceAccountInfo, getActiveAccountInfo} from '../state'
+import {Store, State, getSourceAccountInfo} from '../state'
 import {getWallet} from './wallet'
 import reloadWalletActions from './reloadWallet'
 import loadingActions from './loading'
@@ -280,7 +280,7 @@ export default (store: Store) => {
     const sendAmount = await getWallet()
       .getAccount(state.sourceAccountIndex)
       // TODO: we should pass something more sensible
-      .getMaxNonStakingAmount(getActiveAccountInfo(state).utxos, address, {
+      .getMaxNonStakingAmount(getSourceAccountInfo(state).utxos, address, {
         assetFamily: AssetFamily.ADA,
         fieldValue: '',
         coins: 0 as Lovelace,


### PR DESCRIPTION
Issue: utxos were being incorrectly fetched from the active account rather than the source account - this is important for the case when transferring funds in the dashboard from an account that isn't currently the selected one

bug introduced in: https://github.com/vacuumlabs/adalite/pull/1174