### PR TITLE
Fix incorrectly called staking screen's printAda call

### DIFF
--- a/app/frontend/components/pages/delegations/currentDelegationPage.tsx
+++ b/app/frontend/components/pages/delegations/currentDelegationPage.tsx
@@ -63,7 +63,10 @@ const CurrentDelegationPage = ({
             {SaturationInfo(pool)}
             {pool.liveStake != null && (
               <div className="current-delegation-id">
-                Live stake: {parseFloat(printAda(pool.liveStake as Lovelace)).toLocaleString('en')}
+                Live stake:{' '}
+                {parseFloat(printAda(new BigNumber(pool.liveStake) as Lovelace)).toLocaleString(
+                  'en'
+                )}
               </div>
             )}
             {pool.homepage != null && (


### PR DESCRIPTION
We forgot to convert pool.liveStake into BigNumber before calling printAda.