### PR TITLE
Fix drep delegation for withdrawals [ADLT-3243]

### DIFF
--- a/app/frontend/components/pages/accounts/accountsDashboard.tsx
+++ b/app/frontend/components/pages/accounts/accountsDashboard.tsx
@@ -79,17 +79,6 @@ const AccountsDashboard = () => {
           </p>
         </Alert>
       </div>
-      <div className="dashboard-column account info">
-        <Alert alertType="warning sidebar">
-          <p>
-            <b>
-              This feature is not supported on other wallets yet. If you decide to move your funds
-              to an account other than the first account, you will not see these funds in other
-              wallets such as Yoroi or Daedalus.
-            </b>
-          </p>
-        </Alert>
-      </div>
     </Fragment>
   )
 

--- a/app/frontend/components/pages/delegations/shelleyBalances.tsx
+++ b/app/frontend/components/pages/delegations/shelleyBalances.tsx
@@ -73,17 +73,20 @@ const ShelleyBalances = ({
             )}
           </div>
           {!!rewardsAccountBalance && (
-            <button
+            <span
               {...tooltip(
                 'Cannot withdraw funds while transaction is pending or reloading',
                 shouldDisableSendingButton(walletOperationStatusType)
               )}
-              className="button secondary balance withdraw"
-              onClick={withdrawRewards}
-              disabled={shouldDisableSendingButton(walletOperationStatusType)}
             >
-              Withdraw
-            </button>
+              <button
+                className="button secondary balance withdraw"
+                onClick={withdrawRewards}
+                disabled={shouldDisableSendingButton(walletOperationStatusType)}
+              >
+                Withdraw
+              </button>
+            </span>
           )}
         </div>
 

