### PR TITLE
Display metadata token name instead of onchain asset name

### DIFF
--- a/app/frontend/components/common/asset.tsx
+++ b/app/frontend/components/common/asset.tsx
@@ -1,6 +1,6 @@
 import {h} from 'preact'
 import printAda from '../../helpers/printAda'
-import {AssetFamily, Lovelace, Token} from '../../types'
+import {AssetFamily, Lovelace, RegisteredTokenMetadata, Token} from '../../types'
 import {AdaIcon, HomePageIcon, QuestionFillIcon, StarIcon} from './svg'
 import LinkIcon from './linkIcon'
 import {StringEllipsis} from '../pages/stringEllipsis'
@@ -70,13 +70,23 @@ export const FormattedAssetItem = ({
     }
   }
 
+  const formatAssetName = (metadata: RegisteredTokenMetadata, assetNameHex: string) => {
+    if (metadata?.name) {
+      return metadata.name
+    } else if (assetName) {
+      return assetNameHex2Readable(assetNameHex)
+    } else {
+      return '<no name>'
+    }
+  }
+
   const FormattedAssetName = () => {
     if (type === AssetFamily.ADA) return <span className={styles.assetName}>ADA</span>
     return (
       <span>
         {
           <span className={metadata || assetName ? styles.assetName : styles.empty}>
-            {metadata?.name ?? assetNameHex2Readable(assetName) ?? '<no name>'}
+            {formatAssetName(metadata, assetName)}
           </span>
         }
         <span className={styles.assetName}>{metadata?.ticker ? ` (${metadata?.ticker})` : ''}</span>

--- a/app/frontend/components/common/asset.tsx
+++ b/app/frontend/components/common/asset.tsx
@@ -74,13 +74,11 @@ export const FormattedAssetItem = ({
     if (type === AssetFamily.ADA) return <span className={styles.assetName}>ADA</span>
     return (
       <span>
-        {assetName ? (
-          <span className={styles.assetName}>{assetNameHex2Readable(assetName)}</span>
-        ) : (
-          <span className={styles.empty}>
-            {'<'}no name{'>'}
+        {
+          <span className={metadata || assetName ? styles.assetName : styles.empty}>
+            {metadata?.name ?? assetNameHex2Readable(assetName) ?? '<no name>'}
           </span>
-        )}
+        }
         <span className={styles.assetName}>{metadata?.ticker ? ` (${metadata?.ticker})` : ''}</span>
       </span>
     )

--- a/app/frontend/components/common/asset.tsx
+++ b/app/frontend/components/common/asset.tsx
@@ -70,14 +70,13 @@ export const FormattedAssetItem = ({
     }
   }
 
-  const formatAssetName = (metadata: RegisteredTokenMetadata, assetNameHex: string) => {
+  const formatAssetName = (assetNameHex: string, metadata: RegisteredTokenMetadata | undefined) => {
     if (metadata?.name) {
       return metadata.name
     } else if (assetName) {
       return assetNameHex2Readable(assetNameHex)
-    } else {
-      return '<no name>'
     }
+    return '<no name>'
   }
 
   const FormattedAssetName = () => {
@@ -86,7 +85,7 @@ export const FormattedAssetItem = ({
       <span>
         {
           <span className={metadata || assetName ? styles.assetName : styles.empty}>
-            {formatAssetName(metadata, assetName)}
+            {formatAssetName(assetName, metadata)}
           </span>
         }
         <span className={styles.assetName}>{metadata?.ticker ? ` (${metadata?.ticker})` : ''}</span>

--- a/app/frontend/tokenRegistry/tokenRegistry.ts
+++ b/app/frontend/tokenRegistry/tokenRegistry.ts
@@ -55,6 +55,7 @@ export class TokenRegistry {
         map.set(tokenMetadata.subject, {
           subject: tokenMetadata.subject,
           description: tokenMetadata.description.value,
+          name: tokenMetadata.name.value,
           ticker: tokenMetadata?.ticker?.value,
           url: tokenMetadata?.url?.value,
           logoBase64: tokenMetadata?.logo?.value,

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -83,6 +83,7 @@ export type TokenRegistrySubject = string & {__typeTokenRegistrySubject: any}
 export type RegisteredTokenMetadata = {
   subject: TokenRegistrySubject
   description: string
+  name: string
   ticker?: string
   url?: string
   logoBase64?: string


### PR DESCRIPTION
Currently, we display asset name that is on-chain. In metadata, name field is mandatory. For tokens that actually have metadata, it makes sense to display metadata name to user instead.