### PR TITLE
fix: prefer Trezor Connect xpub over 32-byte publicKey

### DIFF
--- a/app/frontend/wallet/shelley/shelley-trezor-crypto-provider.ts
+++ b/app/frontend/wallet/shelley/shelley-trezor-crypto-provider.ts
@@ -94,6 +94,34 @@ const ShelleyTrezorCryptoProvider = async ({
 
   const getType = () => CryptoProviderType.TREZOR
 
+  // Connect v9 maps the device xpub into `publicKey`. Newer Connect (hosted iframe)
+  // puts the raw 32-byte key in `publicKey` and the 64-byte extended key in `xpub`.
+  // Soft derivation requires the full 64-byte xpub (pubkey ‖ chain code).
+  const cardanoXpubFromResponse = (
+    key: TrezorTypes.CardanoPublicKey & {
+      xpub?: string
+      node?: {public_key?: string; chain_code?: string}
+    }
+  ): Buffer => {
+    const fromNode =
+      key.node?.public_key && key.node?.chain_code
+        ? `${key.node.public_key}${key.node.chain_code}`
+        : undefined
+    const xpubHex = key.xpub ?? fromNode ?? key.publicKey
+    if (typeof xpubHex !== 'string') {
+      throw new InternalError(InternalErrorReason.TrezorError, {
+        message: `Invalid Cardano xpub: expected hex string, got ${typeof xpubHex}`,
+      })
+    }
+    const xpub = Buffer.from(xpubHex, 'hex')
+    if (xpub.length !== 64) {
+      throw new InternalError(InternalErrorReason.TrezorError, {
+        message: `Invalid Cardano xpub length: expected 64 bytes, got ${xpub.length} (hex length ${xpubHex.length})`,
+      })
+    }
+    return xpub
+  }
+
   const deriveXpub = CachedDeriveXpubFactory(
     derivationScheme,
     config.shouldExportPubKeyBulk,
@@ -108,7 +136,7 @@ const ShelleyTrezorCryptoProvider = async ({
       if (!isSuccessful(response.payload)) {
         throw new InternalError(InternalErrorReason.TrezorError, {message: response.payload.error})
       }
-      return response.payload.map(({publicKey}) => Buffer.from(publicKey, 'hex'))
+      return response.payload.map(cardanoXpubFromResponse)
     }
   )
 

--- a/app/frontend/wallet/shelley/shelley-trezor-crypto-provider.ts
+++ b/app/frontend/wallet/shelley/shelley-trezor-crypto-provider.ts
@@ -95,15 +95,13 @@ const ShelleyTrezorCryptoProvider = async ({
   const getType = () => CryptoProviderType.TREZOR
 
   // Soft derivation needs the 64-byte extended key (pubkey ‖ chain code).
-  // Connect v9 put that in `publicKey`; newer hosted Connect puts the raw
-  // 32-byte key there and exposes the full key as `xpub`. `node` is present
-  // in both shapes, so prefer `xpub` when present, otherwise rebuild from node.
-  const cardanoXpubFromResponse = (key: TrezorTypes.CardanoPublicKey & {xpub?: string}): Buffer => {
-    const xpubHex = key.xpub ?? `${key.node.public_key}${key.node.chain_code}`
-    const xpub = Buffer.from(xpubHex, 'hex')
+  // Rebuild from HD node fields, which Connect returns consistently across versions.
+  // Do not use `publicKey` — its meaning changed (full xpub vs raw 32-byte key).
+  const cardanoXpubFromResponse = (key: TrezorTypes.CardanoPublicKey): Buffer => {
+    const xpub = Buffer.from(`${key.node.public_key}${key.node.chain_code}`, 'hex')
     if (xpub.length !== 64) {
       throw new InternalError(InternalErrorReason.TrezorError, {
-        message: `Invalid Cardano xpub length: expected 64 bytes, got ${xpub.length} (hex length ${xpubHex.length})`,
+        message: `Invalid Cardano xpub length: expected 64 bytes, got ${xpub.length}`,
       })
     }
     return xpub

--- a/app/frontend/wallet/shelley/shelley-trezor-crypto-provider.ts
+++ b/app/frontend/wallet/shelley/shelley-trezor-crypto-provider.ts
@@ -94,25 +94,12 @@ const ShelleyTrezorCryptoProvider = async ({
 
   const getType = () => CryptoProviderType.TREZOR
 
-  // Connect v9 maps the device xpub into `publicKey`. Newer Connect (hosted iframe)
-  // puts the raw 32-byte key in `publicKey` and the 64-byte extended key in `xpub`.
-  // Soft derivation requires the full 64-byte xpub (pubkey ‖ chain code).
-  const cardanoXpubFromResponse = (
-    key: TrezorTypes.CardanoPublicKey & {
-      xpub?: string
-      node?: {public_key?: string; chain_code?: string}
-    }
-  ): Buffer => {
-    const fromNode =
-      key.node?.public_key && key.node?.chain_code
-        ? `${key.node.public_key}${key.node.chain_code}`
-        : undefined
-    const xpubHex = key.xpub ?? fromNode ?? key.publicKey
-    if (typeof xpubHex !== 'string') {
-      throw new InternalError(InternalErrorReason.TrezorError, {
-        message: `Invalid Cardano xpub: expected hex string, got ${typeof xpubHex}`,
-      })
-    }
+  // Soft derivation needs the 64-byte extended key (pubkey ‖ chain code).
+  // Connect v9 put that in `publicKey`; newer hosted Connect puts the raw
+  // 32-byte key there and exposes the full key as `xpub`. `node` is present
+  // in both shapes, so prefer `xpub` when present, otherwise rebuild from node.
+  const cardanoXpubFromResponse = (key: TrezorTypes.CardanoPublicKey & {xpub?: string}): Buffer => {
+    const xpubHex = key.xpub ?? `${key.node.public_key}${key.node.chain_code}`
     const xpub = Buffer.from(xpubHex, 'hex')
     if (xpub.length !== 64) {
       throw new InternalError(InternalErrorReason.TrezorError, {


### PR DESCRIPTION
## Summary
- Production error `Invalid parent xpub length ... expected 64 bytes, got 32` on Shelley soft derivation (`m/1852'/1815'/0'/0`) comes from reading Trezor Connect's `publicKey` field.
- Newer hosted Connect maps `publicKey` to the raw 32-byte key and puts the 64-byte extended key in `xpub` (npm v9 still mapped xpub into `publicKey`).
- Prefer `xpub`, then `node.public_key ‖ chain_code`, then `publicKey`, and require 64 bytes before soft derivation.

## Test plan
- [ ] Unlock with Trezor and load a Shelley wallet (account discovery / receive addresses)
- [ ] Confirm soft-derived paths no longer throw `got 32`
- [ ] Regression: Ledger/BitBox login still works


Made with [Cursor](https://cursor.com)