### PR TITLE
Improve initial wallet loading performance for medium sized multi-account wallets

### DIFF
--- a/app/frontend/wallet/account-manager.ts
+++ b/app/frontend/wallet/account-manager.ts
@@ -68,7 +68,7 @@ const AccountManager = ({
     )
 
     if (
-      maxAccountIndex === accounts.length - 1 ||
+      accounts.length - 1 >= maxAccountIndex ||
       (accounts.length > 0 &&
         (shouldExploreOnlyOne || !(await accounts[accounts.length - 1].isAccountUsed())))
     ) {
@@ -106,7 +106,7 @@ const AccountManager = ({
 
       const accountsToAdd = newAccountBatch.slice(
         0,
-        !foundUnusedAccount ? newAccountBatch.length : firstUnusedNewAccountIndex + 1
+        foundUnusedAccount ? firstUnusedNewAccountIndex + 1 : newAccountBatch.length
       )
 
       accounts = [...accounts, ...accountsToAdd]

--- a/app/frontend/wallet/account.ts
+++ b/app/frontend/wallet/account.ts
@@ -411,6 +411,10 @@ const Account = ({config, cryptoProvider, blockchainExplorer, accountIndex}: Acc
     return blockchainExplorer.getTxHistory([...base, ...legacy, account])
   }
 
+  async function ensureAddressesAreDiscovered(): Promise<void> {
+    await myAddresses.discoverAllAddresses()
+  }
+
   async function getStakingHistory(
     validStakepoolDataProvider: StakepoolDataProvider
   ): Promise<StakingHistoryObject[]> {
@@ -515,6 +519,7 @@ const Account = ({config, cryptoProvider, blockchainExplorer, accountIndex}: Acc
     getMaxNonStakingAmount,
     getTxPlan,
     getTxHistory,
+    ensureAddressesAreDiscovered,
     getVisibleAddresses,
     prepareTxAux,
     verifyAddress,

--- a/app/frontend/wallet/account.ts
+++ b/app/frontend/wallet/account.ts
@@ -330,19 +330,32 @@ const Account = ({config, cryptoProvider, blockchainExplorer, accountIndex}: Acc
   }
 
   async function getAccountInfo(validStakepoolDataProvider: StakepoolDataProvider) {
-    const promiseBatch1 = (async () => {
-      const [balance, shelleyAccountInfo] = await Promise.all([
-        getBalance(),
-        getStakingInfo(validStakepoolDataProvider),
-      ])
-      const poolRecommendation = await getPoolRecommendation(
-        shelleyAccountInfo.delegation,
-        balance.baseAddressBalance
-      )
-      return [balance, shelleyAccountInfo, poolRecommendation]
-    })()
-
-    const promiseBatch2 = Promise.all([
+    const [
+      [
+        {baseAddressBalance, nonStakingBalance, balance, tokenBalance},
+        shelleyAccountInfo,
+        poolRecommendation,
+      ],
+      utxos,
+      stakingHistory,
+      visibleAddresses,
+      transactionHistory,
+      isUsed,
+      accountXpubs,
+      stakingXpub,
+      stakingAddress,
+    ] = await Promise.all([
+      (async () => {
+        const [balance, shelleyAccountInfo] = await Promise.all([
+          getBalance(),
+          getStakingInfo(validStakepoolDataProvider),
+        ])
+        const poolRecommendation = await getPoolRecommendation(
+          shelleyAccountInfo.delegation,
+          balance.baseAddressBalance
+        )
+        return [balance, shelleyAccountInfo, poolRecommendation]
+      })(),
       getUtxos(),
       getStakingHistory(validStakepoolDataProvider),
       getVisibleAddresses(),
@@ -352,24 +365,6 @@ const Account = ({config, cryptoProvider, blockchainExplorer, accountIndex}: Acc
       getStakingXpub(cryptoProvider, accountIndex),
       myAddresses.getStakingAddress(),
     ])
-
-    const [
-      [
-        {baseAddressBalance, nonStakingBalance, balance, tokenBalance},
-        shelleyAccountInfo,
-        poolRecommendation,
-      ],
-      [
-        utxos,
-        stakingHistory,
-        visibleAddresses,
-        transactionHistory,
-        isUsed,
-        accountXpubs,
-        stakingXpub,
-        stakingAddress,
-      ],
-    ] = await Promise.all([promiseBatch1, promiseBatch2])
 
     return {
       accountXpubs,

--- a/app/frontend/wallet/helpers/CachedDeriveXpubFactory.ts
+++ b/app/frontend/wallet/helpers/CachedDeriveXpubFactory.ts
@@ -4,6 +4,7 @@ import {derivePublic as deriveChildXpub} from 'cardano-crypto.js'
 import {isShelleyPath} from '../../wallet/shelley/helpers/addresses'
 import {BIP32Path} from '../../types'
 import {UnexpectedError, UnexpectedErrorReason} from '../../errors'
+import {makeBulkAccountIndexIterator} from './accountDiscovery'
 
 const BYRON_V2_PATH = [HARDENED_THRESHOLD + 44, HARDENED_THRESHOLD + 1815, HARDENED_THRESHOLD]
 
@@ -52,14 +53,6 @@ function CachedDeriveXpubFactory(
     const lastIndex = derivationPath.slice(-1)[0]
     const parentXpub = await deriveXpub(derivationPath.slice(0, -1))
     return deriveChildXpub(parentXpub, lastIndex, derivationScheme.ed25519Mode)
-  }
-
-  function* makeBulkAccountIndexIterator() {
-    yield [0, 4]
-    yield [5, 16]
-    for (let i = 17; true; i += 18) {
-      yield [i, i + 17]
-    }
   }
 
   function getAccountIndexExportInterval(accountIndex: number): [number, number] {

--- a/app/frontend/wallet/helpers/accountDiscovery.ts
+++ b/app/frontend/wallet/helpers/accountDiscovery.ts
@@ -1,0 +1,7 @@
+export function* makeBulkAccountIndexIterator() {
+  yield [0, 4]
+  yield [5, 16]
+  for (let i = 17; true; i += 18) {
+    yield [i, i + 17]
+  }
+}


### PR DESCRIPTION
We currently use many async calls in a blocking way. This can be quite slow for multi-account medium/big-sized wallets. This PR changes account discovery and account loading to use async calls in a non-blocking way.

Tested with mnemonic and Ledger HW wallet.