### PR TITLE
Fix delegation fee calculation crashing while clicking between tabs

### DIFF
--- a/app/frontend/actions/delegate.ts
+++ b/app/frontend/actions/delegate.ts
@@ -67,7 +67,11 @@ export default (store: Store) => {
   const calculateDelegationFee = async (): Promise<void> => {
     const state = getState()
     await setPoolInfo(state)
-    assert(state.shelleyDelegation?.selectedPool != null)
+    // selectedPool may be null e.g. when switching tab and selectedPool
+    // is already reset when this debounced function is executed
+    if (state.shelleyDelegation?.selectedPool == null) {
+      return
+    }
     const poolHash = state.shelleyDelegation.selectedPool.poolHash as string
     const isStakingKeyRegistered = getSourceAccountInfo(state).shelleyAccountInfo.hasStakingKey
     const stakingAddress = getSourceAccountInfo(state).stakingAddress


### PR DESCRIPTION
The delegation fee calculation asserted on the selected pool being set which is however not always the case because the selectedPool is reset when clicking between the tabs and the function to calculate the fee is ran denounced, therefore with some delay (300ms) and by that time the pool data in the state may already be reset