### PR TITLE
Fix yarn audit issues

### DIFF
--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -498,9 +498,9 @@ astral-regex@^2.0.0:
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
 async@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
-  integrity sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
+  integrity sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -1730,9 +1730,9 @@ minimist@^1.2.5:
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 moment@^2.29.1:
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.3.tgz#edd47411c322413999f7a5940d526de183c031f3"
+  integrity sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==
 
 ms@2.1.2:
   version "2.1.2"

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
   },
   "resolutions": {
     "redisscan/redis": "^3.1.2",
+    "redisscan/async": "^2.6.4",
     "eslint/**/glob-parent": "^5.1.2",
     "eslint/**/ansi-regex": "^5",
     "prettier-eslint-cli/**/ansi-regex": "^5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -940,10 +940,12 @@ async-retry@1.3.3:
   dependencies:
     retry "0.13.1"
 
-async@~0.2.10:
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
-  integrity "sha1-trvgsGdLnXGXCMo43owjfLUmw9E= sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="
+async@^2.6.4, async@~0.2.10:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
+  integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==
+  dependencies:
+    lodash "^4.17.14"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -4202,9 +4204,9 @@ mocha-headless-chrome@^2.0.3:
     puppeteer "^1.17.0"
 
 moment@^2.27.0:
-  version "2.27.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.27.0.tgz#8bff4e3e26a236220dfe3e36de756b6ebaa0105d"
-  integrity "sha1-i/9OPiaiNiIN/j423nVrbrqgEF0= sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.3.tgz#edd47411c322413999f7a5940d526de183c031f3"
+  integrity "sha1-7dR0EcMiQTmZ96WUDVJt4YPAMfM= sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw=="
 
 mri@1.1.4:
   version "1.1.4"
@@ -5228,7 +5230,7 @@ redis@^2.7.1, redis@^3.1.2:
 redisscan@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/redisscan/-/redisscan-2.0.0.tgz#00e6d6386c5e283445e7286f0472c72690b20621"
-  integrity "sha1-AObWOGxeKDRF5yhvBHLHJpCyBiE= sha512-4B8rU/33V6ABLBDNmfYuOMH8Bd+nxfzN4mk2tM9XJjImmHIDM7B7dnk8Kxs2aNeYN/upaMB0v7I4Z4bjmZGWYQ=="
+  integrity sha1-AObWOGxeKDRF5yhvBHLHJpCyBiE=
   dependencies:
     async "~0.2.10"
     redis "^2.7.1"


### PR DESCRIPTION
How to test:
* try logging into a wallet and check that it works properly
* to test redis, set up the project locally, set REDIS_URL to use the one from adalite-staging heroku app and try loading `/usage_stats` and check that it matches the content on adalite-staging - it will load locally much slower than on staging, this is expected due to making a remote heroku connection