### PR TITLE
Update cardano-crypto.js

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -27,7 +27,7 @@
     "@types/lodash": "^4.14.168",
     "bip39-light": "^1.0.7",
     "borc": "^2.1.2",
-    "cardano-crypto.js": "^6.0.0",
+    "cardano-crypto.js": "^6.1.0",
     "chacha": "^2.1.0",
     "lodash": "^4.17.21",
     "pbkdf2": "^3.1.2",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -660,10 +660,10 @@ call-bind@^1.0.0, call-bind@^1.0.2:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
 
-cardano-crypto.js@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/cardano-crypto.js/-/cardano-crypto.js-6.0.0.tgz#6aac02c54e0047e47477e88cebb02acd2c168616"
-  integrity sha512-r9wcFFfW+bq5+bn6ZBueMkLbUiySP901zHoyM8HNN8hfHEAkO3GHUMkzJutqpIG07qR84mQDqq0WjktMsqO8AA==
+cardano-crypto.js@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/cardano-crypto.js/-/cardano-crypto.js-6.1.0.tgz#5743b30fd4a5b1b127fc1c2bbd9ea5f27bab7f51"
+  integrity sha512-mS4cgQYv3S05wGE00tS86EGrZPAN/zwYn6w5tGkfFZE2xiS5lF7KlpSgOIbO7Bip5XZf1rXCLYSiWgxj2Qnkpg==
   dependencies:
     bech32 "^1.1.4"
     bip39 "^3.0.2"


### PR DESCRIPTION
Motivation:
 - validating some types of addresses like entrerprice_script was not working
 
 Changes: 
 - update cardano-crypto.js
 
 Testing: 
  - tried sending txs, and validating this address `addr1w9kredcpw437afv2lnnmjwxg833a9z5vvkmzh63zv6nggts47nekx`