### PR TITLE
Add tokens to csv export

### DIFF
--- a/app/frontend/components/pages/txHistory/transactionHistory.tsx
+++ b/app/frontend/components/pages/txHistory/transactionHistory.tsx
@@ -186,6 +186,8 @@ const ExportCSV = ({transactionHistory, stakingHistory}: Props): h.JSX.Element =
           const tokenMetadata = tokensMetadata.get(
             createTokenRegistrySubject(tokenEffect.policyId, tokenEffect.assetName)
           )
+          const ticker = tokenMetadata?.ticker
+          const fingerprint = encodeAssetFingerprint(tokenEffect.policyId, tokenEffect.assetName)
           return {
             ...common,
             ...(tokenEffect.quantity > 0
@@ -198,9 +200,7 @@ const ExportCSV = ({transactionHistory, stakingHistory}: Props): h.JSX.Element =
                 sent: Math.abs(tokenEffect.quantity),
               }),
             assetFamily: AssetFamily.TOKEN,
-            currency:
-              tokenMetadata?.ticker ||
-              encodeAssetFingerprint(tokenEffect.policyId, tokenEffect.assetName),
+            currency: ticker ? `${ticker} (${fingerprint})` : fingerprint,
             decimals: tokenMetadata?.decimals || 0,
           }
         })

--- a/app/frontend/components/pages/txHistory/transactionHistory.tsx
+++ b/app/frontend/components/pages/txHistory/transactionHistory.tsx
@@ -135,6 +135,8 @@ const ExportCSV = ({transactionHistory, stakingHistory}: Props): h.JSX.Element =
   const rowsDelimiter = '\n'
 
   const headers = [
+    'Date',
+    'Transaction ID',
     'Type',
     'Received amount',
     'Received currency',
@@ -142,8 +144,6 @@ const ExportCSV = ({transactionHistory, stakingHistory}: Props): h.JSX.Element =
     'Sent currency',
     'Fee amount',
     'Fee currency',
-    'Transaction ID',
-    'Date',
   ]
     .map((header) => `${header}${delimiter}`)
     .join('')
@@ -262,6 +262,8 @@ const ExportCSV = ({transactionHistory, stakingHistory}: Props): h.JSX.Element =
         ? printAda(amount as Lovelace)
         : printTokenAmount(amount, entry.decimals as number)
     return [
+      entry.dateTime.format('MM/DD/YYYY hh:mm A [UTC]'),
+      entry.txHash,
       entry.type,
       entry.received && printAmount(entry.received),
       entry.received !== undefined ? entry.currency : undefined,
@@ -269,8 +271,6 @@ const ExportCSV = ({transactionHistory, stakingHistory}: Props): h.JSX.Element =
       entry.sent !== undefined ? entry.currency : undefined,
       entry.fee && printAda(entry.fee as Lovelace),
       entry.fee !== undefined ? 'ADA' : undefined,
-      entry.txHash,
-      entry.dateTime.format('MM/DD/YYYY hh:mm A [UTC]'),
     ]
       .map((value) => (value === undefined ? delimiter : `${value}${delimiter}`))
       .join('')


### PR DESCRIPTION
Until now, we didn't include token transfers in CSV export, this PR adds them.

Examples (Ledger mnemonic with tokens - Mainnet):
New: [transactions_new.csv](https://github.com/vacuumlabs/adalite/files/7845725/transactions_new.csv)
Old: [transactions_old.csv](https://github.com/vacuumlabs/adalite/files/7845726/transactions_old.csv)

