### PR TITLE
Add fallback value for Trezor crypto provider feature checks

### DIFF
--- a/app/frontend/wallet/constants.ts
+++ b/app/frontend/wallet/constants.ts
@@ -123,6 +123,11 @@ export const LEDGER_ERRORS = {
 }
 
 export const TREZOR_VERSIONS = {
+  [CryptoProviderFeature.MINIMAL]: {
+    major: 2,
+    minor: 3,
+    patch: 2,
+  },
   [CryptoProviderFeature.POOL_OWNER]: {
     major: 2,
     minor: 3,


### PR DESCRIPTION
Fixes bug that prevents users from logging into Adalite because Trezor didn't have a fallback value for feature checks which had been recently refactored to fall back to check for `MINIMAL` version if the feature queried isn't available, and Trezor didn't have such value set, causing the check to crash 