### PR TITLE
Release 6.8.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cardano",
-  "version": "6.8.10",
+  "version": "6.8.11",
   "engines": {
     "node": "14.16"
   },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "normalize-url": "^4.0.0",
     "redis": "^3.1.2",
     "redisscan": "^2.0.0",
-    "universal-analytics": "^0.5.0",
+    "universal-analytics": "^0.5.1",
     "webpack": "^4.1.1",
     "webpack-dev-middleware": "^4.1.0",
     "webpack-hot-middleware": "^2.25.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6945,10 +6945,10 @@ unique-string@^2.0.0:
   dependencies:
     crypto-random-string "^2.0.0"
 
-universal-analytics@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/universal-analytics/-/universal-analytics-0.5.0.tgz#3a326fe3dc4abdbaffe7e9b0bf6690a26475e977"
-  integrity sha512-kLUELbj5EjaWi1tC677zfyDRBR80kj99N/A8Z4ngzFl1PXCIcqd42ZrBoeIAUHGEp5odoN9hgKMpREaOAW/mFg==
+universal-analytics@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/universal-analytics/-/universal-analytics-0.5.1.tgz#6bdaba2109d98522dd74018d8fe56f0464d21625"
+  integrity sha512-raLjYsNQmJbK0o8veSU9GXA5XG/YhfuZDzWCAB4SNDnPI4ozXLrbFSDZiRENdOFEIUqmdUTYcaQCOa0Y36EtsQ==
   dependencies:
     debug "^4.1.1"
     uuid "^8.0.0"


### PR DESCRIPTION
Bump version of universal analytics to the one that has fixed a bug that cause requests to fail: https://github.com/peaksandpies/universal-analytics/commit/2d3dd2ff479e021770f5488788b31ae2f6364b06

This is apparently polluting our sentry logs. I was able to replicate it locally and the problem disappeared after updating the lib