### PR TITLE
Increase bulk addresses summary cache ttl

### DIFF
--- a/app/frontend/wallet/blockchain-explorer.ts
+++ b/app/frontend/wallet/blockchain-explorer.ts
@@ -73,7 +73,7 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
     return 'Right' in result ? result.Right : undefined
   }
 
-  const _getAddressInfos = cacheResults(5000)(_fetchBulkAddressInfo)
+  const _getAddressInfos = cacheResults(15000)(_fetchBulkAddressInfo)
 
   async function getTxHistory(addresses: Array<string>): Promise<TxSummaryEntry[]> {
     const chunks = range(0, Math.ceil(addresses.length / gapLimit))


### PR DESCRIPTION
Loading of wallet is slow. The main culprit is bulk address summary fetch, we already cache this request, but the interval in between requests is higher than TTL in the cache. This hotfix should halve loading times.

Next possible steps
- look into the performance of mentioned request
- introduce a more effective loading of accounts (either lazy or in the background)