### PR TITLE
Fix coin selection for Byron addresses with tokens

### DIFF
--- a/app/frontend/wallet/account.ts
+++ b/app/frontend/wallet/account.ts
@@ -292,8 +292,14 @@ const Account = ({config, cryptoProvider, blockchainExplorer, accountIndex}: Acc
     )
     const nonStakingUtxos = sortedUtxos.filter(({address}) => !isBase(addressToHex(address)))
     const baseAddressUtxos = sortedUtxos.filter(({address}) => isBase(addressToHex(address)))
-    const adaOnlyUtxos = baseAddressUtxos.filter(({tokenBundle}) => tokenBundle?.length === 0)
-    const tokenUtxos = baseAddressUtxos.filter(({tokenBundle}) => tokenBundle.length > 0)
+    const utxosPrioritizedByAddressType = [...nonStakingUtxos, ...baseAddressUtxos]
+
+    const adaOnlyUtxos = utxosPrioritizedByAddressType.filter(
+      ({tokenBundle}) => tokenBundle.length === 0
+    )
+    const tokenUtxos = utxosPrioritizedByAddressType.filter(
+      ({tokenBundle}) => tokenBundle.length > 0
+    )
 
     if (
       txPlanArgs.txType === TxType.SEND_ADA &&
@@ -307,9 +313,9 @@ const Account = ({config, cryptoProvider, blockchainExplorer, accountIndex}: Acc
         ({tokenBundle}) =>
           !tokenBundle.some((token) => token.policyId === policyId && token.assetName === assetName)
       )
-      return [...targetTokenUtxos, ...nonStakingUtxos, ...adaOnlyUtxos, ...nonTargetTokenUtxos]
+      return [...targetTokenUtxos, ...adaOnlyUtxos, ...nonTargetTokenUtxos]
     }
-    return [...nonStakingUtxos, ...adaOnlyUtxos, ...tokenUtxos]
+    return [...adaOnlyUtxos, ...tokenUtxos]
   }
 
   /*


### PR DESCRIPTION
Motivation: there was a Byron address with many token utxos where the user struggled to send an ADA tx because the resulting tx was too big. Turns out our coin selection algorithm was prioritizing "non-staking" utxos regardless of whether they had tokens or not, causing the tx plan to build unnecessarily big txs when trying to send ADA out of such address.

Changes: This PR combines staking and non-staking utxos into a single list before splitting it into the token and ada utxos, adding proper priority even to "non-staking" utxos when sending ADA out of the wallet

How to test: Try sending ADA out of the review app to check tx building still works