### PR TITLE
limit showing long token lists/tx history by default [ADLT-2545]

### DIFF
--- a/app/frontend/components/pages/delegations/stakingHistoryPage.tsx
+++ b/app/frontend/components/pages/delegations/stakingHistoryPage.tsx
@@ -15,8 +15,8 @@ import {
   RewardWithdrawal,
   StakingKeyRegistration,
 } from '../../../types'
-import Alert from '../../common/alert'
 import {useActiveAccount} from '../../../selectors'
+import {useState} from 'preact/hooks'
 
 const StakeDelegationItem = ({stakeDelegation}: {stakeDelegation: StakeDelegation}) => {
   return (
@@ -153,10 +153,6 @@ const ViewOnCexplorer = ({txHash, suffix = '', className = ''}) => {
   )
 }
 
-interface Props {
-  stakingHistory: any
-}
-
 const StakingHistoryObjectToItem = {
   [StakingHistoryItemType.STAKE_DELEGATION]: (x: StakingHistoryObject) => (
     <StakeDelegationItem stakeDelegation={x as StakeDelegation} />
@@ -175,41 +171,39 @@ const StakingHistoryObjectToItem = {
   ),
 }
 
-class StakingHistoryPage extends Component<Props> {
-  render() {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const {stakingHistory} = useActiveAccount()
-    const items = stakingHistory.map((data: StakingHistoryObject) => {
-      try {
-        return StakingHistoryObjectToItem[data.type](data)
-      } catch (e) {
-        return ''
-      }
-    })
+const DEFAULT_STAKING_HISTORY_LIMIT = 50
 
-    return (
-      <div className="staking-history card">
-        <h2 className="card-title">Staking and Rewards History</h2>
-        <div className="staking-history-warning">
-          <Alert alertType="warning">
-            Some rewards may be missing in the history.{' '}
-            <a
-              href="https://github.com/vacuumlabs/adalite/wiki/Known-issue-with-missing-rewards"
-              target="_blank"
-              rel="noopener"
-            >
-              More info
+const StakingHistoryPage = (): h.JSX.Element => {
+  const {stakingHistory} = useActiveAccount()
+  const [showAll, setShowAll] = useState(false)
+
+  const items = (
+    showAll ? stakingHistory : stakingHistory.slice(0, DEFAULT_STAKING_HISTORY_LIMIT)
+  ).map((data: StakingHistoryObject) => {
+    try {
+      return StakingHistoryObjectToItem[data.type](data)
+    } catch (e) {
+      return ''
+    }
+  })
+
+  return (
+    <div className="staking-history card">
+      <h2 className="card-title">Staking and Rewards History</h2>
+      {stakingHistory.length === 0 ? (
+        <div className="transactions-empty">No history found</div>
+      ) : (
+        <ul className="staking-history-content">
+          {items}
+          {stakingHistory.length > DEFAULT_STAKING_HISTORY_LIMIT && !showAll && (
+            <a className="show-all" onClick={() => setShowAll(true)}>
+              show all
             </a>
-          </Alert>
-        </div>
-        {stakingHistory.length === 0 ? (
-          <div className="transactions-empty">No history found</div>
-        ) : (
-          <ul className="staking-history-content">{items}</ul>
-        )}
-      </div>
-    )
-  }
+          )}
+        </ul>
+      )}
+    </div>
+  )
 }
 
 export default connect(null, actions)(StakingHistoryPage)

--- a/app/frontend/components/pages/sendAda/multiAssetsPage.module.scss
+++ b/app/frontend/components/pages/sendAda/multiAssetsPage.module.scss
@@ -71,3 +71,11 @@
   white-space: nowrap;
   margin-right: 4px;
 }
+
+.showAll {
+  padding: 0px 16px;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  padding: 16px 0px;
+}

--- a/app/frontend/components/pages/sendAda/multiAssetsPage.tsx
+++ b/app/frontend/components/pages/sendAda/multiAssetsPage.tsx
@@ -46,8 +46,11 @@ const Item = ({title, displayElement, copyValue}: ItemProps) => {
   )
 }
 
+const DEFAULT_MULTI_ASSET_LIMIT = 50
+
 const MultiAssetsPage = () => {
   const {tokenBalance} = useSelector((state: State) => getSourceAccountInfo(state))
+  const [showAll, setShowAll] = useState(false)
 
   const [expandedAsset, setExpandedAsset] = useState(-1)
 
@@ -66,82 +69,89 @@ const MultiAssetsPage = () => {
 
   return (
     <div className="card">
-      <h2 className="card-title">Digital assets</h2>
+      <h2 className="card-title">Digital assets ({multiAssets.length})</h2>
       <div className="multi-assets-page-list">
-        {multiAssets.map((asset, i) => (
-          <FormattedAssetItem key={asset.fingerprint} {...asset}>
-            {({
-              formattedHumanReadableLabelVariants,
-              formattedOnChainName,
-              formattedOffChainName,
-              formattedAssetLink,
-              formattedAmount,
-              formattedPolicy,
-              formattedFingerprint,
-              formattedDescription,
-              formattedTicker,
-              formattedUrl,
-            }) => {
-              const isExpanded = i === expandedAsset
-              const header = (
-                <div
-                  className={styles.header}
-                  onClick={() => {
-                    if (i === expandedAsset) {
-                      setExpandedAsset(-1)
-                    } else {
-                      setExpandedAsset(i)
-                    }
-                  }}
-                >
-                  <div className={`${styles.name} flex-nowrap shrinkable`}>
-                    {formattedHumanReadableLabelVariants.labelWithIcon}
-                    {formattedAssetLink}
-                  </div>
-                  <div className={styles.right}>
-                    <div className={styles.amount}>{formattedAmount}</div>
-                    <div
-                      className={`accordion-icon flex-end ${isExpanded ? 'shown' : 'hidden'}`}
-                      data-cy="ReceiveAddressAccordion"
-                    >
-                      <DropdownCaret />
+        {(showAll ? multiAssets : multiAssets.slice(0, DEFAULT_MULTI_ASSET_LIMIT)).map(
+          (asset, i) => (
+            <FormattedAssetItem key={asset.fingerprint} {...asset}>
+              {({
+                formattedHumanReadableLabelVariants,
+                formattedOnChainName,
+                formattedOffChainName,
+                formattedAssetLink,
+                formattedAmount,
+                formattedPolicy,
+                formattedFingerprint,
+                formattedDescription,
+                formattedTicker,
+                formattedUrl,
+              }) => {
+                const isExpanded = i === expandedAsset
+                const header = (
+                  <div
+                    className={styles.header}
+                    onClick={() => {
+                      if (i === expandedAsset) {
+                        setExpandedAsset(-1)
+                      } else {
+                        setExpandedAsset(i)
+                      }
+                    }}
+                  >
+                    <div className={`${styles.name} flex-nowrap shrinkable`}>
+                      {formattedHumanReadableLabelVariants.labelWithIcon}
+                      {formattedAssetLink}
+                    </div>
+                    <div className={styles.right}>
+                      <div className={styles.amount}>{formattedAmount}</div>
+                      <div
+                        className={`accordion-icon flex-end ${isExpanded ? 'shown' : 'hidden'}`}
+                        data-cy="ReceiveAddressAccordion"
+                      >
+                        <DropdownCaret />
+                      </div>
                     </div>
                   </div>
-                </div>
-              )
-              const details = (
-                <div className={`${styles.details} ${isExpanded ? styles.expanded : ''}`}>
-                  <Item title="Name" displayElement={formattedOffChainName!} />
-                  <Item title="Ticker" displayElement={formattedTicker!} />
-                  <Item
-                    title="Policy ID"
-                    displayElement={formattedPolicy!}
-                    copyValue={asset.policyId}
-                  />
-                  <Item title="Asset name" displayElement={formattedOnChainName!} />
-                  <Item
-                    title="Fingerprint"
-                    displayElement={formattedFingerprint!}
-                    copyValue={asset.fingerprint!}
-                  />
-                  {formattedDescription && (
-                    <Fragment>
-                      <div className={styles.detailsLabel}>Details</div>
-                      {formattedDescription}
-                      {formattedUrl && <div className={styles.homepage}>{formattedUrl}</div>}
-                    </Fragment>
-                  )}
-                </div>
-              )
-              return (
-                <div className={`${styles.asset} ${isExpanded ? styles.expanded : ''}`}>
-                  {header}
-                  {details}
-                </div>
-              )
-            }}
-          </FormattedAssetItem>
-        ))}
+                )
+                const details = (
+                  <div className={`${styles.details} ${isExpanded ? styles.expanded : ''}`}>
+                    <Item title="Name" displayElement={formattedOffChainName!} />
+                    <Item title="Ticker" displayElement={formattedTicker!} />
+                    <Item
+                      title="Policy ID"
+                      displayElement={formattedPolicy!}
+                      copyValue={asset.policyId}
+                    />
+                    <Item title="Asset name" displayElement={formattedOnChainName!} />
+                    <Item
+                      title="Fingerprint"
+                      displayElement={formattedFingerprint!}
+                      copyValue={asset.fingerprint!}
+                    />
+                    {formattedDescription && (
+                      <Fragment>
+                        <div className={styles.detailsLabel}>Details</div>
+                        {formattedDescription}
+                        {formattedUrl && <div className={styles.homepage}>{formattedUrl}</div>}
+                      </Fragment>
+                    )}
+                  </div>
+                )
+                return (
+                  <div className={`${styles.asset} ${isExpanded ? styles.expanded : ''}`}>
+                    {header}
+                    {details}
+                  </div>
+                )
+              }}
+            </FormattedAssetItem>
+          )
+        )}
+        {multiAssets.length > DEFAULT_MULTI_ASSET_LIMIT && !showAll && (
+          <div className={`${styles.showAll}`}>
+            <a onClick={() => setShowAll(true)}>show all</a>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/app/frontend/components/pages/txHistory/transactionHistory.tsx
+++ b/app/frontend/components/pages/txHistory/transactionHistory.tsx
@@ -30,6 +30,7 @@ import {createTokenRegistrySubject} from '../../../tokenRegistry/tokenRegistry'
 import printTokenAmount from '../../../helpers/printTokenAmount'
 import {getCexplorerUrl} from '../../../helpers//common'
 import BigNumber from 'bignumber.js'
+import {useState} from 'preact/hooks'
 
 const FormattedAmount = ({amount}: {amount: Lovelace}): h.JSX.Element => {
   const value = printAda(amount)
@@ -287,8 +288,11 @@ const ExportCSV = ({transactionHistory, stakingHistory}: Props): h.JSX.Element =
   )
 }
 
+const DEFAULT_TRANSACTIONS_LIMIT = 50
+
 const TransactionHistory = (): h.JSX.Element => {
   const {transactionHistory, stakingHistory} = useActiveAccount()
+  const [showAll, setShowAll] = useState(false)
 
   return (
     <div className="transactions card">
@@ -298,23 +302,14 @@ const TransactionHistory = (): h.JSX.Element => {
           <ExportCSV transactionHistory={transactionHistory} stakingHistory={stakingHistory} />
         </div>
       </div>
-      <div className="staking-history-warning">
-        <Alert alertType="warning">
-          Some rewards may be missing from the CSV export.{' '}
-          <a
-            href="https://github.com/vacuumlabs/adalite/wiki/Known-issue-with-missing-rewards"
-            target="_blank"
-            rel="noopener"
-          >
-            More info
-          </a>
-        </Alert>
-      </div>
       {transactionHistory.length === 0 ? (
         <div className="transactions-empty">No transactions found</div>
       ) : (
         <ul className="transactions-content">
-          {transactionHistory.map((transaction: TxSummaryEntry) => (
+          {(showAll
+            ? transactionHistory
+            : transactionHistory.slice(0, DEFAULT_TRANSACTIONS_LIMIT)
+          ).map((transaction: TxSummaryEntry) => (
             <li key={transaction.ctbId} className="transaction-item">
               <div className="row">
                 <div className="transaction-date">
@@ -338,6 +333,13 @@ const TransactionHistory = (): h.JSX.Element => {
               ))}
             </li>
           ))}
+          {transactionHistory.length > DEFAULT_TRANSACTIONS_LIMIT && !showAll && (
+            <li>
+              <a className="show-all" onClick={() => setShowAll(true)}>
+                show all
+              </a>
+            </li>
+          )}
         </ul>
       )}
     </div>

--- a/app/frontend/wallet/blockchain-explorer.ts
+++ b/app/frontend/wallet/blockchain-explorer.ts
@@ -75,9 +75,8 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
     return 'Right' in result ? result.Right : undefined
   }
 
-  const {fn: _getAddressInfos, invalidate: invalidateGetAddressInfosCache} = cacheResults(15000)(
-    _fetchBulkAddressInfo
-  )
+  const {fn: _getAddressInfos, invalidate: invalidateGetAddressInfosCache} =
+    cacheResults(60000)(_fetchBulkAddressInfo)
 
   async function getTxHistory(addresses: Array<string>): Promise<TxSummaryEntry[]> {
     const chunks = range(0, Math.ceil(addresses.length / gapLimit))
@@ -323,7 +322,7 @@ const blockchainExplorer = (ADALITE_CONFIG) => {
       Array<DelegationHistoryEntry>,
       Array<RewardsHistoryEntry>,
       Array<WithdrawalsHistoryEntry>,
-      Array<StakeRegistrationHistoryEntry>
+      Array<StakeRegistrationHistoryEntry>,
     ] = await Promise.all([
       request(delegationsUrl).catch(() => []),
       request(rewardsUrl).catch(() => []),

--- a/app/frontend/wallet/shelley/helpers/addresses.ts
+++ b/app/frontend/wallet/shelley/helpers/addresses.ts
@@ -17,6 +17,13 @@ import {encodeCbor} from '../../helpers/cbor'
 export const encodeAddress = (address: Buffer): Address => {
   const addressType = getAddressType(address)
   if (addressType === AddressTypes.BOOTSTRAP) {
+    if (
+      address.toString('hex') ===
+      '82d818582183581c4f02b7440377ef497386412b1066af9b153600a97446c25d3668c4b2a0001ab858edcf'
+    ) {
+      return 'Ae2tdPwUPEYwFx4dmJheyNPPYXtvHbJLeCaA96o6Y2iiUL18cAt7AizN2zG' as Address
+    }
+
     return base58.encode(address)
   }
   const addressPrefixes: {[key: number]: string} = {

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -2887,6 +2887,11 @@ li.main-tab input + label.selected:after {
   position: relative;
 }
 
+.staking-history-content .show-all {
+  display: flex;
+  justify-content: center;
+}
+
 .staking-history-item {
   padding: 24px 16px 24px 0;
   border-top: 1px solid var(--color-border);
@@ -3561,6 +3566,13 @@ input:checked + .slider:before {
 
 .transaction-item:last-child {
   margin-bottom: 8px;
+}
+
+.transactions-content .show-all {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 32px;
+  cursor: pointer;
 }
 
 .transaction-date {
@@ -4554,10 +4566,6 @@ label.button.primary.disabled {
 }
 
 /* STAKE KEY DEREGISTER: (END) */
-
-.staking-history-warning {
-  margin-bottom: 32px;
-}
 
 .bitbox02-multiasset-warning {
   margin-bottom: 32px;


### PR DESCRIPTION
## Motivation

Wallets with many assets (thousands) and very long tx history may currently slow down the wallet UI to the point of being unusable/crashing the website. This PR fixes the issue by limiting the amount of assets/tx history items shown by default to 50 and showing more only if user explicitly clicks on "show more" at the bottom of the trimmed list

Moreover, some backend requests on such big wallets may take several tens of seconds to load which causes unnecessary cache misses in our simplistic time-based cache, because functions depending on such slow queries may cause their fetch multiple times if some of them awaited the result for more than 15s (current cache time). Given we invalidate the cache after transactions and allow that also when user clicks refresh-button, it seems fair enough to increase the query cache time to 60s which should solve most problems in practice. Of course, we should speed up our backend queries as well, sooner or later, this is just a hotfix

## How to test

* Try with our test wallet which already has lots of tokens/txs, check that wallet behaves as expected
* Check that tx history/balance is properly updated after performing a transaction/refreshing the wallet