### PR TITLE
Ignore Webassembly error triggered by Eternl addon

### DIFF
--- a/app/frontend/walletApp.js
+++ b/app/frontend/walletApp.js
@@ -89,6 +89,9 @@ init({
     // FF 83.0 specific error to be ignored
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1678243
     'XDR encoding failure',
+    // Eternl wallet error, unrelated to Adalite
+    // https://github.com/ccwalletio/tracker/issues/119
+    'WebAssembly.instantiate(): expected magic word',
   ],
 })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cardano",
-  "version": "6.9.22",
+  "version": "6.9.23",
   "engines": {
     "node": "14.16"
   },


### PR DESCRIPTION
This unhandled error sometimes, depending on how quickly Adalite managed to load, especially when cached, resulted in Adalite showing an error prompt

https://github.com/ccwalletio/tracker/issues/119