### PR TITLE
Reduce amount of utxo requests

### DIFF
--- a/app/frontend/actions/common.ts
+++ b/app/frontend/actions/common.ts
@@ -49,11 +49,9 @@ export default (store: Store) => {
   const prepareTxPlan = async (args: TxPlanArgs): Promise<TxPlanResult> => {
     const state = getState()
     try {
-      const utxos = getSourceAccountInfo(state).utxos
-
       return await getWallet()
         .getAccount(state.sourceAccountIndex)
-        .getTxPlan(args, utxos)
+        .getTxPlan(args, getSourceAccountInfo(state).utxos)
     } catch (e) {
       // TODO: refactor setErrorState to check all errors if there unexpected
       if (

--- a/app/frontend/wallet/account.ts
+++ b/app/frontend/wallet/account.ts
@@ -438,9 +438,7 @@ const Account = ({config, cryptoProvider, blockchainExplorer, accountIndex}: Acc
 
   async function getUtxos(): Promise<Array<UTxO>> {
     const {legacy, base} = await myAddresses.discoverAllAddresses()
-    const baseUtxos = await blockchainExplorer.fetchUnspentTxOutputs(base)
-    const nonStakingUtxos = await blockchainExplorer.fetchUnspentTxOutputs(legacy)
-    return [...nonStakingUtxos, ...baseUtxos]
+    return await blockchainExplorer.fetchUnspentTxOutputs([...legacy, ...base])
   }
 
   async function getVisibleAddresses() {


### PR DESCRIPTION
Fetching utxos in a specific order (legacy first, then shelley) should no longer be relevant as we arrange them in the tx planner anyway and combining them into a single fetch call should save us at least one request per account, perhaps except some edge cases. This PR also lifts the chunking by "gap limit" for the utxo network call so the chunks can actually contain the legacy and shelley addresses or generally, more than the "gap limit" addresses per request.

It's worth noticing that doing so for the tx history call and calls depending on it would actually result in more requests, making the calls miss the respective cache, as tx history call is used in address discovery where the addresses are queried strictly by the gap limit, so that would actually hamper the performance, unless we'd made the requests by some integer multiple of the gap limit, but that would make the caching model even more convoluted/fragile than it already is..

Testing: `odor match ...` wallet on testnet

On current develop a reload triggers 16 utxo requests
On this branch it is only 8 requests
