### PR TITLE
Improve CSP

### DIFF
--- a/server/middlewares/csp.js
+++ b/server/middlewares/csp.js
@@ -6,6 +6,15 @@ const directives = {
     'https://connect.trezor.io/',
     'https://widget.changelly.com/',
   ],
+  // Forbid rendering of our page in <iframe /> in order to prevent clickjacking attack
+  // Note, it is not supported by IE, but IE is already officially deprecated
+  'frame-ancestors': ["'none'"],
+  // advised for backwards compatibility of `frame-ancestors`
+  'child-src': ["'none'"],
+  'form-action': ['https://formspree.io'],
+  // `base-uri` prevents the injection of unauthorized <base /> tags which can be used to redirect
+  // all relative URLs (like scripts) to an attacker-controlled domain.
+  'base-uri': ["'none'"],
   'connect-src': ['*'],
   'img-src': ["'self'", 'data:'],
   'script-src': [
@@ -21,7 +30,11 @@ const directives = {
   ],
   'style-src': ["'self'", "'unsafe-inline'"],
   'object-src': ["'none'"],
+  'worker-src': ["'none'"],
 }
+
+// upgrade-insecure-requests left out in order to allow BitBox02 to work in Firefox
+// through the BitBox bridge app which is a locally hosted app communicating through http
 
 const csp = Object.entries(directives).map(([key, value]) => `${key} ${value.join(' ')};`)
 


### PR DESCRIPTION
Improve content security policy to comply with https://cspscanner.com except `upgrade-insecure-requests` which is needed to make Bitbox02 work on Firefox as it requires a locally hosted bridge app to interact with it as an alternative to webhid which isn't supported in FF

CSP settings can be verified at: https://cspscanner.com/?q=https%3A%2F%2Fadalite-improve-csp-ypgfvkargw.herokuapp.com%2F

testing of potentially impacted functionality:
- [x] Trezor successfully connects (needs iframes which the changes relate to)
- [x] Formspree submission work (restricted form-action)
- [x] Changelly widget works (iframe embedded on our site swap creation)
- [x] Bitbox02 on FF works (needs a local http connection to the bridge app to work)
- [x] Sentry submissions work

tested on the review app in this PR, except BitBox02 which needs to be tested locally due to origin whitelisting by the bridge app (which whitelists only adalite.io and localhost)
