### PR TITLE
Replace yarn audit with improved-yarn-audit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,8 @@ jobs:
     <<: *defaults
     steps:
       - setup
-      - run: yarn audit
-      - run: cd app && yarn audit && cd ../
+      - run: yarn improved-yarn-audit
+      - run: cd app && yarn improved-yarn-audit && cd ../
   
   lint:
     <<: *defaults

--- a/.iyarc
+++ b/.iyarc
@@ -1,0 +1,2 @@
+# minimist, no resolution at the moment (2022-03-22)
+GHSA-xvch-5gv4-984h

--- a/app/.iyarc
+++ b/app/.iyarc
@@ -1,0 +1,3 @@
+# minimist, no resolution at the moment (2022-03-22)
+GHSA-xvch-5gv4-984h
+

--- a/app/package.json
+++ b/app/package.json
@@ -45,6 +45,7 @@
     "cypress": "^9.0.0",
     "fetch-mock": "^6.5.1",
     "fetch-readablestream": "^0.2.0",
+    "improved-yarn-audit": "^3.0.0",
     "sinon": "^7.3.2"
   },
   "resolutions": {

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1368,6 +1368,11 @@ ieee754@^1.1.4:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b"
   integrity sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==
 
+improved-yarn-audit@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/improved-yarn-audit/-/improved-yarn-audit-3.0.0.tgz#dfb09cea1a3a92c790ea2b4056431f6fb1b99bfa"
+  integrity sha512-b7CrBYYwMidtPciCBkW62C7vqGjAV10bxcAWHeJvGrltrcMSEnG5I9CQgi14nmAlUKUQiSvpz47Lo3d7Z3Vjcg==
+
 indent-string@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "eslint-plugin-react-hooks": "^2.3.0",
     "file-loader": "^6.2.0",
     "husky": "^3.0.0",
+    "improved-yarn-audit": "^3.0.0",
     "lint-staged": "^9.2.0",
     "mini-css-extract-plugin": "^1.5.0",
     "prettier": "^1.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3192,6 +3192,11 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
+improved-yarn-audit@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/improved-yarn-audit/-/improved-yarn-audit-3.0.0.tgz#dfb09cea1a3a92c790ea2b4056431f6fb1b99bfa"
+  integrity sha512-b7CrBYYwMidtPciCBkW62C7vqGjAV10bxcAWHeJvGrltrcMSEnG5I9CQgi14nmAlUKUQiSvpz47Lo3d7Z3Vjcg==
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"


### PR DESCRIPTION
rationale: it allows suppressing advisories we can otherwise do nothing reasonable about for the time being. Currently, there's such an issue e.g. with the `minimist` package which this PR suppressed warnings about