### PR TITLE
Unescape pool names strings

### DIFF
--- a/app/frontend/components/pages/delegations/currentDelegationPage.tsx
+++ b/app/frontend/components/pages/delegations/currentDelegationPage.tsx
@@ -1,4 +1,5 @@
 import {Fragment, h} from 'preact'
+import {unescape} from 'lodash'
 import {connect} from '../../../libs/unistore/preact'
 import actions from '../../../actions'
 import printAda from '../../../helpers/printAda'
@@ -41,7 +42,7 @@ const CurrentDelegationPage = ({
         <div>
           <div className="current-delegation-wrapper">
             <div className="current-delegation-name">
-              {pool.name || 'Pool'}
+              {unescape(pool.name) || 'Pool'}
               <LinkIconToPool poolHash={pool.poolHash} />
             </div>
             <div className="current-delegation-id">{pool.poolHash}</div>

--- a/app/frontend/components/pages/delegations/stakePoolInfo.tsx
+++ b/app/frontend/components/pages/delegations/stakePoolInfo.tsx
@@ -1,4 +1,5 @@
 import printAda from '../../../helpers/printAda'
+import {unescape} from 'lodash'
 import {getErrorMessage} from '../../../errors'
 import {Stakepool, Lovelace} from '../../../types'
 import {h} from 'preact'
@@ -48,7 +49,7 @@ export const StakePoolInfo = ({
         <div>
           <div>
             {'Name: '}
-            {print(pool?.name)}
+            {print(unescape(pool?.name))}
           </div>
           <div className="delegation stake-pool-id">
             {'Stake Pool ID: '}

--- a/app/frontend/components/pages/delegations/stakingHistoryPage.tsx
+++ b/app/frontend/components/pages/delegations/stakingHistoryPage.tsx
@@ -1,4 +1,5 @@
 import {h, Component} from 'preact'
+import {unescape} from 'lodash'
 import actions from '../../../actions'
 import {connect} from '../../../libs/unistore/preact'
 import {LinkIconToPool} from './common'
@@ -25,12 +26,12 @@ const StakeDelegationItem = ({stakeDelegation}: {stakeDelegation: StakeDelegatio
         <EpochDateTime epoch={stakeDelegation.epoch} dateTime={stakeDelegation.dateTime} />
       </div>
       <div>
-        New pool: <span className="bold">{stakeDelegation.newStakePool.name}</span>
+        New pool: <span className="bold">{unescape(stakeDelegation.newStakePool.name)}</span>
         <LinkIconToPool poolHash={stakeDelegation.newStakePool.id} />
       </div>
       {stakeDelegation.oldStakePool ? (
         <div>
-          Previous pool: {stakeDelegation.oldStakePool.name}
+          Previous pool: {unescape(stakeDelegation.oldStakePool.name)}
           <LinkIconToPool poolHash={stakeDelegation.oldStakePool.id} />
         </div>
       ) : (
@@ -67,7 +68,8 @@ const StakingRewardItem = ({stakingReward}: {stakingReward: StakingReward}) => {
           </div>
           <div>
             <div className="grey">
-              {stakingReward.rewardType === RewardType.REGULAR && stakingReward.stakePool.name}
+              {stakingReward.rewardType === RewardType.REGULAR &&
+                unescape(stakingReward.stakePool.name)}
               {stakingReward.stakePool.id && (
                 <LinkIconToPool poolHash={stakingReward.stakePool.id} />
               )}

--- a/app/frontend/components/pages/sendAda/confirmTransactionDialog.tsx
+++ b/app/frontend/components/pages/sendAda/confirmTransactionDialog.tsx
@@ -1,5 +1,6 @@
 import {h, Fragment} from 'preact'
 import {useState} from 'preact/hooks'
+import {unescape} from 'lodash'
 import {useSelector, useActions} from '../../../helpers/connect'
 import actions from '../../../actions'
 import printAda from '../../../helpers/printAda'
@@ -146,7 +147,7 @@ const DelegateReview = ({
         <div className="review-label">Pool ID</div>
         <div className="review-amount">{stakePool.poolHash}</div>
         <div className="review-label">Pool Name</div>
-        <div className="review-amount">{stakePool.name}</div>
+        <div className="review-amount">{unescape(stakePool.name)}</div>
         <div className="review-label">Ticker</div>
         <div className="review-amount">{stakePool.ticker}</div>
         <div className="review-label">Tax</div>


### PR DESCRIPTION
Converting the HTML entitie in staking pool names to their corresponding characters.

Hopefully I've not missed any other place where we display pool name.
 previously (`&amp;` instead of &amp;)
![image](https://user-images.githubusercontent.com/64598949/155497045-35d2d3d7-f4c9-40a4-bafc-a7c52b4e0eb8.png)

after changes
![image](https://user-images.githubusercontent.com/64598949/155497079-07722950-164c-4f7c-a621-054188e0150b.png)
![image](https://user-images.githubusercontent.com/64598949/155497105-3c28c419-9c46-4297-b96f-674a4585e900.png)
![image](https://user-images.githubusercontent.com/64598949/155497117-083aa862-c9b4-476b-9386-0ee10cf73036.png)
![image](https://user-images.githubusercontent.com/64598949/155497129-a01f0185-1940-4921-8ce3-fe363438b312.png)


