### PR TITLE
Handle optional ttl

### DIFF
--- a/app/frontend/actions/poolOwner.ts
+++ b/app/frontend/actions/poolOwner.ts
@@ -92,7 +92,7 @@ export default (store: Store) => {
       const {plan, ttl, validityIntervalStart} = state.poolRegTransactionSummary
       const txAux = await getWallet()
         .getAccount(state.sourceAccountIndex)
-        .prepareTxAux(plan, ttl || undefined, validityIntervalStart || undefined)
+        .prepareTxAux(plan, ttl, validityIntervalStart ?? undefined)
       const witness = await getWallet()
         .getAccount(state.sourceAccountIndex)
         .witnessPoolRegTxAux(txAux)

--- a/app/frontend/wallet/account.ts
+++ b/app/frontend/wallet/account.ts
@@ -227,7 +227,7 @@ const Account = ({config, cryptoProvider, blockchainExplorer, accountIndex}: Acc
     }
   }
 
-  async function prepareTxAux(txPlan: TxPlan, ttl?: BigNumber, validityIntervalStart?: BigNumber) {
+  async function prepareTxAux(txPlan: TxPlan, ttl?: BigNumber | null, validityIntervalStart?: BigNumber) {
     const {inputs, outputs, change, fee, certificates, withdrawals, auxiliaryData} = txPlan
     const stakingAddress = await myAddresses.getStakingAddress()
     const changeOutputs: TxOutput[] = change.map((output) => ({

--- a/app/frontend/wallet/account.ts
+++ b/app/frontend/wallet/account.ts
@@ -227,7 +227,11 @@ const Account = ({config, cryptoProvider, blockchainExplorer, accountIndex}: Acc
     }
   }
 
-  async function prepareTxAux(txPlan: TxPlan, ttl?: BigNumber | null, validityIntervalStart?: BigNumber) {
+  async function prepareTxAux(
+    txPlan: TxPlan,
+    ttl?: BigNumber | null,
+    validityIntervalStart?: BigNumber
+  ) {
     const {inputs, outputs, change, fee, certificates, withdrawals, auxiliaryData} = txPlan
     const stakingAddress = await myAddresses.getStakingAddress()
     const changeOutputs: TxOutput[] = change.map((output) => ({

--- a/app/frontend/wallet/shelley/shelley-bitbox02-crypto-provider.ts
+++ b/app/frontend/wallet/shelley/shelley-bitbox02-crypto-provider.ts
@@ -315,6 +315,14 @@ const ShelleyBitBox02CryptoProvider = async ({
 
     const ttl = txAux.ttl
     if (ttl == null) {
+      // not done via isFeatureSupported() because it would be too much hassle
+      // and we suppose the new new FW will support that together with missing multiasset
+      // support which once added, we'd bump the minimal suported version to that
+      //
+      // TODO: bump minimum supported version of Ledger/Trezor as well to the version
+      // that added multiasset and optional TTL support (the respective libs handle the
+      // feature checks for us and it's an edge-case for pool registration, that's why
+      // we aren't using isFeatureSupported() there either)
       throw new UnexpectedError(UnexpectedErrorReason.UnsupportedOperationError, {
         message: 'Optional TTL not supported by Bitbox02 wallet',
       })

--- a/app/frontend/wallet/shelley/shelley-bitbox02-crypto-provider.ts
+++ b/app/frontend/wallet/shelley/shelley-bitbox02-crypto-provider.ts
@@ -313,28 +313,13 @@ const ShelleyBitBox02CryptoProvider = async ({
       })
     }
 
-    const ttl = txAux.ttl
-    if (ttl == null) {
-      // not done via isFeatureSupported() because it would be too much hassle
-      // and we suppose the new new FW will support that together with missing multiasset
-      // support which once added, we'd bump the minimal suported version to that
-      //
-      // TODO: bump minimum supported version of Ledger/Trezor as well to the version
-      // that added multiasset and optional TTL support (the respective libs handle the
-      // feature checks for us and it's an edge-case for pool registration, that's why
-      // we aren't using isFeatureSupported() there either)
-      throw new UnexpectedError(UnexpectedErrorReason.UnsupportedOperationError, {
-        message: 'Optional TTL not supported by Bitbox02 wallet',
-      })
-    }
-
     const response = await withDevice(async (bitbox02: BitBox02API) => {
       return await bitbox02.cardanoSignTransaction({
         network: bb02Network,
         inputs,
         outputs,
         fee: txAux.fee.toString(),
-        ttl: ttl.toString(),
+        ttl: txAux.ttl?.toString() ?? null,
         certificates,
         withdrawals,
         validityIntervalStart: txAux.validityIntervalStart?.toString() ?? null,

--- a/app/frontend/wallet/shelley/shelley-bitbox02-crypto-provider.ts
+++ b/app/frontend/wallet/shelley/shelley-bitbox02-crypto-provider.ts
@@ -303,9 +303,6 @@ const ShelleyBitBox02CryptoProvider = async ({
     const certificates = txAux.certificates.map((certificate) =>
       prepareCertificate(certificate, addressToAbsPathMapper)
     )
-    const validityIntervalStart = txAux.validityIntervalStart
-      ? `${txAux.validityIntervalStart}`
-      : null
 
     if (
       txAux.auxiliaryData?.type === 'CATALYST_VOTING' &&
@@ -316,16 +313,23 @@ const ShelleyBitBox02CryptoProvider = async ({
       })
     }
 
+    const ttl = txAux.ttl
+    if (ttl == null) {
+      throw new UnexpectedError(UnexpectedErrorReason.UnsupportedOperationError, {
+        message: 'Optional TTL not supported by Bitbox02 wallet',
+      })
+    }
+
     const response = await withDevice(async (bitbox02: BitBox02API) => {
       return await bitbox02.cardanoSignTransaction({
         network: bb02Network,
         inputs,
         outputs,
         fee: txAux.fee.toString(),
-        ttl: txAux.ttl.toString(),
+        ttl: ttl.toString(),
         certificates,
         withdrawals,
-        validityIntervalStart,
+        validityIntervalStart: txAux.validityIntervalStart?.toString() ?? null,
       })
     })
 

--- a/app/frontend/wallet/shelley/shelley-ledger-crypto-provider.ts
+++ b/app/frontend/wallet/shelley/shelley-ledger-crypto-provider.ts
@@ -537,7 +537,6 @@ const ShelleyLedgerCryptoProvider = async ({
       prepareCertificate(certificate, addressToAbsPathMapper)
     )
     const feeStr = `${txAux.fee}`
-    const ttlStr = `${txAux.ttl}`
     const withdrawals = txAux.withdrawals.map((withdrawal) =>
       prepareWithdrawal(withdrawal, addressToAbsPathMapper)
     )
@@ -555,7 +554,7 @@ const ShelleyLedgerCryptoProvider = async ({
         inputs,
         outputs,
         fee: feeStr,
-        ttl: ttlStr,
+        ttl: txAux.ttl?.toString(),
         certificates,
         withdrawals,
         auxiliaryData: formattedAuxiliaryData,

--- a/app/frontend/wallet/shelley/shelley-transaction.ts
+++ b/app/frontend/wallet/shelley/shelley-transaction.ts
@@ -61,7 +61,7 @@ function ShelleyTxAux({
   inputs: TxInput[]
   outputs: TxOutput[]
   fee: BigNumber
-  ttl: BigNumber
+  ttl: BigNumber | null
   certificates: TxCertificate[]
   withdrawals: TxWithdrawal[]
   auxiliaryDataHash: HexString | null

--- a/app/frontend/wallet/shelley/shelley-trezor-crypto-provider.ts
+++ b/app/frontend/wallet/shelley/shelley-trezor-crypto-provider.ts
@@ -429,14 +429,10 @@ const ShelleyTrezorCryptoProvider = async ({
       prepareCertificate(certificate, addressToAbsPathMapper)
     )
     const fee = `${txAux.fee}`
-    const ttl = `${txAux.ttl}`
     const withdrawals = txAux.withdrawals.map((withdrawal) =>
       prepareWithdrawal(withdrawal, addressToAbsPathMapper)
     )
 
-    const validityIntervalStart = txAux.validityIntervalStart
-      ? `${txAux.validityIntervalStart}`
-      : undefined
     const formattedAuxiliaryData = txAux.auxiliaryData
       ? formatAuxiliaryData(txAux.auxiliaryData)
       : undefined
@@ -446,12 +442,12 @@ const ShelleyTrezorCryptoProvider = async ({
       outputs,
       protocolMagic: network.protocolMagic,
       fee,
-      ttl,
+      ttl: txAux.ttl?.toString(),
       networkId: network.networkId,
       certificates,
       withdrawals,
       auxiliaryData: formattedAuxiliaryData,
-      validityIntervalStart,
+      validityIntervalStart: txAux.validityIntervalStart?.toString(),
     }
     const response = await TrezorConnect.cardanoSignTransaction(removeNullFields(request))
 

--- a/app/frontend/wallet/shelley/types.ts
+++ b/app/frontend/wallet/shelley/types.ts
@@ -10,7 +10,7 @@ export type TxAux = {
   inputs: TxInput[]
   outputs: TxOutput[]
   fee: BigNumber
-  ttl: BigNumber
+  ttl: BigNumber | null
   certificates: TxCertificate[]
   withdrawals: TxWithdrawal[]
   auxiliaryData: TxAuxiliaryData | null

--- a/app/tests/src/common/tx-settings.ts
+++ b/app/tests/src/common/tx-settings.ts
@@ -340,4 +340,63 @@ export const transactionSettings = {
     ttl,
     txHash: 'bd14cd4375f1c9bffdec00f78b3638d32719b44b0bbf1232fb4676f919e403fb',
   },
+  sendAdaNullTtl: {
+    args: {
+      address:
+        'addr1qjag9rgwe04haycr283datdrjv3mlttalc2waz34xcct0g4uvf6gdg3dpwrsne4uqng3y47ugp2pp5dvuq0jqlperwj83r4pwxvwuxsgds90s0' as Address,
+      coins: 1000000,
+      sendAmount: {assetFamily: AssetFamily.ADA as const, fieldValue: `${1.5}`, coins: new BigNumber(1500000) as Lovelace},
+      txType: TxType.SEND_ADA as const,
+    },
+    utxos,
+    txPlanResult: {
+      success: true,
+      txPlan: {
+        inputs: [
+          {
+            txHash: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+            address:
+              'addr1q8eakg39wqlye7lzyfmh900s2luc99zf7x9vs839pn4srjs2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsjv0zk3' as Address,
+            coins: new BigNumber(10000000) as Lovelace,
+            outputIndex: 1,
+            tokenBundle: inputTokens,
+          },
+        ],
+        outputs: [
+          {
+            isChange: false as const,
+            address:
+              'addr1qjag9rgwe04haycr283datdrjv3mlttalc2waz34xcct0g4uvf6gdg3dpwrsne4uqng3y47ugp2pp5dvuq0jqlperwj83r4pwxvwuxsgds90s0' as Address,
+            coins: new BigNumber(1500000) as Lovelace,
+            tokenBundle: [],
+          },
+        ],
+        change: [
+          {
+            isChange: false as const,
+            address:
+              'addr1q8eakg39wqlye7lzyfmh900s2luc99zf7x9vs839pn4srjs2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsjv0zk3' as Address,
+            coins: new BigNumber(6938608) as Lovelace,
+            tokenBundle: [],
+          },
+          {
+            isChange: false as const,
+            address:
+              'addr1q8eakg39wqlye7lzyfmh900s2luc99zf7x9vs839pn4srjs2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsjv0zk3' as Address,
+            coins: new BigNumber(1383510) as Lovelace,
+            tokenBundle: inputTokens,
+          },
+        ],
+        certificates: [],
+        deposit: new BigNumber(0) as Lovelace,
+        additionalLovelaceAmount: new BigNumber(0) as Lovelace,
+        fee: new BigNumber(177882) as Lovelace,
+        baseFee: new BigNumber(177882) as Lovelace,
+        withdrawals: [],
+        auxiliaryData: null,
+      },
+    },
+    ttl: null,
+    txHash: 'c986502d4efa9d31a5cb99bd18306e49ff7ed96d62e2b3095b591cf34834bdb9',
+  },
 }


### PR DESCRIPTION
Motivation: I have yet to test it, but while testing bitbox02 I realized pool registrations with missing ttl were almost certainly not working. TTL became optional in Mary era: https://github.com/input-output-hk/cardano-ledger/blob/master/eras/shelley-ma/test-suite/cddl-files/shelley-ma.cddl which we already support, but for missing TTL our code would try to generate the TTL, making the tx to be actually signed inconsistent with the tx body supplied

Change: Add proper handling of null TTL so that pool registrations without TTL can work, extend related type signatures and add test case for transaction with null TTL