### PR TITLE
Improve how we display token information

### DIFF
--- a/app/frontend/components/common/asset.module.scss
+++ b/app/frontend/components/common/asset.module.scss
@@ -12,9 +12,12 @@
   align-items: center;
 }
 
-.icon svg {
-  width: 12px;
+.icon svg, .icon img {
   height: 12px;
+}
+
+.iconOffset {
+  margin-right: 6px;
 }
 
 .empty {
@@ -29,10 +32,4 @@
 .iconName {
   display: flex;
   align-items: center;
-}
-
-.iconName svg, .iconName img {
-  margin-right: 6px;
-  width: 12px;
-  height: 12px;
 }

--- a/app/frontend/components/common/asset.tsx
+++ b/app/frontend/components/common/asset.tsx
@@ -10,6 +10,10 @@ import {assetNameHex2Readable} from '../../wallet/shelley/helpers/addresses'
 import printTokenAmount from '../../helpers/printTokenAmount'
 import {createTokenRegistrySubject} from '../../../frontend/tokenRegistry/tokenRegistry'
 
+const isHumanReadable = (value: string): boolean =>
+  // eslint-disable-next-line no-useless-escape
+  !!value && /^[a-zA-Z0-9!"#$%&'()*+,.\/:;<=>?@\[\] ^_`{|}~-]*$/.test(value)
+
 type LinkToAssetProps = {
   policyIdHex: string
   assetNameHex: string
@@ -19,9 +23,145 @@ export const LinkToAsset = ({policyIdHex, assetNameHex}: LinkToAssetProps) => (
   <LinkIcon url={`https://cardanoscan.io/token/${policyIdHex}.${assetNameHex}`} />
 )
 
+type IconProps = {
+  type: AssetFamily
+  metadata: RegisteredTokenMetadata | null
+}
+
+const Icon = ({type, metadata}: IconProps) => {
+  if (type === AssetFamily.ADA) return <AdaIcon />
+  if (metadata) {
+    if (metadata.logoBase64) {
+      return (
+        <img
+          src={`data:image/png;base64,${metadata.logoBase64}`}
+          alt="logo"
+          width="12"
+          height="12"
+        />
+      )
+    } else {
+      return <StarIcon />
+    }
+  } else {
+    return <QuestionFillIcon />
+  }
+}
+
+export const enum FormattedHumanReadableLabelType {
+  ADA,
+  OFFCHAIN_ASSET_NAME,
+  ONCHAIN_ASSET_NAME,
+  FINGERPRINT,
+}
+
+type GetLabelVariantsArgs =
+  | {
+      type: AssetFamily.ADA
+    }
+  | {
+      type: AssetFamily.TOKEN
+      metadata: RegisteredTokenMetadata
+      assetName: string
+      fingerprint: string
+    }
+
+const getLabelVariants = (args: GetLabelVariantsArgs) => {
+  if (args.type === AssetFamily.ADA) {
+    const label = <span className={styles.assetName}>ADA</span>
+    return {
+      type: FormattedHumanReadableLabelType.ADA,
+      label,
+      labelShort: label,
+    }
+  }
+
+  const {metadata, assetName, fingerprint} = args
+
+  if (metadata?.name) {
+    return {
+      type: FormattedHumanReadableLabelType.OFFCHAIN_ASSET_NAME,
+      label: (
+        <span className={styles.assetName}>
+          {`${metadata.name}${metadata?.ticker ? ` (${metadata.ticker})` : ''}`}
+        </span>
+      ),
+      labelShort: <span className={styles.assetName}>{metadata.ticker}</span>,
+    }
+  }
+
+  const readableAssetName = assetName && assetNameHex2Readable(assetName)
+  if (assetName && isHumanReadable(readableAssetName)) {
+    return {
+      type: FormattedHumanReadableLabelType.ONCHAIN_ASSET_NAME,
+      label: <span className={styles.assetName}>{readableAssetName}</span>,
+      labelShort: (
+        <span className={`${styles.assetName} flex-nowrap shrinkable`}>
+          <div className="ellipsis">{readableAssetName}</div>
+        </span>
+      ),
+    }
+  }
+
+  const label = (
+    <span className={`${styles.assetName} flex-nowrap shrinkable`}>
+      <StringEllipsis value={fingerprint!} length={6} />
+    </span>
+  )
+  return {
+    type: FormattedHumanReadableLabelType.FINGERPRINT,
+    label,
+    labelShort: label,
+  }
+}
+
+const getFormattedLabelVariants = (
+  args: GetLabelVariantsArgs
+): FormattedHumanReadableLabelVariants => {
+  const {type, label, labelShort} = getLabelVariants(args)
+
+  const LabelWrapper = ({children}: {children: h.JSX.Element | h.JSX.Element[]}) => (
+    <div
+      className={`${styles.iconName} ${
+        type === FormattedHumanReadableLabelType.FINGERPRINT ? 'flex-nowrap shrinkable' : ''
+      }`}
+    >
+      {children}
+    </div>
+  )
+
+  const icon = (
+    <Icon type={args.type} metadata={args.type === AssetFamily.TOKEN ? args.metadata : null} />
+  )
+
+  return {
+    type,
+    label: <LabelWrapper>{label}</LabelWrapper>,
+    labelWithIcon: (
+      <LabelWrapper>
+        <div className={`${styles.icon} ${styles.iconOffset}`}>{icon}</div>
+        {label}
+      </LabelWrapper>
+    ),
+    labelShortWithIcon: (
+      <LabelWrapper>
+        <div className={`${styles.icon} ${styles.iconOffset}`}>{icon}</div>
+        {labelShort}
+      </LabelWrapper>
+    ),
+  }
+}
+
 export type FormattedAssetItemProps = Token & {
   fingerprint: string | null
   type: AssetFamily
+}
+
+type FormattedHumanReadableLabelVariants = {
+  type: FormattedHumanReadableLabelType
+  label: h.JSX.Element
+  labelWithIcon: h.JSX.Element
+  labelShortWithIcon: h.JSX.Element
 }
 
 // Use to share common formatting, but allow for usage in different layouts
@@ -35,8 +175,9 @@ export const FormattedAssetItem = ({
 }: FormattedAssetItemProps & {
   children: (props: {
     icon: h.JSX.Element
-    formattedAssetName: h.JSX.Element | string
-    formattedAssetIconName: h.JSX.Element
+    formattedHumanReadableLabelVariants: FormattedHumanReadableLabelVariants
+    formattedOnChainName: h.JSX.Element | null
+    formattedOffChainName: h.JSX.Element | null
     formattedAssetLink: h.JSX.Element | null
     formattedAmount: string
     formattedPolicy: h.JSX.Element | null
@@ -46,79 +187,66 @@ export const FormattedAssetItem = ({
     formattedUrl: h.JSX.Element | null
   }) => h.JSX.Element
 }) => {
+  const missingValue = 'N / A'
+
   const metadata = useSelector((state) =>
     state.tokensMetadata.get(createTokenRegistrySubject(policyId, assetName))
   )
 
-  const Icon = () => {
-    if (type === AssetFamily.ADA) return <AdaIcon />
-    if (metadata) {
-      if (metadata.logoBase64) {
-        return (
-          <img
-            src={`data:image/png;base64,${metadata.logoBase64}`}
-            alt="logo"
-            width="12"
-            height="12"
-          />
-        )
-      } else {
-        return <StarIcon />
-      }
-    } else {
-      return <QuestionFillIcon />
-    }
-  }
-
-  const formatAssetName = (assetNameHex: string, metadata: RegisteredTokenMetadata | undefined) => {
-    if (metadata?.name) {
-      return metadata.name
-    } else if (assetName) {
-      return assetNameHex2Readable(assetNameHex)
-    }
-    return '<no name>'
-  }
-
-  const FormattedAssetName = () => {
-    if (type === AssetFamily.ADA) return <span className={styles.assetName}>ADA</span>
-    return (
-      <span>
-        {
-          <span className={metadata || assetName ? styles.assetName : styles.empty}>
-            {formatAssetName(assetName, metadata)}
-          </span>
-        }
-        <span className={styles.assetName}>{metadata?.ticker ? ` (${metadata?.ticker})` : ''}</span>
-      </span>
-    )
-  }
-
-  const FormattedAmount = () => {
-    if (type === AssetFamily.TOKEN) {
-      return printTokenAmount(quantity, metadata?.decimals || 0)
-    } else {
-      return printAda(Math.abs(quantity) as Lovelace)
-    }
-  }
-
   return children({
     icon: (
       <div className={styles.icon}>
-        <Icon />
+        <Icon type={type} metadata={metadata ?? null} />
       </div>
     ),
-    formattedAssetName: <FormattedAssetName />,
-    formattedAssetIconName: (
-      <div className={styles.iconName}>
-        <Icon />
-        <FormattedAssetName />
-      </div>
+    formattedHumanReadableLabelVariants: getFormattedLabelVariants(
+      type === AssetFamily.ADA
+        ? {type}
+        : {
+          type,
+          metadata: metadata!,
+          assetName,
+          fingerprint: fingerprint!,
+        }
     ),
+    formattedOnChainName: (() => {
+      if (type !== AssetFamily.TOKEN) return null
+
+      if (!assetName) {
+        return <span className={styles.empty}>{missingValue}</span>
+      }
+
+      const readableAssetName = assetNameHex2Readable(assetName)
+      return (
+        <span className={`${styles.assetName} flex-nowrap shrinkable`}>
+          <StringEllipsis
+            value={isHumanReadable(readableAssetName) ? readableAssetName : `${assetName} (hex)`}
+            length={12}
+          />
+        </span>
+      )
+    })(),
+    formattedOffChainName:
+      type === AssetFamily.TOKEN ? (
+        <span>
+          {
+            <span className={metadata ? styles.assetName : styles.empty}>
+              {metadata?.name || missingValue}
+            </span>
+          }
+          <span className={styles.assetName}>
+            {metadata?.ticker ? ` (${metadata?.ticker})` : ''}
+          </span>
+        </span>
+      ) : null,
     formattedAssetLink:
       type === AssetFamily.TOKEN ? (
         <LinkToAsset policyIdHex={policyId} assetNameHex={assetName} />
       ) : null,
-    formattedAmount: FormattedAmount(),
+    formattedAmount:
+      type === AssetFamily.TOKEN
+        ? printTokenAmount(quantity, metadata?.decimals || 0)
+        : printAda(Math.abs(quantity) as Lovelace),
     formattedPolicy: policyId ? (
       <div className="multi-asset-hash">
         <StringEllipsis value={policyId} length={6} />
@@ -130,7 +258,14 @@ export const FormattedAssetItem = ({
       </div>
     ) : null,
     formattedDescription: metadata?.description ? <div>{metadata.description}</div> : null,
-    formattedTicker: metadata?.ticker ? <div>{metadata.ticker}</div> : null,
+    formattedTicker:
+      type === AssetFamily.TOKEN ? (
+        metadata?.ticker ? (
+          <div>{metadata.ticker}</div>
+        ) : (
+          <div className={styles.empty}>{missingValue}</div>
+        )
+      ) : null,
     formattedUrl: metadata?.url ? (
       <div className={styles.homepage}>
         <HomePageIcon />

--- a/app/frontend/components/pages/advanced/signPoolCertTxModal.tsx
+++ b/app/frontend/components/pages/advanced/signPoolCertTxModal.tsx
@@ -38,35 +38,33 @@ const SignPoolCertTxModal = ({
       <div className="review pool-owner">
         <Fragment>
           <div className="review-label">Key hash</div>
-          <div className="review-amount">{poolCert.poolKeyHashHex}</div>
+          <div className="review-value">{poolCert.poolKeyHashHex}</div>
           <div className="review-label">Vrf hash</div>
-          <div className="review-amount">{poolCert.vrfKeyHashHex}</div>
+          <div className="review-value">{poolCert.vrfKeyHashHex}</div>
           <div className="review-label">Reward address</div>
-          <div className="review-amount">{poolCert.rewardAccountHex}</div>
+          <div className="review-value">{poolCert.rewardAccountHex}</div>
           <div className="ada-label">Fixed Cost</div>
-          <div className="review-amount">
-            {printAda(parseInt(poolCert.costStr, 10) as Lovelace)}
-          </div>
+          <div className="review-value">{printAda(parseInt(poolCert.costStr, 10) as Lovelace)}</div>
           <div className="ada-label">Pledge</div>
-          <div className="review-amount">
+          <div className="review-value">
             {printAda(parseInt(poolCert.pledgeStr, 10) as Lovelace)}
           </div>
           <div className="review-label">Margin</div>
-          <div className="review-amount">
+          <div className="review-value">
             {(poolCert.margin.numeratorStr * 100) / poolCert.margin.denominatorStr}%
           </div>
           {poolCert.poolOwners.map((owner, i) => (
             <Fragment key={i}>
               <div className="review-label">Owner #{i + 1}</div>
-              <div className="review-amount">{owner.stakingKeyHashHex || owner.pubKeyHex}</div>
+              <div className="review-value">{owner.stakingKeyHashHex || owner.pubKeyHex}</div>
             </Fragment>
           ))}
           {poolCert.metadata && (
             <Fragment>
               <div className="review-label">Metadata url</div>
-              <div className="review-amount">{poolCert.metadata.metadataUrl}</div>
+              <div className="review-value">{poolCert.metadata.metadataUrl}</div>
               <div className="review-label">Metadata hash</div>
-              <div className="review-amount">{poolCert.metadata.metadataHashHex}</div>
+              <div className="review-value">{poolCert.metadata.metadataHashHex}</div>
             </Fragment>
           )}
           {/* relays */}

--- a/app/frontend/components/pages/sendAda/confirmTransactionDialog.tsx
+++ b/app/frontend/components/pages/sendAda/confirmTransactionDialog.tsx
@@ -87,41 +87,43 @@ const SendAdaReview = ({
             </div>
           )}
         </div>
-        <div className="ada-label">Amount</div>
-        <div className="review-amount">{printAda(lovelaceAmount as Lovelace)}</div>
         {token && formattedAssetItemProps && (
           <FormattedAssetItem {...formattedAssetItemProps}>
-            {({formattedAssetIconName, formattedAmount, formattedFingerprint}) => {
+            {({
+              formattedHumanReadableLabelVariants,
+              formattedOnChainName,
+              formattedAmount,
+              formattedFingerprint,
+            }) => {
               return (
                 <Fragment>
-                  <div className="review-label">Token fingerprint</div>
-                  <div className="review-amount">{formattedFingerprint}</div>
-                  <div className="review-label">Token policy Id</div>
-                  <div className="review-amount">{token.policyId}</div>
-                  <div className="review-label">Token name</div>
-                  <div className="review-amount">{formattedAssetIconName}</div>
-                  <div className="review-label">Token amount</div>
-                  <div className="review-amount" data-cy="SendTokenAmount">
-                    {formattedAmount}
+                  <div className="review-label">Fingerprint</div>
+                  <div className="review-value">{formattedFingerprint}</div>
+                  <div className="review-label">Asset name</div>
+                  <div className="review-value">{formattedOnChainName}</div>
+                  <div className="review-label">Amount</div>
+                  <div className="review-value">
+                    <span data-cy="SendTokenAmount">{formattedAmount}</span>
+                    {formattedHumanReadableLabelVariants.labelWithIcon}
                   </div>
                   {isHwWallet(cryptoProviderType) && (
                     <Fragment>
                       <div className="review-label">
                         Token amount on {getDeviceBrandName(cryptoProviderType)}
                       </div>
-                      <div className="review-amount" data-cy="SendTokenAmount">
+                      <div className="review-value" data-cy="SendTokenAmount">
                         {token.quantity}
                       </div>
                     </Fragment>
                   )}
-                  {/* <div className="ada-label">Minimal Lovelace amount</div>
-                  <div className="review-amount">{printAda(minimalLovelaceAmount)}</div> */}
                 </Fragment>
               )
             }}
           </FormattedAssetItem>
         )}
-        <div className="ada-label">Fee</div>
+        <div className="ada-label">Amount</div>
+        <div className="review-value">{printAda(lovelaceAmount as Lovelace)}</div>
+        <div className="ada-label">Network fees</div>
         <div className="review-fee">{printAda(fee as Lovelace)}</div>
         {/* TODO: Hide ADA symbol when handling tokens */}
         <div className="ada-label">Total</div>
@@ -144,17 +146,17 @@ const DelegateReview = ({
     <Fragment>
       <div className="review">
         <div className="review-label">Pool ID</div>
-        <div className="review-amount">{stakePool.poolHash}</div>
+        <div className="review-value">{stakePool.poolHash}</div>
         <div className="review-label">Pool Name</div>
-        <div className="review-amount">{stakePool.name}</div>
+        <div className="review-value">{stakePool.name}</div>
         <div className="review-label">Ticker</div>
-        <div className="review-amount">{stakePool.ticker}</div>
+        <div className="review-value">{stakePool.ticker}</div>
         <div className="review-label">Tax</div>
-        <div className="review-amount">{stakePool.margin && stakePool.margin * 100}%</div>
+        <div className="review-value">{stakePool.margin && stakePool.margin * 100}%</div>
         <div className="review-label">Fixed cost</div>
-        <div className="review-amount">{stakePool.fixedCost && printAda(stakePool.fixedCost)}</div>
+        <div className="review-value">{stakePool.fixedCost && printAda(stakePool.fixedCost)}</div>
         <div className="review-label">Homepage</div>
-        <div className="review-amount">{stakePool.homepage}</div>
+        <div className="review-value">{stakePool.homepage}</div>
         <div className="ada-label">Deposit</div>
         <div className="review-fee">
           {printAda(deposit)}
@@ -251,7 +253,7 @@ const WithdrawReview = ({
           </div>
         </div>
         <div className="ada-label">Rewards</div>
-        <div className="review-amount">{printAda(rewards)}</div>
+        <div className="review-value">{printAda(rewards)}</div>
         <div className="ada-label">Fee</div>
         <div className="review-fee">{printAda(fee)}</div>
         {/* TODO: Hide ADA symbol when handling tokens */}
@@ -278,11 +280,11 @@ const VotingRegistrationReview = ({
           {transactionSummary.plan.auxiliaryData.rewardDestinationAddress.address}
         </div>
         <div className="review-label">Voting key</div>
-        <div className="review-amount">
+        <div className="review-value">
           {encodeCatalystVotingKey(transactionSummary.plan.auxiliaryData.votingPubKey)}
         </div>
         <div className="review-label">Nonce</div>
-        <div className="review-amount">{`${transactionSummary.plan.auxiliaryData.nonce}`}</div>
+        <div className="review-value">{`${transactionSummary.plan.auxiliaryData.nonce}`}</div>
         <div className="ada-label">Fee</div>
         <div className="review-fee" data-cy="VotingFeeAmount">
           {printAda(fee)}
@@ -318,7 +320,7 @@ const ConvertFundsReview = ({
           </div>
         </div>
         <div className="ada-label">Amount</div>
-        <div className="review-amount">{printAda(coins)}</div>
+        <div className="review-value">{printAda(coins)}</div>
         <div className="ada-label">Fee</div>
         <div className="review-fee">{printAda(fee as Lovelace)}</div>
         {/* TODO: Hide ADA symbol when handling tokens */}

--- a/app/frontend/components/pages/sendAda/multiAssetsPage.module.scss
+++ b/app/frontend/components/pages/sendAda/multiAssetsPage.module.scss
@@ -68,5 +68,6 @@
 }
 
 .hashLabel {
+  white-space: nowrap;
   margin-right: 4px;
 }

--- a/app/frontend/components/pages/sendAda/multiAssetsPage.tsx
+++ b/app/frontend/components/pages/sendAda/multiAssetsPage.tsx
@@ -9,6 +9,43 @@ import {useState} from 'preact/hooks'
 import styles from './multiAssetsPage.module.scss'
 import {DropdownCaret} from '../../common/svg'
 
+type ItemProps = {
+  title: string
+  displayElement: h.JSX.Element
+  copyValue?: string
+}
+
+const Item = ({title, displayElement, copyValue}: ItemProps) => {
+  const content = (
+    <div className="multi-asset-page-copy-on-click">
+      <span className={styles.hashLabel}>{title}:</span>
+      {displayElement}
+      {copyValue ? (
+        <div className="desktop">
+          <span className="copy-text margin-left" />
+        </div>
+      ) : (
+        ''
+      )}
+    </div>
+  )
+  return (
+    <div className="multi-asset-page-policy">
+      {copyValue ? (
+        <CopyOnClick
+          value={copyValue}
+          elementClass="copy"
+          tooltipMessage={`${title} copied to clipboard`}
+        >
+          {content}
+        </CopyOnClick>
+      ) : (
+        content
+      )}
+    </div>
+  )
+}
+
 const MultiAssetsPage = () => {
   const {tokenBalance} = useSelector((state: State) => getSourceAccountInfo(state))
 
@@ -34,12 +71,15 @@ const MultiAssetsPage = () => {
         {multiAssets.map((asset, i) => (
           <FormattedAssetItem key={asset.fingerprint} {...asset}>
             {({
-              formattedAssetIconName,
+              formattedHumanReadableLabelVariants,
+              formattedOnChainName,
+              formattedOffChainName,
               formattedAssetLink,
               formattedAmount,
               formattedPolicy,
               formattedFingerprint,
               formattedDescription,
+              formattedTicker,
               formattedUrl,
             }) => {
               const isExpanded = i === expandedAsset
@@ -54,8 +94,8 @@ const MultiAssetsPage = () => {
                     }
                   }}
                 >
-                  <div className={styles.name}>
-                    {formattedAssetIconName}
+                  <div className={`${styles.name} flex-nowrap shrinkable`}>
+                    {formattedHumanReadableLabelVariants.labelWithIcon}
                     {formattedAssetLink}
                   </div>
                   <div className={styles.right}>
@@ -71,36 +111,19 @@ const MultiAssetsPage = () => {
               )
               const details = (
                 <div className={`${styles.details} ${isExpanded ? styles.expanded : ''}`}>
-                  <div className="multi-asset-page-policy">
-                    <CopyOnClick
-                      value={asset?.policyId}
-                      elementClass="copy"
-                      tooltipMessage="Policy id copied to clipboard"
-                    >
-                      <div className="multi-asset-page-copy-on-click">
-                        <span className={styles.hashLabel}>Policy ID:</span>
-                        {formattedPolicy}
-                        <div className="desktop">
-                          <span className="copy-text margin-left" />
-                        </div>
-                      </div>
-                    </CopyOnClick>
-                  </div>
-                  <div className="multi-asset-page-policy">
-                    <CopyOnClick
-                      value={asset?.fingerprint}
-                      elementClass="copy"
-                      tooltipMessage="Fingerprint copied to clipboard"
-                    >
-                      <div className="multi-asset-page-copy-on-click">
-                        <span className={styles.hashLabel}>Fingerprint:</span>
-                        {formattedFingerprint}
-                        <div className="desktop">
-                          <span className="copy-text margin-left" />
-                        </div>
-                      </div>
-                    </CopyOnClick>
-                  </div>
+                  <Item title="Name" displayElement={formattedOffChainName!} />
+                  <Item title="Ticker" displayElement={formattedTicker!} />
+                  <Item
+                    title="Policy ID"
+                    displayElement={formattedPolicy!}
+                    copyValue={asset.policyId}
+                  />
+                  <Item title="Asset name" displayElement={formattedOnChainName!} />
+                  <Item
+                    title="Fingerprint"
+                    displayElement={formattedFingerprint!}
+                    copyValue={asset.fingerprint!}
+                  />
                   {formattedDescription && (
                     <Fragment>
                       <div className={styles.detailsLabel}>Details</div>

--- a/app/frontend/components/pages/sendAda/sendAdaPage.tsx
+++ b/app/frontend/components/pages/sendAda/sendAdaPage.tsx
@@ -26,7 +26,7 @@ import {
   encodeAssetFingerprint,
 } from '../../../../frontend/wallet/shelley/helpers/addresses'
 import tooltip from '../../common/tooltip'
-import {FormattedAssetItem} from '../../common/asset'
+import {FormattedAssetItem, FormattedHumanReadableLabelType} from '../../common/asset'
 import {shouldDisableSendingButton} from '../../../helpers/common'
 import printTokenAmount from '../../../helpers/printTokenAmount'
 import {createTokenRegistrySubject} from '../../../../frontend/tokenRegistry/tokenRegistry'
@@ -60,7 +60,7 @@ type DropdownAssetItem = Token & {
 
 const displayDropdownAssetItem = (props: DropdownAssetItem) => (
   <FormattedAssetItem key={props.fingerprint} {...props}>
-    {({formattedAssetIconName, formattedAssetLink, formattedAmount}) => {
+    {({formattedHumanReadableLabelVariants, formattedAssetLink, formattedAmount}) => {
       return (
         <div
           className="multi-asset-item"
@@ -71,8 +71,8 @@ const displayDropdownAssetItem = (props: DropdownAssetItem) => (
           }
         >
           <div className="multi-asset-name-amount">
-            <div className="multi-asset-name">
-              {formattedAssetIconName}
+            <div className="multi-asset-name flex-nowrap shrinkable">
+              {formattedHumanReadableLabelVariants.labelWithIcon}
               {formattedAssetLink}
             </div>
             <div
@@ -255,17 +255,19 @@ const SendAdaPage = ({
   )
 
   const displayDropdownSelectedItem = (dropdownAssetItem: DropdownAssetItem) => {
-    const {policyId, type} = dropdownAssetItem
+    const {fingerprint, type} = dropdownAssetItem
     return (
-      <div className="wrapper">
+      <div className="wrapper flex-nowrap shrinkable">
         <FormattedAssetItem {...dropdownAssetItem}>
-          {({formattedAssetIconName}) => {
+          {({formattedHumanReadableLabelVariants}) => {
+            const {type: labelType, labelWithIcon} = formattedHumanReadableLabelVariants
+            const isLabelFingerprint = labelType === FormattedHumanReadableLabelType.FINGERPRINT
             return (
               <Fragment>
-                {formattedAssetIconName}
-                {type === AssetFamily.TOKEN && (
-                  <div className="hash">
-                    (<div className="ellipsis">{policyId}</div>)
+                {labelWithIcon}
+                {type === AssetFamily.TOKEN && !isLabelFingerprint && (
+                  <div className="hash flex-nowrap shrinkable">
+                    (<div className="ellipsis">{fingerprint}</div>)
                   </div>
                 )}
               </Fragment>
@@ -432,20 +434,22 @@ const SendAdaPage = ({
       </div>
       <div className="send-total">
         <div className="send-total-title">Total</div>
-        <div className="send-total-inner">
+        <div className="send-total-inner flex-nowrap shrinkable">
           {selectedAsset.type === AssetFamily.ADA ? (
             <div className="send-total-ada">
               {printAda(totalLovelace)}
               <AdaIcon />
             </div>
           ) : (
-            <div className="send-total-ada">
+            <div className="send-total-ada flex-nowrap shrinkable">
               {totalTokens?.quantity != null && tokenDecimals != null
                 ? printTokenAmount(totalTokens.quantity, tokenDecimals)
                 : 0}{' '}
               <FormattedAssetItem {...selectedAsset}>
-                {({formattedAssetIconName}) => {
-                  return <Fragment>{formattedAssetIconName}</Fragment>
+                {({formattedHumanReadableLabelVariants}) => {
+                  return (
+                    <Fragment>{formattedHumanReadableLabelVariants.labelShortWithIcon}</Fragment>
+                  )
                 }}
               </FormattedAssetItem>
             </div>

--- a/app/frontend/components/pages/txHistory/transactionHistory.tsx
+++ b/app/frontend/components/pages/txHistory/transactionHistory.tsx
@@ -15,7 +15,11 @@ import {
   AssetFamily,
 } from '../../../types'
 import {AdaIcon} from '../../common/svg'
-import {FormattedAssetItem, FormattedAssetItemProps} from '../../common/asset'
+import {
+  FormattedAssetItem,
+  FormattedAssetItemProps,
+  FormattedHumanReadableLabelType,
+} from '../../common/asset'
 import styles from './transactionHistory.module.scss'
 import Alert from '../../common/alert'
 import * as moment from 'moment'
@@ -83,18 +87,17 @@ const MultiAsset = (props: FormattedAssetItemProps) => {
     <FormattedAssetItem {...props}>
       {({
         icon,
-        formattedAssetName,
+        formattedHumanReadableLabelVariants,
         formattedAmount,
         formattedAssetLink,
-        formattedPolicy,
         formattedFingerprint,
       }) => {
         const {quantity} = props
         return (
           <Fragment>
             <div className={`${styles.multiAssetRow} row`}>
-              <div className="multi-asset-name">
-                {formattedAssetName}
+              <div className="multi-asset-name shrinkable flex-nowrap">
+                {formattedHumanReadableLabelVariants.label}
                 {formattedAssetLink}
               </div>
               <div className={`${styles.amount} ${quantity > 0 ? 'credit' : 'debit'}`}>
@@ -104,8 +107,10 @@ const MultiAsset = (props: FormattedAssetItemProps) => {
                 {icon}
               </div>
             </div>
-            {formattedPolicy}
-            {formattedFingerprint}
+            {formattedHumanReadableLabelVariants.type ===
+            FormattedHumanReadableLabelType.FINGERPRINT
+              ? ''
+              : formattedFingerprint}
           </Fragment>
         )
       }}

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -180,6 +180,15 @@ p.hey {
   text-overflow: ellipsis;
 }
 
+.flex-nowrap {
+  display: flex;
+  flex-wrap: nowrap;
+}
+
+.shrinkable {
+  min-width: 0;
+}
+
 /* SELECTABILITY */
 
 .one-click-select {
@@ -1494,10 +1503,6 @@ button[data-balloon] {
 
 .dashboard-column {
   flex: 1 1 50%;
-}
-
-.dashboard-column.shrinkable {
-  min-width: 0;
 }
 
 .dashboard-column:first-child {
@@ -3771,6 +3776,8 @@ input:checked + .slider:before {
 }
 
 .send-total-ada svg, .send-total-ada img {
+  position: relative;
+  top: -2px;
   margin-left: 6px;
   height: 18px !important;
   width: unset !important;
@@ -3815,6 +3822,17 @@ input:checked + .slider:before {
   color: var(--color-grey);
   font-size: 14px;
   line-height: 32px;
+}
+
+.review-value {
+  display: flex;
+  align-items: center;
+}
+
+.review-value svg, .review-value img {
+  position: relative;
+  top: -2px;
+  margin-left: 6px;
 }
 
 .review .ada-label {


### PR DESCRIPTION
https://vacuum.atlassian.net/browse/ADLT-1180

# Changes

See the following screenshots. The new version is on the left side, the old version is on the right side.

## Digital assets

![digitalAssets](https://user-images.githubusercontent.com/69396388/166103572-b9c0d804-3869-407c-bcda-a9d49a477aae.png)

Previously we have shown:
- `Off-chain asset name + Ticker` or `On-chain name` in the header
- `Policy ID`,  `Fingerprint`, and `Details` in the expanded content.

This had some problems. `On-chain name` can be hard to read and isn't very helpful for the user. Changes:
- Define a new label for tokens, which is always readable. The priority is the following:
  - `Icon + off-chain name + ticker` > `Onchain name` (must be human-readable) > `Fingerprint`
- Add all information to the description. This is the same as we do it on NuFi:
  - `Name`, `Ticker`, `Policy ID`, `Asset name`, `Fingerprint`

There is one more thing that I find a little bit problematic, and that is the usage of the terminology: `Name` (off-chain) and `Asset name` (on-chain). For now, I chose to display it the same way as we do on NuFi. However, I think this is something that should be improved.

## Digital assets ellipsizing

![digitalAssetsEllipsis](https://user-images.githubusercontent.com/69396388/166103772-50648191-59e2-44a5-9dba-76d138c825a2.png)

Fixed the issue with ellipsizing.

## Select dropdown

![selectDropdown](https://user-images.githubusercontent.com/69396388/166103798-99ae6152-38bb-49aa-bbce-0ba7c06aba5d.png)

Fallback to fingerprint in the case of non-human-readable `off-chain name`.

## Select dropdown ellipsizing

![selectDropdownEllipsis](https://user-images.githubusercontent.com/69396388/166103877-0845c06e-9438-4bb6-975b-fd2b0f184e3d.png)

Fixed the issue with ellipsizing.

## Send asset with off-chain metadata

![sendRegisteredAsset](https://user-images.githubusercontent.com/69396388/166103882-d90c0ce6-a20b-4727-ac55-1ccff53ed518.png)

Previously we have shown `Policy ID` as grey text in brackets after the `icon + off-chain name + ticker`. This was from times when asset `fingerprint` wasn't a thing yet. It's a better universal identifier and should be used instead.

Previously we have used the `icon + off-chain name + ticker` in the total row. In most cases, this combination is too long and went off-screen. `ticker` is good enough to convey the information. Especially because the user has seen what he selected in the dropdown and we will show him a confirmation screen with all information anyway.

Previously, the icon was not visually vertically aligned with the text.

## Send asset without off-chain metadata with non-human-readable name

![sendTokenEllipsis](https://user-images.githubusercontent.com/69396388/166104135-2d7b4be0-a24c-4994-9d72-5c2e52445a07.png)

Fixed the issue with ellipsizing in the dropdown selection element and total row.

No point in showing anything after the `fingerprint` in gray in brackets, as opposed to the assets with `off-chain` metadata.

## Transaction review

![transactionReview](https://user-images.githubusercontent.com/69396388/166104200-ca38d497-2d14-4f42-8552-16a975ab37c5.png)

Make the information consistent with the information shown on the `Digital assets` screen. That being, show `token name + ticker`, `token policy ID`, `token asset name`, `fingerprint` in the same order.

Previously we have shown an icon next to the `token name`, which wasn't always an `off-chain name`. Which can cause confusion as on-chain data never contain icons. Now the icon (which is always off-chain) is next to the `off-chain name`, which is nullable (`N / A`).

## Transaction history

![txHistory](https://user-images.githubusercontent.com/69396388/166104337-68ab29d2-b6ae-48fb-88ae-9e675c366af5.png)

and

![txHistoryAssetsWithOffchainData](https://user-images.githubusercontent.com/69396388/166104432-02729f89-65ce-4e4f-94f0-58a2cfccc8b0.png)

Previously we have shown `non-human-readable on-chain names` or more readable `icon + off-chain name + ticker`. Always followed by `policy ID` and `fingerprint`. In the case of a non-human-readable name, there is no reason to show it. `fingerprint` already acts as a universal identifier, so no reason for `Policy ID` either. Now we show only `icon + off-chain name + ticker` (if exists) and always `Fingerprint`.

## Transaction history ellipsizing

![txHistoryEllipsis](https://user-images.githubusercontent.com/69396388/166104576-1b12831c-8437-40f4-895e-3f756f777f32.png)

Fixed issue with ellipsizing.

