### PR TITLE
Update moment to v 2.29, fix integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - setup
       - run: yarn improved-yarn-audit
       - run: cd app && yarn improved-yarn-audit && cd ../
-  
+
   lint:
     <<: *defaults
     steps:
@@ -41,7 +41,7 @@ jobs:
     steps:
       - setup
       - run: yarn test-chrome-headless
-  
+
   test_integration:
     <<: *defaults
     steps:
@@ -72,4 +72,3 @@ workflows:
       - lint
       - test_unit
       - test_integration
-

--- a/app/cypress/integration/sendingTab.spec.ts
+++ b/app/cypress/integration/sendingTab.spec.ts
@@ -89,8 +89,10 @@ describe('Sending tab', () => {
 
     cy.dataCy('SendAssetDropdown').click()
     cy.dataCy('SendAssetDropdownTokenItem')
+      .first()
       .as('TokenItem')
       .dataCy('SendAssetTokenQuantity')
+      .first()
       .invoke('text')
       .as('TokenQuantity')
 

--- a/app/package.json
+++ b/app/package.json
@@ -33,7 +33,7 @@
     "chacha": "^2.1.0",
     "js-base64": "^3.7.2",
     "lodash": "^4.17.21",
-    "moment": "^2.29.1",
+    "moment": "^2.29.4",
     "pbkdf2": "^3.1.2",
     "preact": "^10.5.11",
     "react-device-detect": "^1.17.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -877,7 +877,7 @@ create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-fetch@^3.1.5:
+cross-fetch@^3.1.4:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
@@ -1729,10 +1729,10 @@ minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
-moment@^2.29.1:
-  version "2.29.3"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.3.tgz#edd47411c322413999f7a5940d526de183c031f3"
-  integrity sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==
+moment@^2.29.4:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
 
 ms@2.1.2:
   version "2.1.2"
@@ -2297,7 +2297,7 @@ trezor-connect@^8.2.6:
   integrity sha512-ioa/NkwtFHY94VI95q4JPdoDU3HaQFFIqdS47751zHa5q8qVBzwf5vgUrNS+q3vJ2ZNE7mTk/r4FjURtDB1xjA==
   dependencies:
     "@babel/runtime" "^7.15.4"
-    cross-fetch "^3.1.5"
+    cross-fetch "^3.1.4"
     events "^3.3.0"
 
 tslib@^1.9.0:

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "glob": "^7.2.0",
     "isomorphic-fetch": "^3.0.0",
     "mocha-headless-chrome": "^2.0.3",
-    "moment": "^2.27.0",
     "normalize-url": "^4.0.0",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4608,11 +4608,6 @@ mocha-headless-chrome@^2.0.3:
     mkdirp "^0.5.1"
     puppeteer "^1.17.0"
 
-moment@^2.27.0:
-  version "2.29.4"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
-  integrity "sha1-Pb4FKIn+fBsu2Wb8s6dzKJZO8Qg= sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
-
 mri@1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.4.tgz#7cb1dd1b9b40905f1fac053abe25b6720f44744a"


### PR DESCRIPTION
1. update moment to latest version, remove no longer needed version of the lib from the project root
2. integration tests were failing, turns out somebody sent tokens to the cypress test wallet and the tests weren't able to handle multiple tokens in the wallet, so I fixed it to take the first available token from the list