### PR TITLE
Add pool saturation message [ADLT-2077]

### DIFF
--- a/app/frontend/components/pages/login/wantedAddressesModal.tsx
+++ b/app/frontend/components/pages/login/wantedAddressesModal.tsx
@@ -1,39 +1,29 @@
-import {Fragment, h} from 'preact'
+import {h} from 'preact'
 import {useActions} from '../../../helpers/connect'
 import actions from '../../../actions'
 import Modal from '../../common/modal'
-import {WANTED_DELEGATOR_ADDRESSES} from '../../../wallet/constants'
-import Alert from '../../common/alert'
 
 const WantedAddressesModal = () => {
   const {closeWantedAddressModal} = useActions(actions)
 
   return (
     <Modal onRequestClose={closeWantedAddressModal} title={'Direct message - Action required'}>
-      <div>
-        Dear owner(s) of this address:{' '}
-        <Alert alertType="wanted">
-          {WANTED_DELEGATOR_ADDRESSES.map((address, key) => (
-            <Fragment key={key}>
-              {address}
-              <br />
-            </Fragment>
-          ))}
-        </Alert>
-      </div>
       <p className="wanted-text">
-        We greatly appreciate that you chose to stake with us. However, you are saturating the pool
-        ADLT3 by delegating more than allowed 62 million ADA to it. By doing so, you are missing out
-        on a lot of rewards.
+        You are delegating to our pool NUFI0 and we are very happy that you chose to stake with us.
+        However, your substantial stake is saturating the pool to 500%. By doing so, you are missing
+        out on around 75% of your staking rewards.
       </p>
       <p className="wanted-text">
-        We have setup a dedicated staking infrastructure with the same conditions as your current
-        pool but it will be dedicated just for you. Please redelegate to the pre-filled Private
-        Adalite pool in the Staking tab. Feel free to contact us at{' '}
-        <a href={'mailto:info@adalite.io'}>info@adalite.io</a>
+        Don't worry, for such cases, we have setup a dedicated staking infrastructure. To optimize
+        your staking profits, we pre-filled more suitable pools specifically for your addresses, you
+        only need to confirm the redelegation transaction in the Staking tab.
+      </p>
+      <p className="wanted-text">
+        We are happy to provide any support just for you respecting your anonymity and privacy.
+        Please, contact us at <a href={'mailto:info@adalite.io'}>info@adalite.io</a>
         {', '}
         <a href={'mailto:michal.petro@vacuumlabs.com'}>michal.petro@vacuumlabs.com</a> or +421 907
-        189 842 to avoid saturation in the future.
+        189 842 to avoid such troubles in the future.
       </p>
       <div className="modal-footer">{}</div>
     </Modal>

--- a/app/frontend/wallet/account.ts
+++ b/app/frontend/wallet/account.ts
@@ -363,8 +363,9 @@ const Account = ({config, cryptoProvider, blockchainExplorer, accountIndex}: Acc
     const visibleAddresses = await getVisibleAddresses()
     const transactionHistory = await getTxHistory()
     const poolRecommendation = await getPoolRecommendation(
-      shelleyAccountInfo.delegation,
-      baseAddressBalance
+      stakingAddress,
+      baseAddressBalance,
+      shelleyAccountInfo.delegation?.poolHash
     )
     const isUsed = await isAccountUsed()
 
@@ -476,15 +477,22 @@ const Account = ({config, cryptoProvider, blockchainExplorer, accountIndex}: Acc
     return await cryptoProvider.displayAddressForPath(absDerivationPath, stakingPath)
   }
 
-  async function getPoolRecommendation(pool: any, stakeAmount: Lovelace): Promise<any> {
-    const poolHash = pool ? pool.poolHash : null
-    const poolRecommendation = await blockchainExplorer.getPoolRecommendation(poolHash, stakeAmount)
+  async function getPoolRecommendation(
+    stakeAddress: Address,
+    stakeAmount: Lovelace,
+    poolHashHex?: string
+  ): Promise<any> {
+    const poolRecommendation = await blockchainExplorer.getPoolRecommendation(
+      stakeAddress,
+      stakeAmount,
+      poolHashHex
+    )
     if (!poolRecommendation.recommendedPoolHash || config.ADALITE_ENFORCE_STAKEPOOL) {
       Object.assign(poolRecommendation, {
         recommendedPoolHash: config.ADALITE_STAKE_POOL_ID,
       })
     }
-    const delegatesToRecommended = poolRecommendation.recommendedPoolHash === pool.poolHash
+    const delegatesToRecommended = poolRecommendation.recommendedPoolHash === poolHashHex
     return {
       ...poolRecommendation,
       shouldShowSaturatedBanner:

--- a/app/frontend/wallet/blockchain-explorer.ts
+++ b/app/frontend/wallet/blockchain-explorer.ts
@@ -53,6 +53,7 @@ import cacheResults from '../helpers/cacheResults'
 import {filterValidTransactions} from '../helpers/common'
 import * as assert from 'assert'
 import BigNumber from 'bignumber.js'
+import {bechAddressToHex} from './shelley/helpers/addresses'
 
 const blockchainExplorer = (ADALITE_CONFIG) => {
   const gapLimit = ADALITE_CONFIG.ADALITE_GAP_LIMIT
@@ -487,10 +488,20 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
   }
 
   function getPoolRecommendation(
-    poolHash: string,
-    stakeAmount: Lovelace
+    stakeAddress: Address,
+    stakeAmount: Lovelace,
+    currentDelegatedPoolHash?: string
   ): Promise<PoolRecommendationResponse> {
-    const url = `${ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL}/api/account/poolRecommendation/poolHash/${poolHash}/stake/${stakeAmount}`
+    const searchParams = new URLSearchParams({
+      stakeAddress: bechAddressToHex(stakeAddress),
+      stakeAmount: stakeAmount.toString(),
+    })
+    if (currentDelegatedPoolHash) {
+      searchParams.set('currentDelegatedPoolHash', currentDelegatedPoolHash)
+    }
+    const url = `${
+      ADALITE_CONFIG.ADALITE_BLOCKCHAIN_EXPLORER_URL
+    }/api/poolRecommendation?${searchParams.toString()}`
     return request(url).catch(() => ({
       recommendedPoolHash: ADALITE_CONFIG.ADALITE_STAKE_POOL_ID,
       isInRecommendedPoolSet: true,

--- a/app/frontend/wallet/constants.ts
+++ b/app/frontend/wallet/constants.ts
@@ -75,9 +75,14 @@ export const BIG_DELEGATOR_THRESHOLD = 10000000000000
 
 export const CATALYST_MIN_THRESHOLD = 500000000
 
-export const WANTED_DELEGATOR_ADDRESSES = []
-
-export const WANTED_DELEGATOR_STAKING_ADDRESSES = []
+export const WANTED_DELEGATOR_STAKING_ADDRESSES = [
+  'stake1uyqh38ttzlhqmhdsepazqreewejv9dgv28jtw0xzgzqqryclv0ts0',
+  'stake1u9p57w0j9hx0dcrx70e7w9eaju4qg6c5unhywdm87ec0tgsjts43u',
+  'stake1u8dn2se7yl4qhdqwtry7945z73p0z43ap93xm3arggvfkuqx5th8a',
+  'stake1uxfx2grhp7va36ypm2smg2kaukaz44rqvauw7sn5lh4zwrghkf55l',
+  'stake1ux2936h9zvwe45pahh73kv0x7a42gvzjy537dwkql0eu4dgswu6up',
+  'stake1uydh7fgueccyqdr630uqv32z5n46p000sd3lr60cnplh83qqjhz7u',
+]
 
 export const SATURATION_POINT = 66800000000000
 

--- a/app/frontend/wallet/constants.ts
+++ b/app/frontend/wallet/constants.ts
@@ -84,6 +84,8 @@ export const WANTED_DELEGATOR_STAKING_ADDRESSES = [
   'stake1uydh7fgueccyqdr630uqv32z5n46p000sd3lr60cnplh83qqjhz7u',
 ]
 
+export const POOLS_TO_DESATURATE = ['a0fc643d831b144e1dd289f5acf4274aedc331b6a0e4257ef5376520']
+
 export const SATURATION_POINT = 66800000000000
 
 export const BITBOX02_VERSIONS = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6967,9 +6967,9 @@ vm-browserify@0.0.4:
     indexof "0.0.1"
 
 vm2@^3.9.8:
-  version "3.9.11"
-  resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.11.tgz#a880f510a606481719ec3f9803b940c5805a06fe"
-  integrity sha512-PFG8iJRSjvvBdisowQ7iVF580DXb1uCIiGaXgm7tynMR1uTBlv7UJlB1zdv5KJ+Tmq1f0Upnj3fayoEOPpCBKg==
+  version "3.9.16"
+  resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.16.tgz#0fbc2a265f7bf8b837cea6f4a908f88a3f93b8e6"
+  integrity "sha1-D7wqJl97+Lg3zqb0qQj4ij+TuOY= sha512-3T9LscojNTxdOyG+e8gFeyBXkMlOBYDoF6dqZbj+MPVHi9x10UfiTAJIobuchRCp3QvC+inybTbMJIUrLsig0w=="
   dependencies:
     acorn "^8.7.0"
     acorn-walk "^8.2.0"


### PR DESCRIPTION
* Add personalized pool saturation message
* update logic to show the message to take into account whether the user already made the changes requestes (i.e. no longer delegating to any of the pools we want to desaturate)
* integrate with new endpoint in adalite BE (needs to be reviewed/deployed first), which allows custom recommendations per stake address (needed to override the recommendations for certain stake addresses that we know are saturating our pools)