### PR TITLE
Apply sticky footer CSS outside of media query

### DIFF
--- a/app/public/css/0-1366px.css
+++ b/app/public/css/0-1366px.css
@@ -11,17 +11,6 @@
     padding-right: 56px;
   }
 
-  .welcome-footer {
-    position: -webkit-sticky;
-    position: sticky;
-    width: 100%;
-    bottom: -56px;
-    border-top: 1px solid var(--color-border);
-    padding: 24px 56px;
-    margin-top: 0;
-    background-color: white;
-  }
-
   .welcome .credits {
     border-bottom-width: 0;
   }

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -3008,11 +3008,18 @@ li.main-tab input + label.selected:after {
 }
 
 .welcome-footer {
-  margin-top: 56px;
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: flex-end;
+  position: -webkit-sticky;
+  position: sticky;
+  width: 100%;
+  bottom: -56px;
+  border-top: 1px solid var(--color-border);
+  padding: 24px 56px;
+  margin-top: 0;
+  background-color: white;
 }
 
 .welcome-footer .button {


### PR DESCRIPTION
The css that makes the footer sticky currently has a max height of 1366px so it doesn't get applied on large screens.
I removed this so that the css is applied on all screen sizes as a base that can be overridden on smaller screens.

Fixes #1086 

### Notes
- I've found it very helpful to use storybooks with visual regression snapshots to understand the effects of css changes
