### PR TITLE
Fix utxos sorting to sort before grouping

### DIFF
--- a/app/tests/src/wallet/account/utxo-settings.js
+++ b/app/tests/src/wallet/account/utxo-settings.js
@@ -75,6 +75,6 @@ export const utxoSettings = {
       txType: TxType.SEND_ADA,
     },
     availableUtxos: [utxos.adaOnly, utxos.withTokens2, utxos.legacy, utxos.withTokens1],
-    selectedUtxos: [utxos.legacy, utxos.adaOnly, utxos.withTokens1, utxos.withTokens2],
+    selectedUtxos: [utxos.withTokens1, utxos.legacy, utxos.adaOnly, utxos.withTokens2],
   },
 }


### PR DESCRIPTION
Fix bug introduced in https://github.com/vacuumlabs/adalite/pull/1174 which basically negated all the arranging of utxos as it sorted the utxos after the partitioning (which respects the order of utxos supplied) rather than before, resulting in a suboptimal tx plan being computed in terms of transaction size/fees