### PR TITLE
Disable Firefox for BitBox02 wallet

### DIFF
--- a/app/frontend/components/pages/login/hardwareAuth.tsx
+++ b/app/frontend/components/pages/login/hardwareAuth.tsx
@@ -7,7 +7,7 @@ import {useActions} from '../../../helpers/connect'
 import actions from '../../../actions'
 import {useState, useCallback} from 'preact/hooks'
 import {localStorageVars} from '../../../localStorage'
-import {isMobileOnly} from 'react-device-detect'
+import {isMobileOnly, isFirefox} from 'react-device-detect'
 import LedgerTransportSelect from './ledgerTransportSelect'
 import {LedgerTransportChoice} from '../../../../frontend/types'
 import styles from './hardwareAuth.module.scss'
@@ -143,12 +143,16 @@ const LoadByHardwareWalletSection = () => {
             dangerouslySetInnerHTML={{__html: '&nbsp;'}}
           />
           <button
-            disabled={!ADALITE_CONFIG.ADALITE_ENABLE_BITBOX02 || isMobileOnly}
+            disabled={!ADALITE_CONFIG.ADALITE_ENABLE_BITBOX02 || isMobileOnly || isFirefox}
             {...tooltip(
               'Support for BitBox02 is temporarily disabled',
               !ADALITE_CONFIG.ADALITE_ENABLE_BITBOX02
             )}
             {...tooltip('Not supported on mobile devices', isMobileOnly)}
+            {...tooltip(
+              'BitBox02 currently not supported on Firefox, use Chrome instead',
+              isFirefox
+            )}
             className="button primary thin-data-balloon"
             onClick={() =>
               loadWallet({

--- a/app/frontend/components/pages/login/hardwareAuth.tsx
+++ b/app/frontend/components/pages/login/hardwareAuth.tsx
@@ -7,7 +7,7 @@ import {useActions} from '../../../helpers/connect'
 import actions from '../../../actions'
 import {useState, useCallback} from 'preact/hooks'
 import {localStorageVars} from '../../../localStorage'
-import {isMobileOnly, isFirefox} from 'react-device-detect'
+import {isMobileOnly} from 'react-device-detect'
 import LedgerTransportSelect from './ledgerTransportSelect'
 import {LedgerTransportChoice} from '../../../../frontend/types'
 import styles from './hardwareAuth.module.scss'
@@ -143,16 +143,12 @@ const LoadByHardwareWalletSection = () => {
             dangerouslySetInnerHTML={{__html: '&nbsp;'}}
           />
           <button
-            disabled={!ADALITE_CONFIG.ADALITE_ENABLE_BITBOX02 || isMobileOnly || isFirefox}
+            disabled={!ADALITE_CONFIG.ADALITE_ENABLE_BITBOX02 || isMobileOnly}
             {...tooltip(
               'Support for BitBox02 is temporarily disabled',
               !ADALITE_CONFIG.ADALITE_ENABLE_BITBOX02
             )}
             {...tooltip('Not supported on mobile devices', isMobileOnly)}
-            {...tooltip(
-              'BitBox02 currently not supported on Firefox, use Chrome instead',
-              isFirefox
-            )}
             className="button primary thin-data-balloon"
             onClick={() =>
               loadWallet({

--- a/server/middlewares/csp.js
+++ b/server/middlewares/csp.js
@@ -26,6 +26,6 @@ const directives = {
 const csp = Object.entries(directives).map(([key, value]) => `${key} ${value.join(' ')};`)
 
 module.exports = (req, res, next) => {
-  res.setHeader('Content-Security-Policy', csp.join(' '))
+  res.setHeader('Content-Security-Policy', `upgrade-insecure-requests; ${csp.join(' ')}`)
   next()
 }


### PR DESCRIPTION
Motivation: BitBox02 can't connect on Firefox because Adalite firewall is apparently appending the upgrade-insecure-requests header which doesn't allow connecting with the bitbox-bridge running on localhost over an insecure connection, resulting in a "Bitbox is busy" error