### PR TITLE
Release 6.9.18

### DIFF
--- a/app/bitbox02-api.d.ts
+++ b/app/bitbox02-api.d.ts
@@ -37,8 +37,14 @@ declare module 'bitbox02-api' {
     prevOutIndex: number
   }
 
+  type CardanoAssetGroupToken = {
+    assetName: Uint8Array,
+    value: string,
+  }
+
   type CardanoAssetGroup = {
     policyId: Uint8Array
+    tokens: CardanoAssetGroupToken[]
   }
 
   type CardanoOutput = {
@@ -99,7 +105,7 @@ declare module 'bitbox02-api' {
       inputs: CardanoInput[]
       outputs: CardanoOutput[]
       fee: string
-      ttl: string
+      ttl: string | null
       certificates: CardanoCertificate[]
       withdrawals: CardanoWithdrawal[]
       validityIntervalStart: string | null

--- a/app/bitbox02-api.d.ts
+++ b/app/bitbox02-api.d.ts
@@ -37,10 +37,15 @@ declare module 'bitbox02-api' {
     prevOutIndex: number
   }
 
+  type CardanoAssetGroup = {
+    policyId: Uint8Array
+  }
+
   type CardanoOutput = {
     encodedAddress: string
     value: string
     scriptConfig?: ScriptConfig
+    assetGroups: CardanoAssetGroup[]
   }
 
   type CardanoCertificate =

--- a/app/frontend/components/pages/common.tsx
+++ b/app/frontend/components/pages/common.tsx
@@ -1,10 +1,5 @@
 import toLocalDate from '../../../frontend/helpers/toLocalDate'
 import {h} from 'preact'
-import Alert from '../common/alert'
-import {useSelector} from '../../helpers/connect'
-import {CryptoProviderFeature} from '../../types'
-import {CryptoProviderType} from '../../wallet/types'
-import {useIsWalletFeatureSupported} from '../../selectors'
 
 export const EpochDateTime = ({
   epoch,
@@ -20,25 +15,4 @@ export const EpochDateTime = ({
       Epoch {epoch}, {toLocalDate(dateTime)}
     </span>
   )
-}
-
-export const BitBox02MultiAssetAlert = () => {
-  const cryptoProviderInfo = useSelector((state) => state.cryptoProviderInfo)
-  const isMultiAssetSupported = useIsWalletFeatureSupported(CryptoProviderFeature.MULTI_ASSET)
-
-  // checking both conditions for future-proofness, once MA support is added to BitBox02
-  return !isMultiAssetSupported && cryptoProviderInfo?.type === CryptoProviderType.BITBOX02 ? (
-    <Alert alertType="warning">
-      BitBox02 currently does not support sending Cardano tokens/NFTs. If you received tokens and
-      cannot send them, please contact{' '}
-      <a href={'mailto:support@shiftcrypto.ch'}>support@shiftcrypto.ch</a>.{' '}
-      <a
-        href="https://shiftcrypto.support/help/en-us/35-adalite-cardano/176-adalite-guide"
-        target="_blank"
-        rel="noopener"
-      >
-        More info
-      </a>
-    </Alert>
-  ) : null
 }

--- a/app/frontend/components/pages/receiveAda/myAddresses.tsx
+++ b/app/frontend/components/pages/receiveAda/myAddresses.tsx
@@ -2,7 +2,6 @@ import {h} from 'preact'
 import AddressItem from './addressItem'
 import {useState} from 'preact/hooks'
 import {useActiveAccount} from '../../../selectors'
-import {BitBox02MultiAssetAlert} from '../common'
 
 const MyAddresses = (): h.JSX.Element => {
   const {visibleAddresses: addresses} = useActiveAccount()
@@ -12,9 +11,6 @@ const MyAddresses = (): h.JSX.Element => {
   return (
     <div className="addresses card">
       <h2 className="card-title">My Addresses</h2>
-      <div className="bitbox02-multiasset-warning">
-        <BitBox02MultiAssetAlert />
-      </div>
       <div className="addresses-content">
         {addresses.map((adr, index) => (
           <AddressItem

--- a/app/frontend/components/pages/sendAda/sendAdaPage.tsx
+++ b/app/frontend/components/pages/sendAda/sendAdaPage.tsx
@@ -31,7 +31,6 @@ import {shouldDisableSendingButton} from '../../../helpers/common'
 import printTokenAmount from '../../../helpers/printTokenAmount'
 import {createTokenRegistrySubject} from '../../../../frontend/tokenRegistry/tokenRegistry'
 import * as assert from 'assert'
-import {BitBox02MultiAssetAlert} from '../common'
 
 const CalculatingFee = () => <div className="validation-message send">Calculating fee...</div>
 
@@ -404,9 +403,6 @@ const SendAdaPage = ({
     <div className="send card" ref={sendCardDiv}>
       <h2 className={`card-title ${isModal ? 'show' : ''}`}>{title}</h2>
       {isModal ? accountSwitch : addressInput}
-      <div className="bitbox02-multiasset-warning">
-        <BitBox02MultiAssetAlert />
-      </div>
       <div className="send-values">
         {selectAssetDropdown}
         {amountInput}

--- a/app/frontend/errors/errorMessages.ts
+++ b/app/frontend/errors/errorMessages.ts
@@ -95,7 +95,7 @@ const internalErrorMessages: {[key in InternalErrorReason]: (params?: any) => st
       BITBOX02_VERSIONS[CryptoProviderFeature.MINIMAL].patch
     } or later, using the latest release of the BitBoxApp.`,
   [InternalErrorReason.BitBox02MultiAssetNotSupported]: () =>
-    'BitBox02MultiAssetNotSupported: The BitBox02 does not support this feature at the moment.',
+    'BitBox02MultiAssetNotSupported: Please update your BitBox02 firmware for token support.',
   [InternalErrorReason.LedgerMultiAssetNotSupported]: () =>
     'LedgerMultiAssetNotSupported: Sending tokens is not supported on Ledger device. Please update your cardano application to the latest version.',
   [InternalErrorReason.LedgerOutdatedCardanoAppError]: ({message}) =>

--- a/app/frontend/wallet/constants.ts
+++ b/app/frontend/wallet/constants.ts
@@ -75,6 +75,11 @@ export const BITBOX02_VERSIONS = {
     minor: 8,
     patch: 0,
   },
+  [CryptoProviderFeature.MULTI_ASSET]: {
+    major: 9,
+    minor: 9,
+    patch: 0,
+  },
 }
 
 export const BITBOX02_ERRORS = {

--- a/app/package.json
+++ b/app/package.json
@@ -27,7 +27,7 @@
     "@types/lodash": "^4.14.168",
     "babel-polyfill": "6.26.0",
     "bip39-light": "^1.0.7",
-    "bitbox02-api": "^0.12.0",
+    "bitbox02-api": "^0.13.0",
     "borc": "^2.1.2",
     "cardano-crypto.js": "^6.1.0",
     "chacha": "^2.1.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1564,7 +1564,7 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
-json-schema@0.2.3, json-schema@>=0.4.0:
+json-schema@0.2.3, json-schema@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
   integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -604,10 +604,10 @@ bip39@^3.0.2:
     pbkdf2 "^3.0.9"
     randombytes "^2.0.1"
 
-bitbox02-api@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/bitbox02-api/-/bitbox02-api-0.12.0.tgz#77ded20c93b4a0c03065a0f82235eb7f2b65a923"
-  integrity sha512-owETucLCIdtVA/SlZpF+E9bNRdK5H24kxYQci5FgI/3pxMKG0WBmy0zFBzqhTFHLaQYKSzI6wPSNq+y0ZLUV0w==
+bitbox02-api@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/bitbox02-api/-/bitbox02-api-0.13.0.tgz#06566f943e960199b935abb4dc948cf6f84e53e1"
+  integrity sha512-Ht5Liv7xsTAfrvo7CG4v0mR33KWLcui//kvEy62q/JBSWxJFsdBjP13YJagFJCesCwwqPSQNkNAyqQodpetMGg==
 
 blob-util@^2.0.2:
   version "2.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cardano",
-  "version": "6.9.17",
+  "version": "6.9.18",
   "engines": {
     "node": "14.16"
   },


### PR DESCRIPTION
Enable tokens for bitbox02 9.9.0 firmware

Tested with physical device both that for 9.8.0 token transactions fail with the expected error, prompting the user to upgrade (and non-token pass) and for 9.9.0 both transactions pass