### PR TITLE
Improve wording of tx too big error

### DIFF
--- a/app/frontend/errors/errorMessages.ts
+++ b/app/frontend/errors/errorMessages.ts
@@ -74,7 +74,7 @@ const internalErrorMessages: {[key in InternalErrorReason]: (params?: any) => st
   [InternalErrorReason.ChangeOutputTooSmall]: () =>
     'ChangeOutputTooSmall: Not enough funds to make this transaction, try sending a different amount.',
   [InternalErrorReason.TxTooBig]: () =>
-    'Transaction is too big, try sending lesser amount of coins.',
+    'Transaction too big, try sending less in multiple transactions.',
   [InternalErrorReason.OutputTooBig]: () =>
     'Transaction output is too big, try sending a diffrent amount.',
 


### PR DESCRIPTION
Motivation: The original wording was gramatically incorrect and it didn't give to the users clear guidance on what to do to solve the problem