--- a/app/frontend/components/pages/sendAda/confirmTransactionDialog.tsx
+++ b/app/frontend/components/pages/sendAda/confirmTransactionDialog.tsx
@@ -463,7 +463,7 @@ const ConfirmTransactionDialog = () => {
         return <ConvertFundsReview transactionSummary={transactionSummary} />
       case TxType.WITHDRAW:
         if (
-          !transactionSummary.plan?.certificates.find(
+          transactionSummary.plan?.certificates.find(
             (cert) => cert.type === CertificateType.VOTE_DELEGATION
           )
         ) {

--- a/app/frontend/components/pages/sendAda/confirmTransactionDialog.tsx
+++ b/app/frontend/components/pages/sendAda/confirmTransactionDialog.tsx
@@ -10,6 +10,7 @@ import tooltip from '../../common/tooltip'
 import Alert from '../../common/alert'
 import {
   AssetFamily,
+  CertificateType,
   DelegateTransactionSummary,
   DeregisterStakingKeyTransactionSummary,
   Lovelace,
@@ -234,6 +235,53 @@ const DeregisterStakeKeyReview = ({
   )
 }
 
+const WithdrawDrepDelegationReview = ({
+  transactionSummary,
+}: {
+  transactionSummary: TransactionSummary & WithdrawTransactionSummary
+}) => {
+  assert(transactionSummary.plan != null)
+  const {rewards, fee} = transactionSummary
+  const total = rewards.minus(fee) as Lovelace
+  return (
+    <Fragment>
+      <Alert alertType="info">
+        <div className="mb-6">
+          In order to be a able to withdraw rewards, we first need you to make an empty delegation
+          to a DRep. You may later modify it using{' '}
+          <a href="https://nu.fi" target="_blank">
+            NuFi wallet
+          </a>{' '}
+          through{' '}
+          <a href="https://gov.tools" target="_blank">
+            https://gov.tools
+          </a>
+          .
+        </div>
+        <div>
+          Please sign this transaction and once it is submitted, you will be able to properly
+          withdraw your staking rewards.
+        </div>
+      </Alert>
+      <div className="review">
+        <div className="review-label">Address</div>
+        <div className="review-address">
+          {transactionSummary.plan.change[0].address}
+          <div className="review-address-verification">
+            <AddressVerification address={transactionSummary.plan.change[0].address} />
+          </div>
+        </div>
+        <div className="ada-label">Rewards</div>
+        <div className="review-value">{'N/A'}</div>
+        <div className="ada-label">Fee</div>
+        <div className="review-fee">{printAda(fee)}</div>
+        <div className="ada-label">Total</div>
+        <div className="review-total">{printAda(total)}</div>
+      </div>
+    </Fragment>
+  )
+}
+
 const WithdrawReview = ({
   transactionSummary,
 }: {
@@ -260,7 +308,6 @@ const WithdrawReview = ({
         <div className="review-value">{printAda(rewards)}</div>
         <div className="ada-label">Fee</div>
         <div className="review-fee">{printAda(fee)}</div>
-        {/* TODO: Hide ADA symbol when handling tokens */}
         <div className="ada-label">Total</div>
         <div className="review-total">{printAda(total)}</div>
       </div>
@@ -415,6 +462,13 @@ const ConfirmTransactionDialog = () => {
       case TxType.CONVERT_LEGACY:
         return <ConvertFundsReview transactionSummary={transactionSummary} />
       case TxType.WITHDRAW:
+        if (
+          !transactionSummary.plan?.certificates.find(
+            (cert) => cert.type === CertificateType.VOTE_DELEGATION
+          )
+        ) {
+          return <WithdrawDrepDelegationReview transactionSummary={transactionSummary} />
+        }
         return <WithdrawReview transactionSummary={transactionSummary} />
       case TxType.SEND_ADA:
         return (

--- a/app/frontend/wallet/shelley/transaction/computeTxPlan.ts
+++ b/app/frontend/wallet/shelley/transaction/computeTxPlan.ts
@@ -364,10 +364,12 @@ export const validateTxPlan = (txPlanResult: TxPlanResult): TxPlanResult => {
   const isDeregisteringStakeKey = certificates.some(
     (c) => c.type === CertificateType.STAKING_KEY_DEREGISTRATION
   )
-  // Excluding deregistering stake key case
-  // because the returned "deposit" (2 ADA) is always higher than the Tx fee
   if (
-    withdrawnRewards.gt(0) &&
+    // Excluding deregistering stake key case
+    // because the returned "deposit" (2 ADA) is always higher than the Tx fee
+    !isDeregisteringStakeKey &&
+    withdrawals.length > 0 &&
+    withdrawnRewards.gte(0) &&
     !isDeregisteringStakeKey &&
     (withdrawnRewards.lt(fee) || fee.gt(baseFee))
   ) {

--- a/app/frontend/wallet/shelley/transaction/shelley-transaction-planner.ts
+++ b/app/frontend/wallet/shelley/transaction/shelley-transaction-planner.ts
@@ -94,8 +94,15 @@ const prepareTxPlanDraft = (txPlanArgs: TxPlanArgs): TxPlanDraft => {
   }
 
   const prepareWithdrawalTx = (txPlanArgs: WithdrawRewardsTxPlanArgs): TxPlanDraft => {
+    // note that if the user is not delegating to a DRep yet,
+    // we need to modify the tx to include a vote delegation.
+    // Moreover, the vote delegation cannot be done in the same tx
+    // hence we hack it by dropping the withdrawal and adding just the vote delegation
+
     const withdrawals: TxWithdrawal[] = []
-    withdrawals.push({stakingAddress: txPlanArgs.stakingAddress, rewards: txPlanArgs.rewards})
+    if (txPlanArgs.hasVoteDelegation) {
+      withdrawals.push({stakingAddress: txPlanArgs.stakingAddress, rewards: txPlanArgs.rewards})
+    }
 
     const certificates: TxCertificate[] = []
     if (!txPlanArgs.hasVoteDelegation) {

--- a/app/tests/src/common/tx-settings.ts
+++ b/app/tests/src/common/tx-settings.ts
@@ -331,7 +331,7 @@ export const transactionSettings = {
             isChange: false as const,
             address:
               'addr1q8eakg39wqlye7lzyfmh900s2luc99zf7x9vs839pn4srjs2s3ps2plp2rc2qcgfmsa8kx2kk7s9s6hfq799tmcwpvpsjv0zk3' as Address,
-            coins: new BigNumber(13426611) as Lovelace,
+            coins: new BigNumber(8434301) as Lovelace,
             tokenBundle: [],
           },
           {
@@ -352,20 +352,16 @@ export const transactionSettings = {
         ],
         deposit: new BigNumber(0) as Lovelace,
         additionalLovelaceAmount: new BigNumber(0) as Lovelace,
-        fee: new BigNumber(189879) as Lovelace,
-        baseFee: new BigNumber(189879) as Lovelace,
-        withdrawals: [
-          {
-            stakingAddress:
-              'stake1uy9ggsc9qls4pu9qvyyacwnmr9tt0gzcdt5s0zj4au8qkqc65geks' as Address,
-            rewards: new BigNumber(5000000) as Lovelace,
-          },
-        ],
+        fee: new BigNumber(182189) as Lovelace,
+        baseFee: new BigNumber(182189) as Lovelace,
+        // withdrawals and vote delegation cannot be combined
+        // therefore this "withdrawal" tx has only the vote delegation
+        withdrawals: [],
         auxiliaryData: null,
       },
     },
     ttl,
-    txHash: '74cb7308c8017cc0104415062fa9ac9227816f0a4f35e733f6fa6e256da13bac',
+    txHash: 'acd01dca8aafcc158be820694c242563856e13ae85173e6d69d86881df27f7d8',
   },
   voting: {
     args: {


### PR DESCRIPTION
Turns out that in case the user isn't already delegating to a DRep, withdrawals cannot be combined with drep delegation and the tx just fails with `ConwayWdrlNotDelegatedToDRep`. This PR fixes this issue by removing the withdrawal from the withdrawal tx if no drep delegation is detected, and we show a modified tx summary which let's the user know about the edge case and the need to sign an extra tx:

![Screenshot 2025-01-31 at 01 13 10](https://github.com/user-attachments/assets/08874a6f-24b8-461f-b5ab-b319125d6d6a)

A better UX would obviously be making it a flow where two txs would be submitted automatically, instead of making the user "withdraw" again, but given this is a one-off thing, such extra handling would be imho an overkill
